### PR TITLE
Fix issues #54 and  #56

### DIFF
--- a/Resources/Prototypes/Catalog/Cargo/cargo_materials.yml
+++ b/Resources/Prototypes/Catalog/Cargo/cargo_materials.yml
@@ -113,7 +113,7 @@
   icon:
     sprite: Structures/Storage/tanks.rsi
     state: highwatertank
-  product: WaterTankHighCapacityFull
+  product: WaterTankHighCapacity
   cost: 6000 # it has 10,000u of water so roughly 6x the cost makes sense to me
   category: cargoproduct-category-name-materials
   group: market

--- a/Resources/Prototypes/Catalog/Cargo/cargo_materials.yml
+++ b/Resources/Prototypes/Catalog/Cargo/cargo_materials.yml
@@ -107,3 +107,13 @@
   cost: 1000
   category: cargoproduct-category-name-materials
   group: market
+
+- type: cargoProduct # making the highcap water tank purchasable
+  id: MaterialHighWaterTank
+  icon:
+    sprite: Structures/Storage/tanks.rsi
+    state: HighWaterTank
+  product: HighWaterTankFull
+  cost: 6000 # it has 10,000u of water so roughly 6x the cost makes sense to me
+  category: cargoproduct-category-name-materials
+  group: market

--- a/Resources/Prototypes/Catalog/Cargo/cargo_materials.yml
+++ b/Resources/Prototypes/Catalog/Cargo/cargo_materials.yml
@@ -113,7 +113,7 @@
   icon:
     sprite: Structures/Storage/tanks.rsi
     state: HighWaterTank
-  product: HighWaterTankFull
+  product: WaterTankHighCapacityFull
   cost: 6000 # it has 10,000u of water so roughly 6x the cost makes sense to me
   category: cargoproduct-category-name-materials
   group: market

--- a/Resources/Prototypes/Catalog/Cargo/cargo_materials.yml
+++ b/Resources/Prototypes/Catalog/Cargo/cargo_materials.yml
@@ -108,12 +108,12 @@
   category: cargoproduct-category-name-materials
   group: market
 
-- type: cargoProduct # making the highcap water tank purchasable
-  id: MaterialHighCapacityWaterTank
-  icon:
-    sprite: Structures/Storage/tanks.rsi
-    state: highwatertank
-  product: WaterTankHighCapacity
-  cost: 5000
-  category: cargoproduct-category-name-materials
-  group: market
+#- type: cargoProduct # making the highcap water tank purchasable
+#  id: MaterialHighCapacityWaterTank
+#  icon:
+#    sprite: Structures/Storage/tanks.rsi
+#    state: highwatertank
+#  product: WaterTankHighCapacity
+#  cost: 5000
+#  category: cargoproduct-category-name-materials
+#  group: market

--- a/Resources/Prototypes/Catalog/Cargo/cargo_materials.yml
+++ b/Resources/Prototypes/Catalog/Cargo/cargo_materials.yml
@@ -114,6 +114,6 @@
     sprite: Structures/Storage/tanks.rsi
     state: highwatertank
   product: WaterTankHighCapacity
-  cost: 6000 # it has 10,000u of water so roughly 6x the cost makes sense to me
+  cost: 5000
   category: cargoproduct-category-name-materials
   group: market

--- a/Resources/Prototypes/Catalog/Cargo/cargo_materials.yml
+++ b/Resources/Prototypes/Catalog/Cargo/cargo_materials.yml
@@ -109,10 +109,10 @@
   group: market
 
 - type: cargoProduct # making the highcap water tank purchasable
-  id: MaterialHighWaterTank
+  id: MaterialHighCapacityWaterTank
   icon:
     sprite: Structures/Storage/tanks.rsi
-    state: HighWaterTank
+    state: highwatertank
   product: WaterTankHighCapacityFull
   cost: 6000 # it has 10,000u of water so roughly 6x the cost makes sense to me
   category: cargoproduct-category-name-materials

--- a/Resources/Prototypes/Recipes/Lathes/Packs/engineering.yml
+++ b/Resources/Prototypes/Recipes/Lathes/Packs/engineering.yml
@@ -83,6 +83,7 @@
   - PortableScrubberMachineCircuitBoard
   - SolarControlComputerCircuitboard
   - SolarTrackerElectronics
+  - PowerComputerCircuitBoard # readd the power monitor board to lathes
   - GasRecyclerMachineCircuitboard
   - PortableGeneratorPacmanMachineCircuitboard
   - PortableGeneratorSuperPacmanMachineCircuitboard

--- a/Resources/Prototypes/Recipes/Lathes/electronics.yml
+++ b/Resources/Prototypes/Recipes/Lathes/electronics.yml
@@ -151,6 +151,11 @@
 
 - type: latheRecipe
   parent: BaseCircuitboardRecipe
+  id: PowerComputerCircuitBoard
+  result: PowerComputerCircuitboard
+
+- type: latheRecipe
+  parent: BaseCircuitboardRecipe
   id: PortableScrubberMachineCircuitBoard
   result: PortableScrubberMachineCircuitBoard
 

--- a/Resources/Prototypes/Research/industrial.yml
+++ b/Resources/Prototypes/Research/industrial.yml
@@ -92,6 +92,7 @@
   - SolarControlComputerCircuitboard
   - SolarTrackerElectronics
   - EmitterCircuitboard
+  - PowerComputerCircuitBoard #readding the power monitor board
 
 - type: technology
   id: AtmosphericTech


### PR DESCRIPTION
Power monitor can be researched and printed as it used to be.
High capacity water tank can be bought for 6000, kinda expensive but it's 10,000u of water so you shouldn't need to buy a bunch even on a really long shift(and most botany bounties will cover all, most or like double the cost of one)
**Changelog**
:cl:
- add: High capacity water tank to the cargo orders console
- add: Power monitoring board added to power generation research, unlocks it in the circuit imprinter