### PR TITLE
Power monitor(and atmos monitor) can be researched and printed

### DIFF
--- a/Resources/Prototypes/Recipes/Lathes/Packs/engineering.yml
+++ b/Resources/Prototypes/Recipes/Lathes/Packs/engineering.yml
@@ -91,3 +91,4 @@
   - TelecomServerCircuitboard
   - SMESAdvancedMachineCircuitboard
   - HolopadMachineCircuitboard
+  - PowerComputerCircuitBoard

--- a/Resources/Prototypes/Recipes/Lathes/Packs/engineering.yml
+++ b/Resources/Prototypes/Recipes/Lathes/Packs/engineering.yml
@@ -92,3 +92,4 @@
   - SMESAdvancedMachineCircuitboard
   - HolopadMachineCircuitboard
   - PowerComputerCircuitBoard
+  - AtmosMonitoringComputerCircuitBoard

--- a/Resources/Prototypes/Recipes/Lathes/electronics.yml
+++ b/Resources/Prototypes/Recipes/Lathes/electronics.yml
@@ -612,3 +612,8 @@
   parent: BaseCircuitboardRecipe
   id: PowerComputerCircuitBoard
   result: PowerComputerCircuitboard
+
+- type: latheRecipe
+  parent: BaseCircuitboardRecipe
+  id: AtmosMonitoringComputerCircuitBoard
+  result: AtmosMonitoringComputerCircuitboard

--- a/Resources/Prototypes/Recipes/Lathes/electronics.yml
+++ b/Resources/Prototypes/Recipes/Lathes/electronics.yml
@@ -607,3 +607,8 @@
   parent: BaseCircuitboardRecipe
   id: HolopadMachineCircuitboard
   result: HolopadMachineCircuitboard
+
+- type: latheRecipe
+  parent: BaseCircuitboardRecipe
+  id: PowerComputerCircuitBoard
+  result: PowerComputerCircuitboard

--- a/Resources/Prototypes/Research/industrial.yml
+++ b/Resources/Prototypes/Research/industrial.yml
@@ -107,6 +107,7 @@
   - ThermomachineFreezerMachineCircuitBoard
   - GasRecyclerMachineCircuitboard
   - AlertsComputerCircuitboard # DeltaV - Allows atmos computers to be researched
+  - AtmosMonitoringComputerCircuitBoard
 
 - type: technology
   id: RipleyAPLU

--- a/Resources/Prototypes/Research/industrial.yml
+++ b/Resources/Prototypes/Research/industrial.yml
@@ -92,6 +92,7 @@
   - SolarControlComputerCircuitboard
   - SolarTrackerElectronics
   - EmitterCircuitboard
+  - PowerComputerCircuitBoard
 
 - type: technology
   id: AtmosphericTech

--- a/Resources/Prototypes/Research/industrial.yml
+++ b/Resources/Prototypes/Research/industrial.yml
@@ -84,7 +84,7 @@
     state: portgen0
   discipline: Industrial
   tier: 1
-  cost: 7500
+  cost: 8000
   recipeUnlocks:
   - PortableGeneratorPacmanMachineCircuitboard
   - PortableGeneratorSuperPacmanMachineCircuitboard
@@ -102,7 +102,7 @@
     state: freezerOff
   discipline: Industrial
   tier: 1
-  cost: 7500
+  cost: 8000
   recipeUnlocks:
   - ThermomachineFreezerMachineCircuitBoard
   - GasRecyclerMachineCircuitboard


### PR DESCRIPTION
The power monitor board was put back where it belongs and the atmos monitor was tucked into the research tier for the scrubbers and freezers. Also bumped the cost a little.
**Changelog**
:cl:
- add: New boards to existing research options
- add: Said boards to the engineering lathe pack

