### PR TITLE
Adding some recipes to the fabs

### DIFF
--- a/Resources/Prototypes/Recipes/Lathes/Packs/medical.yml
+++ b/Resources/Prototypes/Recipes/Lathes/Packs/medical.yml
@@ -48,6 +48,7 @@
   - DiseaseSwab
   - BodyBag
   - WhiteCane
+  - WalkingCane
 
 - type: latheRecipePack
   id: RollerBedsStatic

--- a/Resources/Prototypes/Recipes/Lathes/Packs/medical.yml
+++ b/Resources/Prototypes/Recipes/Lathes/Packs/medical.yml
@@ -48,7 +48,7 @@
   - DiseaseSwab
   - BodyBag
   - WhiteCane
-  - WalkingCane
+  - Cane
 
 - type: latheRecipePack
   id: RollerBedsStatic

--- a/Resources/Prototypes/Recipes/Lathes/Packs/service.yml
+++ b/Resources/Prototypes/Recipes/Lathes/Packs/service.yml
@@ -24,6 +24,7 @@
   - MopItem
   - Holoprojector
   - WetFloorSign
+  - DiseaseSwab # botanists can make swabs at their fab now
 
 - type: latheRecipePack
   parent:

--- a/Resources/Prototypes/Recipes/Lathes/medical.yml
+++ b/Resources/Prototypes/Recipes/Lathes/medical.yml
@@ -218,8 +218,8 @@
     Plastic: 100
 
 - type: latheRecipe
-  id: WalkingCane
-  result: WalkingCane
+  id: Cane
+  result: Cane
   completetime: 2
   materials:
     Steel: 100

--- a/Resources/Prototypes/Recipes/Lathes/medical.yml
+++ b/Resources/Prototypes/Recipes/Lathes/medical.yml
@@ -216,3 +216,11 @@
   materials:
     Steel: 100
     Plastic: 100
+
+- type: latheRecipe
+  id: WalkingCane
+  result: WalkingCane
+  completetime: 2
+  materials:
+    Steel: 100
+    Wood: 200


### PR DESCRIPTION
Currently just two recipes idk I tried making the department fabs researchable and craftable but it didn't work and I gave up lol

**Changelog**
:cl:
- add: Service fab has sterile swabs for .2 cloth and .2 steel
- add: Medical fab has walking canes for 1 steel, 2 wood
