### PR TITLE
Change suit sensors to be global across a server's map

### DIFF
--- a/Content.Client/Medical/CrewMonitoring/CrewMonitoringWindow.xaml.cs
+++ b/Content.Client/Medical/CrewMonitoring/CrewMonitoringWindow.xaml.cs
@@ -311,7 +311,7 @@ public sealed partial class CrewMonitoringWindow : FancyWindow
                     else
                     {
                         _trackedEntity = sensor.SuitSensorUid;
-                        NavMap.CenterToCoordinates(coordinates.Value);
+                        NavMap.CenterToCoordinates(CoordinatesToLocal(coordinates.Value)); // L5 - map-global suit sensors
                     }
 
                     NavMap.Focus = _trackedEntity;

--- a/Content.Server/Medical/SuitSensors/SuitSensorSystem.cs
+++ b/Content.Server/Medical/SuitSensors/SuitSensorSystem.cs
@@ -79,8 +79,9 @@ public sealed class SuitSensorSystem : EntitySystem
             if (curTime < sensor.NextUpdate)
                 continue;
 
-            if (!CheckSensorAssignedStation(uid, sensor))
-                continue;
+            // L5 - map-global suit sensors
+            // if (!CheckSensorAssignedStation(uid, sensor))
+            //     continue;
 
             // TODO: This would cause imprecision at different tick rates.
             sensor.NextUpdate = curTime + sensor.UpdateRate;
@@ -93,7 +94,8 @@ public sealed class SuitSensorSystem : EntitySystem
             //Retrieve active server address if the sensor isn't connected to a server
             if (sensor.ConnectedServer == null)
             {
-                if (!_singletonServerSystem.TryGetActiveServerAddress<CrewMonitoringServerComponent>(sensor.StationId!.Value, out var address))
+                // L5 - map-global suit sensors
+                if (!_singletonServerSystem.TryGetActiveServerAddress<CrewMonitoringServerComponent>(Transform(uid).MapID, out var address))
                     continue;
 
                 sensor.ConnectedServer = address;
@@ -113,6 +115,8 @@ public sealed class SuitSensorSystem : EntitySystem
         }
     }
 
+    /*
+    L5 - map-global suit sensors
     /// <summary>
     /// Checks whether the sensor is assigned to a station or not
     /// and tries to assign an unassigned sensor to a station if it's currently on a grid
@@ -126,6 +130,7 @@ public sealed class SuitSensorSystem : EntitySystem
         sensor.StationId = _stationSystem.GetOwningStation(uid);
         return sensor.StationId.HasValue;
     }
+    */
 
     private void OnPlayerSpawn(PlayerSpawnCompleteEvent ev)
     {
@@ -369,7 +374,8 @@ public sealed class SuitSensorSystem : EntitySystem
             return null;
 
         // check if sensor is enabled and worn by user
-        if (sensor.Mode == SuitSensorMode.SensorOff || sensor.User == null || !HasComp<MobStateComponent>(sensor.User) || transform.GridUid == null)
+        // L5 - map-global suit sensors:
+        if (sensor.Mode == SuitSensorMode.SensorOff || sensor.User == null || !HasComp<MobStateComponent>(sensor.User))
             return null;
 
         // try to get mobs id from ID slot

--- a/Resources/Prototypes/Entities/Clothing/Uniforms/base_clothinguniforms.yml
+++ b/Resources/Prototypes/Entities/Clothing/Uniforms/base_clothinguniforms.yml
@@ -54,8 +54,8 @@
     transmitFrequencyId: SuitSensor
     savableAddress: false
   - type: WirelessNetworkConnection
-    range: 1200
-  - type: StationLimitedNetwork
+    range: 10000 # L5 - map-global (ish) suit sensors
+  # - type: StationLimitedNetwork # L5
 
 - type: entity
   abstract: true

--- a/Resources/Prototypes/Entities/Mobs/Player/admin_ghost.yml
+++ b/Resources/Prototypes/Entities/Mobs/Player/admin_ghost.yml
@@ -104,7 +104,7 @@
     transmitFrequencyId: ShuttleTimer
   - type: WirelessNetworkConnection
     range: 500
-  - type: StationLimitedNetwork
+  # - type: StationLimitedNetwork # L5 - map-global suit sensors
   - type: Thieving
     stripTimeReduction: 9999
     stealthy: true

--- a/Resources/Prototypes/Entities/Objects/Misc/subdermal_implants.yml
+++ b/Resources/Prototypes/Entities/Objects/Misc/subdermal_implants.yml
@@ -94,9 +94,9 @@
     - type: DeviceNetwork
       deviceNetId: Wireless
       transmitFrequencyId: SuitSensor
-    - type: StationLimitedNetwork
+    # - type: StationLimitedNetwork # L5 - map-global suit sensors
     - type: WirelessNetworkConnection
-      range: 500
+      range: 10000 # L5 - map-global (ish) suit sensors
     - type: TriggerOnMobstateChange
       mobState:
       - Critical

--- a/Resources/Prototypes/Entities/Structures/Machines/crew_monitor_server.yml
+++ b/Resources/Prototypes/Entities/Structures/Machines/crew_monitor_server.yml
@@ -30,7 +30,7 @@
       autoConnect: false
     - type: WirelessNetworkConnection
       range: 10000 # Delta-V Maximises the range for the Crew Monitor Server to make it work for Listening Post
-    - type: StationLimitedNetwork
+    # - type: StationLimitedNetwork # L5 - map-global suit sensors.
     - type: ApcPowerReceiver
       powerLoad: 200
     - type: ExtensionCableReceiver


### PR DESCRIPTION
<!-- If you are new to the Delta-V repository, please read the [Contributing Guidelines](https://github.com/DeltaV-Station/Delta-v/blob/master/CONTRIBUTING.md) -->

## About the PR
Suit sensor servers/consoles will now transceive across the entire map they are on.

## Why / Balance
<!-- Discuss how this would affect game balance or explain why it was changed. Link any relevant discussions or issues. -->
Round removed because your suit's radio is blocked by the vacuum of space is bad.

## Technical details
<!-- Summary of code changes for easier review. -->
Lightly based on Frontier's method of a similar change—suit sensors no longer care about their stationId, and instead just broadcast to all the servers on their map. The console originally just states your X and Y position on the station's grid, which isn't super helpful if you aren't on said grid, so the console now displays both the grid coordinates and the map coordinates of the selected user.

## Media
<!-- Attach media if the PR makes ingame changes (clothing, items, features, etc).
Small fixes/refactors are exempt. -->
<img width="1257" alt="image" src="https://github.com/user-attachments/assets/7c3b667b-9d7a-484a-84c5-395dc77c5f3a" />
(The blip had blunk off at time of screenshot, but those work as expected.)

## Requirements
<!-- Confirm the following by placing an X in the brackets [X]: -->
- [X] I have tested all added content and changes.
- [X] I have added media to this PR or it does not require an ingame showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->

## Breaking changes
<!-- List any breaking changes, including namespaces, public class/method/field changes, prototype renames; and provide instructions for fixing them. -->

**Changelog**
<!-- Add a Changelog entry to make players aware of new features or changes that could affect gameplay.
Make sure to read the guidelines and take this Changelog template out of the comment block in order for it to show up.
Changelogs must have a :cl: symbol, so the bot recognizes the changes and adds them to the game's changelog. -->
:cl:
- add: Suit sensors and servers now have greatly increased range.
<!--
:cl:
- add: Added fun!
- remove: Removed fun!
- tweak: Changed fun!
- fix: Fixed fun!
-->
