### PR TITLE
Tracking implanters now report on Medical channel, updated lore

### DIFF
--- a/Resources/Prototypes/Catalog/Cargo/cargo_armory.yml
+++ b/Resources/Prototypes/Catalog/Cargo/cargo_armory.yml
@@ -35,7 +35,7 @@
     state: implanter0
   product: CrateTrackingImplants
   cost: 4000 # DeltaV - was 1000
-  category: cargoproduct-category-name-armory
+  category: cargoproduct-category-name-medical # L5 - Move to medical
   group: market
 
 - type: cargoProduct

--- a/Resources/Prototypes/Catalog/Fills/Crates/armory.yml
+++ b/Resources/Prototypes/Catalog/Fills/Crates/armory.yml
@@ -28,7 +28,7 @@
   id: CrateTrackingImplants
   parent: [ CrateWeaponSecure, BaseSecurityContraband ]
   name: tracking implant crate # L5 - consistent naming
-  description: Contains a handful of tracking implanters. Useful for letting Paramedics find you when you inevitably get hurt. Requires Armory access to open. # L5 - tracking implanters are for medical, not sec
+  description: Contains a handful of tracking implanters. Useful for letting paramedics find you when you inevitably get hurt. Requires Armory access to open. # L5 - tracking implanters are for medical, not sec
   components:
   - type: StorageFill
     contents:

--- a/Resources/Prototypes/Catalog/Fills/Crates/armory.yml
+++ b/Resources/Prototypes/Catalog/Fills/Crates/armory.yml
@@ -28,7 +28,7 @@
   id: CrateTrackingImplants
   parent: [ CrateWeaponSecure, BaseSecurityContraband ]
   name: tracking implants
-  description: Contains a handful of tracking implanters. Good for prisoners you'd like to release but still keep track of.
+  description: Contains a handful of tracking implanters, so that Paramedics can find you when you inevitably get hurt. Requires Armory access to open. # L5 - tracking implanters are for medical, not sec
   components:
   - type: StorageFill
     contents:

--- a/Resources/Prototypes/Catalog/Fills/Crates/armory.yml
+++ b/Resources/Prototypes/Catalog/Fills/Crates/armory.yml
@@ -27,7 +27,7 @@
 - type: entity
   id: CrateTrackingImplants
   parent: [ CrateWeaponSecure, BaseSecurityContraband ]
-  name: tracking implants
+  name: tracking implant crate # L5 - consistent naming
   description: Contains a handful of tracking implanters. Useful for letting Paramedics find you when you inevitably get hurt. Requires Armory access to open. # L5 - tracking implanters are for medical, not sec
   components:
   - type: StorageFill

--- a/Resources/Prototypes/Catalog/Fills/Crates/armory.yml
+++ b/Resources/Prototypes/Catalog/Fills/Crates/armory.yml
@@ -28,7 +28,7 @@
   id: CrateTrackingImplants
   parent: [ CrateWeaponSecure, BaseSecurityContraband ]
   name: tracking implants
-  description: Contains a handful of tracking implanters, so that Paramedics can find you when you inevitably get hurt. Requires Armory access to open. # L5 - tracking implanters are for medical, not sec
+  description: Contains a handful of tracking implanters. Useful for letting Paramedics find you when you inevitably get hurt. Requires Armory access to open. # L5 - tracking implanters are for medical, not sec
   components:
   - type: StorageFill
     contents:

--- a/Resources/Prototypes/Entities/Objects/Misc/subdermal_implants.yml
+++ b/Resources/Prototypes/Entities/Objects/Misc/subdermal_implants.yml
@@ -79,7 +79,7 @@
   parent: BaseSubdermalImplant
   id: TrackingImplant
   name: tracking implant
-  description: This implant has a tracking device attached to the suit sensor network, as well as a condition monitor for the Medical radio channel.
+  description: This implant has a tracking device attached to the suit sensor network, as well as a condition monitor for the Medical radio channel. # L5 - medical instead of sec
   categories: [ HideSpawnMenu ]
   components:
     - type: SubdermalImplant

--- a/Resources/Prototypes/Entities/Objects/Misc/subdermal_implants.yml
+++ b/Resources/Prototypes/Entities/Objects/Misc/subdermal_implants.yml
@@ -79,7 +79,7 @@
   parent: BaseSubdermalImplant
   id: TrackingImplant
   name: tracking implant
-  description: This implant has a tracking device attached to the suit sensor network, as well as a condition monitor for the Security radio channel.
+  description: This implant has a tracking device attached to the suit sensor network, as well as a condition monitor for the Medical radio channel.
   categories: [ HideSpawnMenu ]
   components:
     - type: SubdermalImplant
@@ -101,7 +101,7 @@
       mobState:
       - Critical
     - type: Rattle
-      radioChannel: "Security"
+      radioChannel: Medical # L5 - tracking implants are for medical, not sec
 
 #Traitor implants
 


### PR DESCRIPTION
## About the PR
Fixes #109 

## Technical details
I would make implanters for both Med and Sec but the problem is that the implant adds a RattleComponent which only supports one channel and, as with any comp, you can only have one instance of.

I kept the armory access despite them being more of a Med item lore-wise because of balancing: There is currently no way to remove them, which makes them a bit of a privacy risk. The SA should at least tacitly approve implantation by unlocking the crate for Med. Maybe they could be made CMO access only in the future?

## Media *(feat. Quincey, the comically oversized mouse cursor)*

https://github.com/user-attachments/assets/c69d2db9-e5d7-408a-bb32-d668ecc1f1ea

## Requirements
- [x] I have tested all added content and changes.
- [x] I have added media to this PR or it does not require an ingame showcase.

**Changelog**
:cl:
- tweak: Tracking implants now speak on the Medical channel instead of the Security channel.

