### PR TITLE
Rename "uniform printer" to "universal textile fabricator"

### DIFF
--- a/Resources/Prototypes/Entities/Objects/Devices/Circuitboards/Machine/production.yml
+++ b/Resources/Prototypes/Entities/Objects/Devices/Circuitboards/Machine/production.yml
@@ -221,7 +221,7 @@
 - type: entity
   id: UniformPrinterMachineCircuitboard
   parent: BaseMachineCircuitboard
-  name: uniform printer machine board
+  name: universal textile fabricator machine board # L5 - rename because it does more than print uniforms
   components:
   - type: MachineBoard
     prototype: UniformPrinter

--- a/Resources/Prototypes/Entities/Structures/Machines/lathe.yml
+++ b/Resources/Prototypes/Entities/Structures/Machines/lathe.yml
@@ -536,8 +536,8 @@
 - type: entity
   parent: [BaseLathe, BaseMaterialSiloUtilizer]
   id: UniformPrinter
-  name: uniform printer
-  description: Prints new or replacement uniforms.
+  name: universal textile fabricator  # L5 - rename because it does more than print uniforms
+  description: Weaves, dyes, sews and finishes items such as uniforms, bedsheets or carpet tiles. # L5
   components:
   - type: Transform
     noRot: false


### PR DESCRIPTION
## About the PR
Fixes #120

## Why / Balance
- "universal" because it makes a lot of different things and sounds sci-fi
- "textile" because it encompasses both uniforms, carpets, etc.
- "fabricator" because it's in line with other lathes (techfabs, exosuit fabricator, medical biofabricator)
 
"digital loom" is neat but I decided against it because a loom just weaves, but the uniform printer also does all the other steps.

## Media

![image](https://github.com/user-attachments/assets/8a4941e6-c89f-4173-9fbc-3358d2532e97)
![image](https://github.com/user-attachments/assets/48d47b98-624d-4d37-91c0-52e30c6ce0d6)

## Breaking changes
![walter-white-cooking](https://github.com/user-attachments/assets/ffe4be9c-99fb-43fc-aa3d-17ad8d32c39e)

**Changelog**
:cl:
- tweak: "Uniform Printer" renamed to "Universal Textile Fabricator", since it prints more than uniforms.