### PR TITLE
Display days in round duration fields

### DIFF
--- a/Content.Client/Administration/UI/CustomControls/AdminLogLabel.cs
+++ b/Content.Client/Administration/UI/CustomControls/AdminLogLabel.cs
@@ -11,7 +11,7 @@ public sealed class AdminLogLabel : RichTextLabel
         Log = log;
         Separator = separator;
 
-        SetMessage($"{log.Date:HH:mm:ss}: {log.Message}");
+        SetMessage($"{log.Date:yyyy-MM-dd HH:mm:ss}: {log.Message}");
         OnVisibilityChanged += VisibilityChanged;
     }
 

--- a/Content.Client/Cargo/UI/BountyHistoryEntry.xaml.cs
+++ b/Content.Client/Cargo/UI/BountyHistoryEntry.xaml.cs
@@ -34,7 +34,7 @@ public sealed partial class BountyHistoryEntry : BoxContainer
         RewardLabel.SetMarkup(Loc.GetString("bounty-console-reward-label", ("reward", bountyPrototype.Reward)));
         IdLabel.SetMarkup(Loc.GetString("bounty-console-id-label", ("id", bounty.Id)));
 
-        TimestampLabel.SetMarkup(bounty.Timestamp.ToString(@"hh\:mm\:ss"));
+        TimestampLabel.SetMarkup(bounty.Timestamp.ToString(@"d\.hh\:mm\:ss"));
 
         if (bounty.Result == CargoBountyHistoryData.BountyResult.Completed)
         {

--- a/Content.Client/CartridgeLoader/Cartridges/NewsReaderUiFragment.xaml.cs
+++ b/Content.Client/CartridgeLoader/Cartridges/NewsReaderUiFragment.xaml.cs
@@ -37,7 +37,7 @@ public sealed partial class NewsReaderUiFragment : BoxContainer
 
         NotificationSwitch.Text = Loc.GetString(notificationOn ? "news-read-ui-notification-on" : "news-read-ui-notification-off");
 
-        string shareTime = article.ShareTime.ToString(@"hh\:mm\:ss");
+        string shareTime = article.ShareTime.ToString(@"d\.hh\:mm\:ss");
         ShareTime.SetMarkup(Loc.GetString("news-read-ui-time-prefix-text") + " " + shareTime);
 
         Author.SetMarkup(Loc.GetString("news-read-ui-author-prefix") + " " + (article.Author != null ? article.Author : Loc.GetString("news-read-ui-no-author")));

--- a/Content.Client/MassMedia/Ui/NewsArticleCard.xaml.cs
+++ b/Content.Client/MassMedia/Ui/NewsArticleCard.xaml.cs
@@ -35,7 +35,7 @@ public sealed partial class NewsArticleCard : Control
         set
         {
             _publicationTime = value;
-            PublishTimeLabel.Text = value?.ToString(@"hh\:mm\:ss") ?? "";
+            PublishTimeLabel.Text = value?.ToString(@"d\.hh\:mm\:ss") ?? "";
         }
     }
 

--- a/Content.Client/PDA/PdaMenu.xaml.cs
+++ b/Content.Client/PDA/PdaMenu.xaml.cs
@@ -117,7 +117,7 @@ namespace Content.Client.PDA
             StationTimeButton.OnPressed += _ =>
             {
                 var stationTime = _gameTiming.CurTime.Subtract(_gameTicker.RoundStartTimeSpan);
-                _clipboard.SetText((stationTime.ToString("hh\\:mm\\:ss")));
+                _clipboard.SetText((stationTime.ToString(@"d\.hh\:mm\:ss")));
             };
 
             StationAlertLevelInstructionsButton.OnPressed += _ =>
@@ -165,12 +165,12 @@ namespace Content.Client.PDA
             _stationName = state.StationName ?? Loc.GetString("comp-pda-ui-unknown");
             StationNameLabel.SetMarkup(Loc.GetString("comp-pda-ui-station",
                 ("station", _stationName)));
-            
+
 
             var stationTime = _gameTiming.CurTime.Subtract(_gameTicker.RoundStartTimeSpan);
 
             StationTimeLabel.SetMarkup(Loc.GetString("comp-pda-ui-station-time",
-                ("time", stationTime.ToString("hh\\:mm\\:ss"))));
+                ("time", stationTime.ToString(@"d\.hh\:mm\:ss"))));
 
             var alertLevel = state.PdaOwnerInfo.StationAlertLevel;
             var alertColor = state.PdaOwnerInfo.StationAlertColor;
@@ -344,7 +344,7 @@ namespace Content.Client.PDA
             var stationTime = _gameTiming.CurTime.Subtract(_gameTicker.RoundStartTimeSpan);
 
             StationTimeLabel.SetMarkup(Loc.GetString("comp-pda-ui-station-time",
-                ("time", stationTime.ToString("hh\\:mm\\:ss"))));
+                ("time", stationTime.ToString(@"d\.hh\:mm\:ss"))));
         }
     }
 }

--- a/Content.Server/Administration/Systems/BwoinkSystem.cs
+++ b/Content.Server/Administration/Systems/BwoinkSystem.cs
@@ -128,7 +128,7 @@ namespace Content.Server.Administration.Systems
                 string.Empty,
                 string.Empty,
                 true,
-                _gameTicker.RoundDuration().ToString("hh\\:mm\\:ss"),
+                _gameTicker.RoundDuration().ToString(@"d\.hh\:mm\:ss"),
                 _gameTicker.RunLevel,
                 playedSound: false
             );
@@ -163,7 +163,7 @@ namespace Content.Server.Administration.Systems
                 string.Empty,
                 string.Empty,
                 true,
-                _gameTicker.RoundDuration().ToString("hh\\:mm\\:ss"),
+                _gameTicker.RoundDuration().ToString(@"d\.hh\:mm\:ss"),
                 _gameTicker.RunLevel,
                 playedSound: false
             );
@@ -282,8 +282,8 @@ namespace Content.Server.Administration.Systems
             }
 
             // Get the current timestamp
-            var timestamp = DateTime.Now.ToString("HH:mm:ss");
-            var roundTime = _gameTicker.RoundDuration().ToString("hh\\:mm\\:ss");
+            var timestamp = DateTime.Now.ToString(@"d\.hh\:mm\:ss");
+            var roundTime = _gameTicker.RoundDuration().ToString(@"d\.hh\:mm\:ss");
 
             // Determine the icon based on the status type
             string icon = statusType switch
@@ -903,7 +903,7 @@ namespace Content.Server.Administration.Systems
                     senderName,
                     str,
                     senderId != message.UserId,
-                    _gameTicker.RoundDuration().ToString("hh\\:mm\\:ss"),
+                    _gameTicker.RoundDuration().ToString(@"d\.hh\:mm\:ss"),
                     _gameTicker.RunLevel,
                     playedSound: playSound,
                     isDiscord: fromWebhook, // DeltaV

--- a/Content.Server/GameTicking/GameTicker.GameRule.cs
+++ b/Content.Server/GameTicking/GameTicker.GameRule.cs
@@ -424,7 +424,7 @@ public sealed partial class GameTicker
 
             foreach (var (time, rule) in sortedRules)
             {
-                var formattedTime = time.ToString(@"hh\:mm\:ss");
+                var formattedTime = time.ToString(@"d\.hh\:mm\:ss");
                 message += $"| {formattedTime,-10} | {rule,-16} \n";
             }
 

--- a/Content.Server/_DV/TapeRecorder/TapeRecorderSystem.cs
+++ b/Content.Server/_DV/TapeRecorder/TapeRecorderSystem.cs
@@ -118,7 +118,7 @@ public sealed class TapeRecorderSystem : SharedTapeRecorderSystem
             var time = TimeSpan.FromSeconds((double) message.Timestamp);
 
             text.AppendLine(Loc.GetString("tape-recorder-print-message-text",
-                ("time", time.ToString(@"hh\:mm\:ss")),
+                ("time", time.ToString(@"d\.hh\:mm\:ss")),
                 ("source", name),
                 ("message", message.Message)));
         }

--- a/Resources/ConfigPresets/Build/development.toml
+++ b/Resources/ConfigPresets/Build/development.toml
@@ -1,5 +1,5 @@
 ﻿[game]
-lobbyenabled = true # L5
+lobbyenabled = false
 # Dev map for faster loading & convenience
 map = "Dev"
 role_timers = false


### PR DESCRIPTION
<!-- If you are new to the Delta-V repository, please read the [Contributing Guidelines](https://github.com/DeltaV-Station/Delta-v/blob/master/CONTRIBUTING.md) -->

## About the PR
<!-- What did you change? -->
Displays total days in addition to hours and minutes and seconds. Here is the exhaustive list:
- Entity log timestamps (these display a full real date in addition to the real time)
- Bounties consoles
- News (PDA and console)
- Shift duration (PDA)
- GameRule records
- Tape recorder printouts
- AHelp relay timestamps

## Why / Balance
<!-- Discuss how this would affect game balance or explain why it was changed. Link any relevant discussions or issues. -->
Our rounds usually go longer than 24hours, and we would like for the game not to come apart at the seams when we do that!

## Technical details
<!-- Summary of code changes for easier review. -->
- Completes #114.
- `TimeSpan.ToString()` does a modulo on hours, minutes, and seconds, but _not_ on days. Arbitrarily long shifts should simply display as the total number of days, plus `hh:mm:ss`.
- The format generally used in this PR prepends days and uses a dot separator. This maintains a relatively compact display, but is unambiguous as to where hours lie. A problem we have had in the past is not knowing whether playtime displays hours or days because of the use of an extra colon separator.
- Drive-by fix: Reverted our change to `development.toml` since we are not testing lobby-adjacent behaviors anymore.

## Media
<!-- Attach media if the PR makes ingame changes (clothing, items, features, etc).
Small fixes/refactors are exempt. -->
![image](https://github.com/user-attachments/assets/d1253c29-7ebb-4b7a-9e62-60a2e82f14d3)
![image](https://github.com/user-attachments/assets/a29fe482-6b76-4af9-b346-2dfc03464ffe)

## Requirements
<!-- Confirm the following by placing an X in the brackets [X]: -->
- [X] I have tested all added content and changes.
- [X] I have added media to this PR or it does not require an ingame showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->

## Breaking changes
<!-- List any breaking changes, including namespaces, public class/method/field changes, prototype renames; and provide instructions for fixing them. -->
Worth keeping an eye on, but nothing evident in a few minutes of testing, and nothing but presentation should have been altered.