### PR TITLE
Ore boxes now have magnets and are dumpable

### DIFF
--- a/Content.Shared/_NF/Storage/EntitySystems/MaterialReclaimerMagnetPickupSystem.cs
+++ b/Content.Shared/_NF/Storage/EntitySystems/MaterialReclaimerMagnetPickupSystem.cs
@@ -67,10 +67,10 @@ public sealed class MaterialReclaimerMagnetPickupSystem : EntitySystem
     // Frontier, used to show the magnet state on examination
     private void OnExamined(EntityUid uid, MaterialReclaimerMagnetPickupComponent component, ExaminedEvent args)
     {
-        args.PushMarkup(Loc.GetString("magnet-pickup-component-on-examine-main",
-                        ("stateText", Loc.GetString(component.MagnetEnabled
-                        ? "magnet-pickup-component-magnet-on"
-                        : "magnet-pickup-component-magnet-off"))));
+        // L5 - improved magnet localization
+        args.PushMarkup(Loc.GetString(component.MagnetEnabled
+            ? "magnet-pickup-component-magnet-on"
+            : "magnet-pickup-component-magnet-off"));
     }
 
     public override void Update(float frameTime)

--- a/Content.Shared/_NF/Storage/EntitySystems/MaterialStorageMagnetPickupSystem.cs
+++ b/Content.Shared/_NF/Storage/EntitySystems/MaterialStorageMagnetPickupSystem.cs
@@ -67,10 +67,10 @@ public sealed class MaterialStorageMagnetPickupSystem : EntitySystem
     // Frontier, used to show the magnet state on examination
     private void OnExamined(EntityUid uid, MaterialStorageMagnetPickupComponent component, ExaminedEvent args)
     {
-        args.PushMarkup(Loc.GetString("magnet-pickup-component-on-examine-main",
-                        ("stateText", Loc.GetString(component.MagnetEnabled
-                        ? "magnet-pickup-component-magnet-on"
-                        : "magnet-pickup-component-magnet-off"))));
+        // L5 - improved magnet localization
+        args.PushMarkup(Loc.GetString(component.MagnetEnabled
+            ? "magnet-pickup-component-magnet-on"
+            : "magnet-pickup-component-magnet-off"));
     }
 
     public override void Update(float frameTime)

--- a/Resources/Locale/en-US/_NF/storage/components/magnet-pickup-components.ftl
+++ b/Resources/Locale/en-US/_NF/storage/components/magnet-pickup-components.ftl
@@ -1,4 +1,5 @@
 magnet-pickup-component-toggle-verb = Toggle magnet
 magnet-pickup-component-on-examine-main = The magnet appears to be {$stateText}.
-magnet-pickup-component-magnet-on = [color=darkgreen]on[/color]
-magnet-pickup-component-magnet-off =  [color=darkred]off[/color]
+# L5 - improved magnet localization
+magnet-pickup-component-magnet-on = The magnet appears to be [color=darkgreen]on[/color].
+magnet-pickup-component-magnet-off = The magnet appears to be [color=darkred]off[/color].

--- a/Resources/Prototypes/Entities/Structures/Storage/ore_box.yml
+++ b/Resources/Prototypes/Entities/Structures/Storage/ore_box.yml
@@ -58,6 +58,21 @@
     whitelist:
       tags:
       - Ore
+      - ArtifactFragment # L5 - parity with ore bag
+  # Begin L5 - magnetizable and dumpable ore box
+  - type: MagnetPickup
+    range: 2
+  - type: Dumpable
+  - type: ItemToggle
+    soundActivate: &soundActivate
+      collection: sparks
+      params:
+        variation: 0.25
+    soundDeactivate: *soundActivate
+  - type: ItemToggleExamine
+    on: magnet-pickup-component-magnet-on
+    off: magnet-pickup-component-magnet-off
+  # End L5
   - type: UserInterface
     interfaces:
       enum.StorageUiKey.Key:


### PR DESCRIPTION
## About the PR
<!-- What did you change? -->
Essentially bringing them in line with ore bags: they can now hold artifact fragments, they magnetize in the same way (and it is toggable), and you can dump their contents on the ground.

Also makes the magnet enabled localization actually say a whole sentence.

## Why / Balance
<!-- Discuss how this would affect game balance or explain why it was changed. Link any relevant discussions or issues. -->
Fixes #42.

## Technical details
<!-- Summary of code changes for easier review. -->
It like ore bag.

## Media
<!-- Attach media if the PR makes ingame changes (clothing, items, features, etc).
Small fixes/refactors are exempt. -->
![image](https://github.com/user-attachments/assets/7d1c04a3-e396-4a0d-9329-1042cb9b75ce)

## Requirements
<!-- Confirm the following by placing an X in the brackets [X]: -->
- [X] I have tested all added content and changes.
- [X] I have added media to this PR or it does not require an ingame showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->

## Breaking changes
<!-- List any breaking changes, including namespaces, public class/method/field changes, prototype renames; and provide instructions for fixing them. -->

**Changelog**
<!-- Add a Changelog entry to make players aware of new features or changes that could affect gameplay.
Make sure to read the guidelines and take this Changelog template out of the comment block in order for it to show up.
Changelogs must have a :cl: symbol, so the bot recognizes the changes and adds them to the game's changelog. -->
<!--
:cl:
- add: Added fun!
- remove: Removed fun!
- tweak: Changed fun!
- fix: Fixed fun!
-->
:cl:
- add: Ore boxes are now (optionally) magnetic, and can be dumped just like ore bags.
