### PR TITLE
Fixed the scaling on the synth brain and vet cone

### DIFF
--- a/Resources/Prototypes/_DEN/Entities/Clothing/Neck/misc.yml
+++ b/Resources/Prototypes/_DEN/Entities/Clothing/Neck/misc.yml
@@ -6,6 +6,7 @@
   components:
   - type: Sprite
     sprite: _DEN/Clothing/Neck/Misc/vet-cone.rsi
+    scale: 0.5, 0.5
   - type: Clothing
     sprite: _DEN/Clothing/Neck/Misc/vet-cone.rsi
     equipDelay: 0.5

--- a/Resources/Prototypes/_DEN/Entities/Clothing/Neck/misc.yml
+++ b/Resources/Prototypes/_DEN/Entities/Clothing/Neck/misc.yml
@@ -6,7 +6,7 @@
   components:
   - type: Sprite
     sprite: _DEN/Clothing/Neck/Misc/vet-cone.rsi
-    scale: 0.5, 0.5
+    scale: 0.75, 0.75 # L5 Scaled down to not be the size of a whole tile
   - type: Clothing
     sprite: _DEN/Clothing/Neck/Misc/vet-cone.rsi
     equipDelay: 0.5

--- a/Resources/Prototypes/_L5/Body/Organs/synth.yml
+++ b/Resources/Prototypes/_L5/Body/Organs/synth.yml
@@ -10,6 +10,7 @@
   components:
   - type: Sprite
     sprite: _L5/Mobs/Species/Synth/synth_brain.rsi
+    scale: 0.5, 0.5
     layers:
       - state: brain
       - state: brain-lights

--- a/Resources/Prototypes/_L5/Body/Organs/synth.yml
+++ b/Resources/Prototypes/_L5/Body/Organs/synth.yml
@@ -10,7 +10,7 @@
   components:
   - type: Sprite
     sprite: _L5/Mobs/Species/Synth/synth_brain.rsi
-    scale: 0.5, 0.5
+    scale: 0.75, 0.75  # L5 scaling it down a little so synths aren't so big brain
     layers:
       - state: brain
       - state: brain-lights


### PR DESCRIPTION
Apparently it's very easy and you can just scale: x, y in their prototypes. It's advised not to scale things up but downsizing seems fine? The sprites don't seem to mind unless I'm blind and missed some glaring defects caused by the scaling.
![dotnet_86X2ZLSMcd](https://github.com/user-attachments/assets/48edccfe-1bb1-4219-873d-e8a97cf9af2a)

![dotnet_C2t4AJ7Pi1](https://github.com/user-attachments/assets/e83cd486-5f1b-4c9d-aacf-6c0c7706221d)
