### PR TITLE
feat: make flowerwreaths quickequip better

### DIFF
--- a/Content.Shared/Clothing/EntitySystems/ClothingSystem.cs
+++ b/Content.Shared/Clothing/EntitySystems/ClothingSystem.cs
@@ -1,3 +1,4 @@
+using System.Linq;
 using Content.Shared.Clothing.Components;
 using Content.Shared.Hands.Components;
 using Content.Shared.Hands.EntitySystems;
@@ -51,8 +52,19 @@ public abstract class ClothingSystem : EntitySystem
         Entity<ClothingComponent> toEquipEnt,
         Entity<InventoryComponent, HandsComponent> userEnt)
     {
-        foreach (var slotDef in userEnt.Comp1.Slots)
+        // Begin L5 - prioritized quickequips
+        var slots = userEnt.Comp1.Slots;
+        if (toEquipEnt.Comp.PreferredSlots != SlotFlags.NONE)
         {
+            // We want to sort so we have the ordering 1) empty prio slots, 2) empty slots, 3) full piro slots, 4) rest
+            slots = slots
+                .OrderBy(a => _invSystem.TryGetSlotEntity(userEnt, a.Name, out _, userEnt))
+                .ThenBy(a => (a.SlotFlags & toEquipEnt.Comp.PreferredSlots) == 0)
+                .ToArray();
+        }
+        foreach (var slotDef in slots)
+        {
+            // End L5
             if (!_invSystem.CanEquip(userEnt, toEquipEnt, slotDef.Name, out _, slotDef, userEnt, toEquipEnt))
                 continue;
 

--- a/Content.Shared/_L5/Clothing/ClothingComponent.cs
+++ b/Content.Shared/_L5/Clothing/ClothingComponent.cs
@@ -1,0 +1,10 @@
+
+using Content.Shared.Inventory;
+
+namespace Content.Shared.Clothing.Components;
+
+public sealed partial class ClothingComponent
+{
+    [DataField]
+    public SlotFlags PreferredSlots = SlotFlags.NONE;
+}

--- a/Resources/Prototypes/Entities/Clothing/Head/misc.yml
+++ b/Resources/Prototypes/Entities/Clothing/Head/misc.yml
@@ -46,6 +46,8 @@
     slots:
     - HEAD
     - neck
+    preferredSlots: # L5 - preferred quickequip slots
+    - HEAD
   - type: Construction
     graph: flowerwreath
     node: flowerwreath


### PR DESCRIPTION
<!-- If you are new to the Delta-V repository, please read the [Contributing Guidelines](https://github.com/DeltaV-Station/Delta-v/blob/master/CONTRIBUTING.md) -->

## About the PR
<!-- What did you change? -->

Make the flowerwreaths quick equip by trying the head slot before the neck slot.

## Why / Balance
<!-- Discuss how this would affect game balance or explain why it was changed. Link any relevant discussions or issues. -->
Fixes #105.

## Technical details
<!-- Summary of code changes for easier review. -->

Frick you I'll use LINQ.

## Media
<!-- Attach media if the PR makes ingame changes (clothing, items, features, etc).
Small fixes/refactors are exempt. -->
<img width="468" alt="image" src="https://github.com/user-attachments/assets/f0727cd3-3933-428a-9bcf-b96afb67af3c" />
I dunno here's Effe looking cute I guess.

## Requirements
<!-- Confirm the following by placing an X in the brackets [X]: -->
- [X] I have tested all added content and changes.
- [X] I have added media to this PR or it does not require an ingame showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->

## Breaking changes
<!-- List any breaking changes, including namespaces, public class/method/field changes, prototype renames; and provide instructions for fixing them. -->

**Changelog**
<!-- Add a Changelog entry to make players aware of new features or changes that could affect gameplay.
Make sure to read the guidelines and take this Changelog template out of the comment block in order for it to show up.
Changelogs must have a :cl: symbol, so the bot recognizes the changes and adds them to the game's changelog. -->
<!--
:cl:
- add: Added fun!
- remove: Removed fun!
- tweak: Changed fun!
- fix: Fixed fun!
-->
:cl:
- fix: The glaring issue of flower wreaths equipping to your neck instead of your head first has been FIXED.