### PR TITLE
Reenable & Add Collision to Wheelchairs

### DIFF
--- a/Content.Shared/_L5/Movement/Systems/PilotOnBuckleSystem.cs
+++ b/Content.Shared/_L5/Movement/Systems/PilotOnBuckleSystem.cs
@@ -2,12 +2,18 @@ using Content.Shared._L5.Movement.Components;
 using Content.Shared.Buckle.Components;
 using Content.Shared.Movement.Components;
 using Content.Shared.Movement.Systems;
+using Content.Shared.Physics;
+using Robust.Shared.Physics.Components;
+using Robust.Shared.Physics;
+using Robust.Shared.Physics.Systems;
+using System.Linq;
 
 namespace Content.Shared._L5.Movement.Systems
 {
     public sealed class PilotOnBuckleSystem() : EntitySystem
     {
         [Dependency] private readonly SharedMoverController _moverController = default!;
+        [Dependency] private readonly SharedPhysicsSystem _physics = default!;
         public override void Initialize()
         {
             // When strapping into an object, update entity associations.
@@ -26,6 +32,23 @@ namespace Content.Shared._L5.Movement.Systems
             // We need the moved entity to be able to be moved and have a move speed to use.
             EnsureComp<InputMoverComponent>(movedEntity);
             EnsureComp<MovementSpeedModifierComponent>(movedEntity);
+
+            // Physics 'bullshittery' necessary for object to behave properly (modified from AnimateSpellSystem)
+            // For collision layer, the Opaque CG is used rather MobLayer to ensure bullets don't collide with the wheelchair (otherwise this totally becomes a moving riot shield)
+            // Admins be warned - applying this to players will change their physics and *probably* makes them immune to bullets
+            if (TryComp<FixturesComponent>(movedEntity, out var fixtures) && TryComp<PhysicsComponent>(movedEntity, out var physics))
+            {
+                var xform = Transform(movedEntity);
+                var fixture = fixtures.Fixtures.First();
+
+                _physics.SetCanCollide(movedEntity, true, true, false, fixtures, physics);
+                _physics.SetCollisionMask(movedEntity, fixture.Key, fixture.Value, (int)CollisionGroup.MobMask, fixtures, physics);
+                _physics.SetCollisionLayer(movedEntity, fixture.Key, fixture.Value, (int)CollisionGroup.Opaque, fixtures, physics);
+                _physics.SetBodyType(movedEntity, BodyType.KinematicController, fixtures, physics, xform);
+                _physics.SetBodyStatus(movedEntity, physics, BodyStatus.OnGround, true);
+                _physics.SetFixedRotation(movedEntity, false, true, fixtures, physics);
+                _physics.SetHard(movedEntity, fixture.Value, true, fixtures);
+            }
 
             _moverController.SetRelay(moverEntity, movedEntity);
         }

--- a/Content.Shared/_L5/Movement/Systems/PilotOnBuckleSystem.cs
+++ b/Content.Shared/_L5/Movement/Systems/PilotOnBuckleSystem.cs
@@ -34,9 +34,9 @@ namespace Content.Shared._L5.Movement.Systems
             EnsureComp<MovementSpeedModifierComponent>(movedEntity);
 
             // Physics 'bullshittery' necessary for object to behave properly (modified from AnimateSpellSystem)
-            // For collision layer, the Opaque CG is used rather MobLayer to ensure bullets don't collide with the wheelchair (otherwise this totally becomes a moving riot shield)
-            // Admins be warned - applying this to players will change their physics and *probably* makes them immune to bullets
-            if (TryComp<FixturesComponent>(movedEntity, out var fixtures) && TryComp<PhysicsComponent>(movedEntity, out var physics))
+            // For collision layer, the Opaque CG is used over MobLayer to ensure bullets don't collide with the wheelchair (otherwise this totally becomes a moving riot shield)
+            // We *probably* don't want to change the collision states of objects that can already be collided with, otherwise we can get into a state where we accidentally makes someone immune to bullets
+            if (TryComp<FixturesComponent>(movedEntity, out var fixtures) && TryComp<PhysicsComponent>(movedEntity, out var physics) && !physics.CanCollide)
             {
                 var xform = Transform(movedEntity);
                 var fixture = fixtures.Fixtures.First();

--- a/Resources/Locale/en-US/_L5/traits/traits.ftl
+++ b/Resources/Locale/en-US/_L5/traits/traits.ftl
@@ -10,7 +10,7 @@ trait-sign-language-desc = You can speak the most common signed language, allowi
 
 # Disability traits
 trait-lowmobility-name = Low Mobility
-trait-lowmobility-desc = You aren't able to get around very fast. Not for the faint of heart.
+trait-lowmobility-desc = You aren't able to get around very fast. Not without your trusty wheelchair, anyways! Careful not to bump into anything.
 
 trait-hard-of-hearing-name = Hard of hearing
 trait-hard-of-hearing-desc = You aren't able to hear well. Voices far away may appear muffled or unintelligible.

--- a/Resources/Prototypes/_L5/Traits/disabilities.yml
+++ b/Resources/Prototypes/_L5/Traits/disabilities.yml
@@ -2,6 +2,7 @@
   id: LowMobility
   name: trait-lowmobility-name
   description: trait-lowmobility-desc
+  traitGear: BaseWheelchair
   category: Disabilities
   components:
   - type: LowMobility


### PR DESCRIPTION
<!-- If you are new to the Delta-V repository, please read the [Contributing Guidelines](https://github.com/DeltaV-Station/Delta-v/blob/master/CONTRIBUTING.md) -->

## About the PR
<!-- What did you change? -->
Added collision behavior to wheelchairs

## Why / Balance
<!-- Discuss how this would affect game balance or explain why it was changed. Link any relevant discussions or issues. -->

## Technical details
<!-- Summary of code changes for easier review. -->
Reenabled wheelchairs as part of the low-mobility starting gear, and modified pilot-on-buckle system to automatically add collision to buckled entities.

## Media
<!-- Attach media if the PR makes ingame changes (clothing, items, features, etc).
Small fixes/refactors are exempt. -->

## Requirements
<!-- Confirm the following by placing an X in the brackets [X]: -->
- [X] I have tested all added content and changes.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->

## Breaking changes
<!-- List any breaking changes, including namespaces, public class/method/field changes, prototype renames; and provide instructions for fixing them. -->

**Changelog**
<!-- Add a Changelog entry to make players aware of new features or changes that could affect gameplay.
Make sure to read the guidelines and take this Changelog template out of the comment block in order for it to show up.
Changelogs must have a :cl: symbol, so the bot recognizes the changes and adds them to the game's changelog. -->
<!--
:cl:
- add: Collision behavior for wheelchairs, wheelchairs as part of the low mobility trait (again).
-->
