### PR TITLE
Auto-restart changes for both servers

### DIFF
--- a/Resources/ConfigPresets/L5/L5.toml
+++ b/Resources/ConfigPresets/L5/L5.toml
@@ -85,7 +85,6 @@ admin_prefix_webhook = false
 
 [server]
 rules_file             = "L5Ruleset"
-uptime_restart_minutes = 20160 # 2 weeks
 
 [rmc]
 mentor_help_sound = "/Audio/_DV/Effects/Admin/chord2.ogg" # we get our own sound

--- a/Resources/ConfigPresets/L5/outpost.toml
+++ b/Resources/ConfigPresets/L5/outpost.toml
@@ -9,4 +9,5 @@ preset_enabled = false
 map_enabled    = false
 
 [server]
-id = "lagrange14_outpost"
+id                     = "lagrange14_outpost"
+uptime_restart_minutes = -1 # Don't auto restart; we'll do it after each round

--- a/Resources/ConfigPresets/L5/substations.toml
+++ b/Resources/ConfigPresets/L5/substations.toml
@@ -1,6 +1,7 @@
 [game]
 hostname = "[EN][HRP][18+] Lagrange Substations"
-desc     = "An HRP Space Station 14 server centered around the System, a machine that dreams. You will be stationed on one of the stations supporting a shard of the System."
+desc     = "An HRP Space Station 14 server centered around the System, a machine that dreams. You will be living and working one of the stations supporting a shard of the System."
 
 [server]
-id = "lagrange14_outpost"
+id                     = "lagrange14_outpost"
+uptime_restart_minutes = 7200 # 5 days


### PR DESCRIPTION
<!-- If you are new to the Delta-V repository, please read the [Contributing Guidelines](https://github.com/DeltaV-Station/Delta-v/blob/master/CONTRIBUTING.md) -->

## About the PR
<!-- What did you change? -->
* Outpost doesn't auto-restart; we have to remember to do it between rounds
* Substations auto-restarts after five days

## Why / Balance
<!-- Discuss how this would affect game balance or explain why it was changed. Link any relevant discussions or issues. -->

## Technical details
<!-- Summary of code changes for easier review. -->

## Media
<!-- Attach media if the PR makes ingame changes (clothing, items, features, etc).
Small fixes/refactors are exempt. -->

## Requirements
<!-- Confirm the following by placing an X in the brackets [X]: -->
- [X] I have tested all added content and changes.
- [X] I have added media to this PR or it does not require an ingame showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->

## Breaking changes
<!-- List any breaking changes, including namespaces, public class/method/field changes, prototype renames; and provide instructions for fixing them. -->

**Changelog**
<!-- Add a Changelog entry to make players aware of new features or changes that could affect gameplay.
Make sure to read the guidelines and take this Changelog template out of the comment block in order for it to show up.
Changelogs must have a :cl: symbol, so the bot recognizes the changes and adds them to the game's changelog. -->
<!--
:cl:
- add: Added fun!
- remove: Removed fun!
- tweak: Changed fun!
- fix: Fixed fun!
-->
:cl:
- tweak: Outpost server no longer auto-restarts, and substations auto-restarts after five days