### PR TITLE
Doubled the time it takes for holopads to idle timeout

### DIFF
--- a/Content.Shared/Telephone/TelephoneComponent.cs
+++ b/Content.Shared/Telephone/TelephoneComponent.cs
@@ -20,7 +20,7 @@ public sealed partial class TelephoneComponent : Component
     /// Sets how long the telephone can remain idle in-call before it automatically hangs up
     /// </summary>
     [DataField]
-    public float IdlingTimeout = 60;
+    public float IdlingTimeout = 120;
 
     /// <summary>
     /// Sets how long the telephone will stay in the hanging up state before return to idle


### PR DESCRIPTION
Issue #258, far as I can tell it is literally just this value that determines it(and yes I checked in game and sat silent in a holocall for two minutes lmao).

Two minutes seems good enough but well, if it isn't it is dead easy to increase 