### PR TITLE
Reintroduce Security Icons to Corpsman Glasses

### DIFF
--- a/Resources/Prototypes/_DV/Entities/Clothing/Eyes/glasses.yml
+++ b/Resources/Prototypes/_DV/Entities/Clothing/Eyes/glasses.yml
@@ -14,7 +14,7 @@
         Caustic: 0.85
 
 - type: entity
-  parent: [ClothingEyesBase, ShowMedicalIcons, BaseSecurityContraband]
+  parent: [ClothingEyesBase, ShowMedicalIcons, ShowSecurityIcons, BaseSecurityContraband]
   id: ClothingEyesGlassesCorpsman
   name: corpsman glasses
   description: Security glasses designed for the Corpsman for medical needs. Now with a cool blue hue*

--- a/Resources/Prototypes/_DV/Recipes/Construction/Graphs/clothing/glasses_corpshud.yml
+++ b/Resources/Prototypes/_DV/Recipes/Construction/Graphs/clothing/glasses_corpshud.yml
@@ -18,6 +18,12 @@
           sprite: Clothing/Eyes/Hud/med.rsi
           state: icon
         doAfter: 5
+      - tag: HudSecurity
+        name: construction-graph-tag-security-hud
+        icon:
+          sprite: Clothing/Eyes/Hud/sec.rsi
+          state: icon
+        doAfter: 5
       - material: Cable
         amount: 5
         doAfter: 5


### PR DESCRIPTION
<!-- If you are new to the Delta-V repository, please read the [Contributing Guidelines](https://github.com/DeltaV-Station/Delta-v/blob/master/CONTRIBUTING.md) -->

## About the PR
Re-adds the security icons to corpsman glasses. Additionally requires security hud as a component in building corpsman glasses from the inventory.

## Why / Balance
To undo someone's 'balancing decision.'

## Requirements
<!-- Confirm the following by placing an X in the brackets [X]: -->
- [X] I have tested all added content and changes.
- [X] I have added media to this PR or it does not require an ingame showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->

## Breaking changes
<!-- List any breaking changes, including namespaces, public class/method/field changes, prototype renames; and provide instructions for fixing them. -->

**Changelog**
<!-- Add a Changelog entry to make players aware of new features or changes that could affect gameplay.
Make sure to read the guidelines and take this Changelog template out of the comment block in order for it to show up.
Changelogs must have a :cl: symbol, so the bot recognizes the changes and adds them to the game's changelog. -->
<!--
:cl:
-->
:cl:
- tweak: Returned corpsman glasses to their former glory.
