### PR TITLE
feat: disable time requirements for loadouts

### DIFF
--- a/Content.Shared/Preferences/Loadouts/Effects/JobRequirementLoadoutEffect.cs
+++ b/Content.Shared/Preferences/Loadouts/Effects/JobRequirementLoadoutEffect.cs
@@ -18,6 +18,9 @@ public sealed partial class JobRequirementLoadoutEffect : LoadoutEffect
 
     public override bool Validate(HumanoidCharacterProfile profile, RoleLoadout loadout, ICommonSession? session, IDependencyCollection collection, [NotNullWhen(false)] out FormattedMessage? reason)
     {
+        reason = FormattedMessage.Empty;
+        return true; // L5 - lol
+        /*
         if (session == null)
         {
             reason = FormattedMessage.Empty;
@@ -34,5 +37,6 @@ public sealed partial class JobRequirementLoadoutEffect : LoadoutEffect
             playtimes,
             out reason,
             isWhitelisted); // DeltaV
+        */
     }
 }

--- a/Content.Shared/Roles/JobRequirement/DepartmentTimeRequirement.cs
+++ b/Content.Shared/Roles/JobRequirement/DepartmentTimeRequirement.cs
@@ -32,6 +32,8 @@ public sealed partial class DepartmentTimeRequirement : JobRequirement
         bool isWhitelisted) // DeltaV
     {
         reason = new FormattedMessage();
+        return true; // L5 - lol. (Even though game.role_timers exists, loadout effects ignore it.)
+        /*
         var playtime = TimeSpan.Zero;
 
         // Check all jobs' departments
@@ -83,5 +85,6 @@ public sealed partial class DepartmentTimeRequirement : JobRequirement
         }
 
         return true;
+        */
     }
 }


### PR DESCRIPTION
<!-- If you are new to the Delta-V repository, please read the [Contributing Guidelines](https://github.com/DeltaV-Station/Delta-v/blob/master/CONTRIBUTING.md) -->

## About the PR
<!-- What did you change? -->
Disabled time requirements for loadouts.

## Why / Balance
<!-- Discuss how this would affect game balance or explain why it was changed. Link any relevant discussions or issues. -->
They're dumb.

Fixes #89, as far as I know.
Partially addresses #119.

## Technical details
<!-- Summary of code changes for easier review. -->
TECHNICALLY this also disables departmental time requirements, but we're always going to have that off via cvar anyway.

## Media
<!-- Attach media if the PR makes ingame changes (clothing, items, features, etc).
Small fixes/refactors are exempt. -->

## Requirements
<!-- Confirm the following by placing an X in the brackets [X]: -->
- [X] I have tested all added content and changes.
- [X] I have added media to this PR or it does not require an ingame showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->

## Breaking changes
<!-- List any breaking changes, including namespaces, public class/method/field changes, prototype renames; and provide instructions for fixing them. -->

**Changelog**
<!-- Add a Changelog entry to make players aware of new features or changes that could affect gameplay.
Make sure to read the guidelines and take this Changelog template out of the comment block in order for it to show up.
Changelogs must have a :cl: symbol, so the bot recognizes the changes and adds them to the game's changelog. -->
<!--
:cl:
- add: Added fun!
- remove: Removed fun!
- tweak: Changed fun!
- fix: Fixed fun!
-->
:cl:
- remove: Loadout time requirements.
