### PR TITLE
Move moth and reptilian diets to traits

### DIFF
--- a/Content.Server/_L5/Traits/DietaryRestriction/DietaryRestrictionSystem.cs
+++ b/Content.Server/_L5/Traits/DietaryRestriction/DietaryRestrictionSystem.cs
@@ -34,6 +34,9 @@ public sealed class DietaryRestrictionSystem : EntitySystem
         SubscribeLocalEvent<GlutenAllergyComponent, MapInitEvent>(InitGlutenAllergy);
         SubscribeLocalEvent<LatexAllergyComponent, MapInitEvent>(InitLatexAllergy);
         SubscribeLocalEvent<NightshadeAllergyComponent, MapInitEvent>(InitNightshadeAllergy);
+
+        SubscribeLocalEvent<ReptilianDietComponent, MapInitEvent>(InitReptilianDiet);
+        SubscribeLocalEvent<MothDietComponent, MapInitEvent>(InitMothDiet);
     }
 
     private void InitPescetarianRestriction(Entity<PescetarianRestrictionComponent> entity, ref MapInitEvent args)
@@ -88,6 +91,18 @@ public sealed class DietaryRestrictionSystem : EntitySystem
     {
         var restriction = EnsureComp<DietaryRestrictionComponent>(entity);
         restriction.Restrictions.Add("NightshadeAllergy");
+    }
+
+    private void InitReptilianDiet(Entity<ReptilianDietComponent> entity, ref MapInitEvent args)
+    {
+        var restriction = EnsureComp<DietaryRestrictionComponent>(entity);
+        restriction.Restrictions.Add("ReptilianDiet");
+    }
+
+    private void InitMothDiet(Entity<MothDietComponent> entity, ref MapInitEvent args)
+    {
+        var restriction = EnsureComp<DietaryRestrictionComponent>(entity);
+        restriction.Restrictions.Add("MothDiet");
     }
 
     public bool TryFood(EntityUid user, EntityUid food)

--- a/Content.Shared/_L5/Traits/DietaryRestriction/DietaryRestrictionComponents.cs
+++ b/Content.Shared/_L5/Traits/DietaryRestriction/DietaryRestrictionComponents.cs
@@ -56,3 +56,13 @@ public sealed partial class LatexAllergyComponent : Component
 public sealed partial class NightshadeAllergyComponent : Component
 {
 }
+
+[RegisterComponent]
+public sealed partial class ReptilianDietComponent : Component
+{
+}
+
+[RegisterComponent]
+public sealed partial class MothDietComponent : Component
+{
+}

--- a/Resources/Locale/en-US/_L5/traits/traits.ftl
+++ b/Resources/Locale/en-US/_L5/traits/traits.ftl
@@ -57,6 +57,14 @@ trait-dietary-restriction-NightshadeAllergy-name = Nightshade allergy
 trait-dietary-restriction-NightshadeAllergy-desc = You're allergic to glycoalkaloids, a natural pest deterrent found in plants such as potatoes and tomatoes
 trait-dietary-restriction-NightshadeAllergy-fail = Oh no...that has nightshades in it...you may get sick...
 
+trait-dietary-restriction-ReptilianDiet-name = Reptilian diet
+trait-dietary-restriction-ReptilianDiet-desc = You stick to meat, fruit, and a minimum of dairy, carbs, and sugars
+trait-dietary-restriction-ReptilianDiet-fail = You can't eat that with your diet...
+
+trait-dietary-restriction-MothDiet-name = Moth diet
+trait-dietary-restriction-MothDiet-desc = You stick to fruit and veggies, and you have an affinity for things made of cloth
+trait-dietary-restriction-MothDiet-fail = You can't eat that with your diet...
+
 # Skills
 trait-hud-security-name = Security HUD
 trait-hud-security-desc = A Security HUD is installed in your display. Doesn't actually increase how secure you feel, especially if Paul's around.

--- a/Resources/Prototypes/Body/Organs/moth.yml
+++ b/Resources/Prototypes/Body/Organs/moth.yml
@@ -5,12 +5,13 @@
   name: moth stomach # Shitmed
   components:
   - type: Stomach
-    specialDigestible:
-      tags:
-      - ClothMade
-      - Fruit # DeltaV - Moth can eat fruits.
-      - Paper
-      - Pill
+# L5: moved to trait
+#    specialDigestible:
+#      tags:
+#      - ClothMade
+#      - Fruit # DeltaV - Moth can eat fruits.
+#      - Paper
+#      - Pill
   - type: SolutionContainerManager
     solutions:
       stomach:

--- a/Resources/Prototypes/Body/Organs/reptilian.yml
+++ b/Resources/Prototypes/Body/Organs/reptilian.yml
@@ -4,14 +4,15 @@
   categories: [ HideSpawnMenu ]
   components:
   - type: Stomach
-    specialDigestible:
-      tags:
-      - Fruit
-      - ReptilianFood
-      - Meat
-      - Pill
-      - Crayon
-      - Paper
+# L5: moved to trait
+#    specialDigestible:
+#      tags:
+#      - Fruit
+#      - ReptilianFood
+#      - Meat
+#      - Pill
+#      - Crayon
+#      - Paper
   - type: SolutionContainerManager
     solutions:
       stomach:

--- a/Resources/Prototypes/_L5/Traits/restricted_diet.yml
+++ b/Resources/Prototypes/_L5/Traits/restricted_diet.yml
@@ -123,3 +123,32 @@
       - BorgChassis
   excludedSpecies:
     - IPC
+
+- type: trait
+  category: Diet
+  id: ReptilianDiet
+  name: trait-dietary-restriction-ReptilianDiet-name
+  description: trait-dietary-restriction-ReptilianDiet-desc
+  components:
+    - type: ReptilianDiet
+  blacklist:
+    components:
+      - Silicon
+      - BorgChassis
+  excludedSpecies:
+    - IPC
+
+- type: trait
+  category: Diet
+  id: MothDiet
+  name: trait-dietary-restriction-MothDiet-name
+  description: trait-dietary-restriction-MothDiet-desc
+  components:
+  - type: MothDiet
+  blacklist:
+    components:
+    - Silicon
+    - BorgChassis
+  excludedSpecies:
+  - IPC
+

--- a/Resources/Prototypes/_L5/dietary_restrictions.yml
+++ b/Resources/Prototypes/_L5/dietary_restrictions.yml
@@ -68,9 +68,8 @@
   chanceOfVomiting: 0.1
 
 # Species
-# This is currently just an example and doesn't replace the way stomachs work.
 - type: dietaryRestriction
-  id: LizardDiet
+  id: ReptilianDiet
   mustHave:
     tags:
     - Fruit
@@ -79,3 +78,12 @@
     - Pill
     - Crayon
     - Paper
+
+- type: dietaryRestriction
+  id: MothDiet
+  mustHave:
+    tags:
+    - ClothMade
+    - Fruit # DeltaV - Moth can eat fruits.
+    - Paper
+    - Pill


### PR DESCRIPTION
<!-- If you are new to the Delta-V repository, please read the [Contributing Guidelines](https://github.com/DeltaV-Station/Delta-v/blob/master/CONTRIBUTING.md) -->

## About the PR
<!-- What did you change? -->
By default, moths and lizards can eat everything, but now anyone can select their diets as a trait

## Why / Balance
<!-- Discuss how this would affect game balance or explain why it was changed. Link any relevant discussions or issues. -->
This is the type of thing that was probably thought about pretty early on.

## Technical details
<!-- Summary of code changes for easier review. -->
It still currently shows the doafter, but it fails at the end without consuming. It should at least show the fail message.

## Media
<!-- Attach media if the PR makes ingame changes (clothing, items, features, etc).
Small fixes/refactors are exempt. -->

## Requirements
<!-- Confirm the following by placing an X in the brackets [X]: -->
- [X] I have tested all added content and changes.
- [X] I have added media to this PR or it does not require an ingame showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->

## Breaking changes
<!-- List any breaking changes, including namespaces, public class/method/field changes, prototype renames; and provide instructions for fixing them. -->

**Changelog**
<!-- Add a Changelog entry to make players aware of new features or changes that could affect gameplay.
Make sure to read the guidelines and take this Changelog template out of the comment block in order for it to show up.
Changelogs must have a :cl: symbol, so the bot recognizes the changes and adds them to the game's changelog. -->
<!--
:cl:
- add: Added fun!
- remove: Removed fun!
- tweak: Changed fun!
- fix: Fixed fun!
-->
:cl:
- tweak: Lizard and moth diets are now traits rather than species specific; anyone can take them!