### PR TITLE
Offer holobeds to paramedics

### DIFF
--- a/Resources/Prototypes/_DV/Catalog/Fills/Lockers/medical.yml
+++ b/Resources/Prototypes/_DV/Catalog/Fills/Lockers/medical.yml
@@ -171,7 +171,8 @@
     children:
     - id: ClothingShoesBootsWinterParamedic
     - id: BoxBodyBag
-    - id: EmergencyRollerBedSpawnFolded
+    #- id: EmergencyRollerBedSpawnFolded
+    - id: RollerBedHoloSpawnFolded # L5
     - id: EmergencyJawsOfLife
     - id: HandheldCrewMonitor
     - id: LunchboxMedicalFilledRandom

--- a/Resources/Prototypes/_DV/Recipes/Lathes/Packs/medical.yml
+++ b/Resources/Prototypes/_DV/Recipes/Lathes/Packs/medical.yml
@@ -24,6 +24,7 @@
   id: MedicalDeltaV
   recipes:
   - HandheldCrewMonitor # RE
+  - RollerBedHolo # L5
 
 - type: latheRecipePack
   id: MedicalBoardsDeltaV

--- a/Resources/Prototypes/_L5/Recipes/Lathes/medical.yml
+++ b/Resources/Prototypes/_L5/Recipes/Lathes/medical.yml
@@ -1,0 +1,9 @@
+- type: latheRecipe
+  id: RollerBedHolo
+  result: RollerBedHoloSpawnFolded
+  completetime: 5
+  materials:
+    Steel: 200
+    Plastic: 100
+    Glass: 100
+    Plasma: 200

--- a/Resources/Prototypes/_L5/Research/civilianservices.yml
+++ b/Resources/Prototypes/_L5/Research/civilianservices.yml
@@ -1,0 +1,11 @@
+- type: technology
+  id: Holobed
+  name: research-technology-holobed
+  icon:
+    sprite: _DV/Structures/Furniture/rollerbeds.rsi
+    state: rollerbed
+  discipline: CivilianServices
+  tier: 1
+  cost: 5000
+  recipeUnlocks:
+  - RollerBedHolo


### PR DESCRIPTION
<!-- If you are new to the Delta-V repository, please read the [Contributing Guidelines](https://github.com/DeltaV-Station/Delta-v/blob/master/CONTRIBUTING.md) -->

## About the PR
<!-- What did you change? -->
Paramedics now spawn with holographic rollerbeds in their lockers, which can also be researched at tier 1 and printed in the med fab.

## Why / Balance
<!-- Discuss how this would affect game balance or explain why it was changed. Link any relevant discussions or issues. -->
It's the future.

## Technical details
<!-- Summary of code changes for easier review. -->

## Media
<!-- Attach media if the PR makes ingame changes (clothing, items, features, etc).
Small fixes/refactors are exempt. -->

## Requirements
<!-- Confirm the following by placing an X in the brackets [X]: -->
- [X] I have tested all added content and changes.
- [X] I have added media to this PR or it does not require an ingame showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->

## Breaking changes
<!-- List any breaking changes, including namespaces, public class/method/field changes, prototype renames; and provide instructions for fixing them. -->

**Changelog**
<!-- Add a Changelog entry to make players aware of new features or changes that could affect gameplay.
Make sure to read the guidelines and take this Changelog template out of the comment block in order for it to show up.
Changelogs must have a :cl: symbol, so the bot recognizes the changes and adds them to the game's changelog. -->
<!--
:cl:
- add: Added fun!
- remove: Removed fun!
- tweak: Changed fun!
- fix: Fixed fun!
-->
:cl:
- add: Holographic rollerbeds can be researched at tier 1 and printed in the med fab
- tweak: Paramedic lockers spawn with holographic rollerbeds