### PR TITLE
fix: air alarm panic/fill flowmos presets unborken

### DIFF
--- a/Content.Server/Atmos/Monitor/Systems/AirAlarmModes.cs
+++ b/Content.Server/Atmos/Monitor/Systems/AirAlarmModes.cs
@@ -193,16 +193,10 @@ public sealed class AirAlarmPanicMode : AirAlarmModeExecutor
             switch (device.VentFlowmosMode)
             {
                 case GasVentPumpData.VentPumpFlowmos.Inlet:
-                    var inletPreset = GasVentPumpData.FilterInletPreset;
-                    inletPreset.Enabled = false;
-
-                    AirAlarmSystem.SetData(uid, addr, inletPreset);
+                    AirAlarmSystem.SetData(uid, addr, GasVentPumpData.PanicModeInletPreset);
                     break;
                 case GasVentPumpData.VentPumpFlowmos.Outlet:
-                    var outletPreset = GasVentPumpData.FilterOutletPreset;
-                    outletPreset.ExternalPressureBound = 0;
-
-                    AirAlarmSystem.SetData(uid, addr, outletPreset);
+                    AirAlarmSystem.SetData(uid, addr, GasVentPumpData.PanicModeOutletPreset);
                     break;
                 default:
                     AirAlarmSystem.SetData(uid, addr, GasVentPumpData.FillModePreset);
@@ -231,16 +225,10 @@ public sealed class AirAlarmFillMode : AirAlarmModeExecutor
             switch (device.VentFlowmosMode)
             {
                 case GasVentPumpData.VentPumpFlowmos.Inlet:
-                    var inletPreset = GasVentPumpData.FilterInletPreset;
-                    inletPreset.PressureLockoutOverride = true;
-                    inletPreset.ExternalPressureBound = GasVentPumpData.FillModePreset.ExternalPressureBound;
-
-                    AirAlarmSystem.SetData(uid, addr, inletPreset);
+                    AirAlarmSystem.SetData(uid, addr, GasVentPumpData.FillModeInletPreset);
                     break;
                 case GasVentPumpData.VentPumpFlowmos.Outlet:
-                    var outletPreset = GasVentPumpData.FilterOutletPreset;
-                    outletPreset.Enabled = false;
-                    AirAlarmSystem.SetData(uid, addr, outletPreset);
+                    AirAlarmSystem.SetData(uid, addr, GasVentPumpData.FillModeOutletPreset);
                     break;
                 default:
                     AirAlarmSystem.SetData(uid, addr, GasVentPumpData.FillModePreset);

--- a/Content.Shared/_L5/Atmos/GasVentPumpData.cs
+++ b/Content.Shared/_L5/Atmos/GasVentPumpData.cs
@@ -50,6 +50,53 @@ public sealed partial class GasVentPumpData
         PressureLockoutOverride = false,
     };
 
+    // FilterInlet but just disabled
+    public static GasVentPumpData PanicModeInletPreset = new()
+    {
+        Enabled = false,
+        PumpDirection = VentPumpDirection.Releasing,
+        PressureChecks = VentPressureBound.ExternalBound,
+        VentFlowmosMode = VentPumpFlowmos.Inlet,
+        ExternalPressureBound = Atmospherics.OneAtmosphere + Atmospherics.AirVentPressureDelta,
+        InternalPressureBound = 0f,
+        PressureLockoutOverride = false,
+    };
+
+    // FilterOutlet but external pressure bound set to 0 kPa
+    public static GasVentPumpData PanicModeOutletPreset = new()
+    {
+        Enabled = true,
+        PumpDirection = VentPumpDirection.Siphoning,
+        PressureChecks = VentPressureBound.ExternalBound,
+        VentFlowmosMode = VentPumpFlowmos.Outlet,
+        ExternalPressureBound = 0f,
+        InternalPressureBound = 0f,
+        PressureLockoutOverride = false,
+    };
+
+    // FilterInlet but pressure lockout overriden and max external pressure bound
+    public static GasVentPumpData FillModeInletPreset = new()
+    {
+        Enabled = true,
+        PumpDirection = VentPumpDirection.Releasing,
+        PressureChecks = VentPressureBound.ExternalBound,
+        VentFlowmosMode = VentPumpFlowmos.Inlet,
+        ExternalPressureBound = Atmospherics.OneAtmosphere * 50,
+        InternalPressureBound = 0f,
+        PressureLockoutOverride = true,
+    };
+
+    // FilterOutlet but disabled
+    public static GasVentPumpData FillModeOutletPreset = new()
+    {
+        Enabled = false,
+        PumpDirection = VentPumpDirection.Siphoning,
+        PressureChecks = VentPressureBound.ExternalBound,
+        VentFlowmosMode = VentPumpFlowmos.Outlet,
+        ExternalPressureBound = Atmospherics.OneAtmosphere - Atmospherics.AirVentPressureDelta,
+        InternalPressureBound = 0f,
+        PressureLockoutOverride = false,
+    };
 
     [Flags]
     [Serializable, NetSerializable]


### PR DESCRIPTION
<!-- If you are new to the Delta-V repository, please read the [Contributing Guidelines](https://github.com/DeltaV-Station/Delta-v/blob/master/CONTRIBUTING.md) -->

## About the PR
<!-- What did you change? -->
Fill and panic were... modifying reference types.

Why is GasVentPumpData not a struuuuct gaahhhhhh.
## Why / Balance
<!-- Discuss how this would affect game balance or explain why it was changed. Link any relevant discussions or issues. -->

## Technical details
<!-- Summary of code changes for easier review. -->

## Media
<!-- Attach media if the PR makes ingame changes (clothing, items, features, etc).
Small fixes/refactors are exempt. -->

## Requirements
<!-- Confirm the following by placing an X in the brackets [X]: -->
- [X] I have tested all added content and changes.
- [X] I have added media to this PR or it does not require an ingame showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->

## Breaking changes
<!-- List any breaking changes, including namespaces, public class/method/field changes, prototype renames; and provide instructions for fixing them. -->

**Changelog**
<!-- Add a Changelog entry to make players aware of new features or changes that could affect gameplay.
Make sure to read the guidelines and take this Changelog template out of the comment block in order for it to show up.
Changelogs must have a :cl: symbol, so the bot recognizes the changes and adds them to the game's changelog. -->
<!--
:cl:
- add: Added fun!
- remove: Removed fun!
- tweak: Changed fun!
- fix: Fixed fun!
-->
