### PR TITLE
feat: let ore processors "print" to ore silos

### DIFF
--- a/Content.Client/Lathe/UI/LatheBoundUserInterface.cs
+++ b/Content.Client/Lathe/UI/LatheBoundUserInterface.cs
@@ -1,5 +1,6 @@
 using Content.Shared._DV.Salvage; // DeltaV
 using Content.Shared.Lathe;
+using Content.Shared.Materials.OreSilo;
 using Content.Shared.Research.Components;
 using JetBrains.Annotations;
 using Robust.Client.UserInterface;
@@ -33,6 +34,9 @@ namespace Content.Client.Lathe.UI
             };
 
             _menu.OnClaimMiningPoints += () => SendMessage(new LatheClaimMiningPointsMessage()); // DeltaV
+
+            // L5 - ore processor silo support
+            _menu.OnEnableSiloPressed += enabled => SendMessage(new EnableSiloButtonPressed(enabled));
         }
 
         protected override void UpdateState(BoundUserInterfaceState state)

--- a/Content.Client/Lathe/UI/LatheMenu.xaml.cs
+++ b/Content.Client/Lathe/UI/LatheMenu.xaml.cs
@@ -33,6 +33,7 @@ public sealed partial class LatheMenu : DefaultWindow
     public event Action<BaseButton.ButtonEventArgs>? OnServerListButtonPressed;
     public event Action<string, int>? RecipeQueueAction;
     public event Action? OnClaimMiningPoints; // DeltaV
+    public event Action<bool>? OnEnableSiloPressed; // L5
 
     public List<ProtoId<LatheRecipePrototype>> Recipes = new();
 
@@ -66,6 +67,9 @@ public sealed partial class LatheMenu : DefaultWindow
         FilterOption.OnItemSelected += OnItemSelected;
 
         ServerListButton.OnPressed += a => OnServerListButtonPressed?.Invoke(a);
+
+        // L5 - ore processor silo support
+        MaterialsList.OnEnableSiloPressed += a => OnEnableSiloPressed?.Invoke(a);
     }
 
     public void SetEntity(EntityUid uid)

--- a/Content.Client/Materials/UI/MaterialStorageControl.xaml
+++ b/Content.Client/Materials/UI/MaterialStorageControl.xaml
@@ -6,6 +6,13 @@
         <BoxContainer Name="MaterialList" Orientation="Vertical" VerticalExpand="True">
             <Label Name="NoMatsLabel" Text="{Loc 'lathe-menu-no-materials-message'}" HorizontalAlignment="Center" VerticalAlignment="Center" VerticalExpand="True"/>
         </BoxContainer>
-        <Label Name="SiloLinkedLabel" Text="{Loc 'lathe-menu-silo-linked-message'}" StyleClasses="LabelSubText" Visible="False" HorizontalAlignment="Center"/>
+        <!-- Begin L5 changes - ore processor silo support -->
+        <BoxContainer Name="SiloLinkedBox" Orientation="Horizontal" Visible="False">
+            <Label Name="SiloLinkedLabel" Text="{Loc 'lathe-menu-silo-linked-message'}" StyleClasses="LabelSubText"
+                   HorizontalAlignment="Center" HorizontalExpand="True" />
+            <CheckBox Name="SiloEnableCheckbox" Text="{Loc 'lathe-menu-silo-enabled'}" Pressed="True"
+                      Visible="False" HorizontalAlignment="Right" Margin="0 0 10 0"/>
+        </BoxContainer>
+        <!-- End L5 changes -->
     </BoxContainer>
 </ScrollContainer>

--- a/Content.Client/Materials/UI/MaterialStorageControl.xaml.cs
+++ b/Content.Client/Materials/UI/MaterialStorageControl.xaml.cs
@@ -15,6 +15,8 @@ namespace Content.Client.Materials.UI;
 [GenerateTypedNameReferences]
 public sealed partial class MaterialStorageControl : ScrollContainer
 {
+    public event Action<bool>? OnEnableSiloPressed; // L5 - ore processor silo support
+
     [Dependency] private readonly IEntityManager _entityManager = default!;
     private readonly MaterialStorageSystem _materialStorage;
 
@@ -28,6 +30,9 @@ public sealed partial class MaterialStorageControl : ScrollContainer
         IoCManager.InjectDependencies(this);
 
         _materialStorage = _entityManager.System<MaterialStorageSystem>();
+
+        // L5 - ore processor silo support
+        SiloEnableCheckbox.OnPressed += args => OnEnableSiloPressed?.Invoke(args.Button.Pressed);
     }
 
     public void SetOwner(EntityUid owner)
@@ -94,6 +99,12 @@ public sealed partial class MaterialStorageControl : ScrollContainer
 
         _currentMaterials = mats;
         NoMatsLabel.Visible = MaterialList.ChildCount == 1;
-        SiloLinkedLabel.Visible = _entityManager.TryGetComponent<OreSiloClientComponent>(_owner.Value, out var client) && client.Silo != null;
+        // Begin L5 changes - ore processor silo support
+        var siloLinked = _entityManager.TryGetComponent<OreSiloClientComponent>(_owner.Value, out var client)
+                              && client.Silo != null;
+        SiloLinkedBox.Visible = siloLinked;
+        SiloEnableCheckbox.Visible = siloLinked && client!.Source;
+        SiloEnableCheckbox.Pressed = siloLinked && client!.Enabled;
+        // End L5 changes
     }
 }

--- a/Content.Server/Lathe/LatheSystem.cs
+++ b/Content.Server/Lathe/LatheSystem.cs
@@ -24,6 +24,7 @@ using Content.Shared.Lathe;
 using Content.Shared.Lathe.Prototypes;
 using Content.Shared.Localizations;
 using Content.Shared.Materials;
+using Content.Shared.Materials.OreSilo;
 using Content.Shared.Power;
 using Content.Shared.ReagentSpeed;
 using Content.Shared.Research.Components;
@@ -225,7 +226,12 @@ namespace Content.Server.Lathe
             if (!Resolve(uid, ref comp, ref prodComp, false))
                 return;
 
-            if (comp.CurrentRecipe != null)
+            // Begin L5 - ore processor silo support
+            var finishEv = new LatheFinishPrintingEvent((uid, comp), false);
+            RaiseLocalEvent(uid, ref finishEv);
+
+            if (comp.CurrentRecipe != null && !finishEv.Handled)
+            // End L5
             {
                 if (comp.CurrentRecipe.Result is { } resultProto)
                 {

--- a/Content.Shared/Materials/OreSilo/SharedOreSiloSystem.cs
+++ b/Content.Shared/Materials/OreSilo/SharedOreSiloSystem.cs
@@ -1,10 +1,11 @@
+using Content.Shared.Lathe;
 using Content.Shared.Power.EntitySystems;
 using JetBrains.Annotations;
 using Robust.Shared.Utility;
 
 namespace Content.Shared.Materials.OreSilo;
 
-public abstract class SharedOreSiloSystem : EntitySystem
+public abstract partial class SharedOreSiloSystem : EntitySystem // L5 - made partial
 {
     [Dependency] private readonly SharedMaterialStorageSystem _materialStorage = default!;
     [Dependency] private readonly SharedPowerReceiverSystem _powerReceiver = default!;
@@ -23,10 +24,14 @@ public abstract class SharedOreSiloSystem : EntitySystem
             subs.Event<BoundUIOpenedEvent>(OnBoundUIOpened);
         });
 
+        // L5
+        Subs.BuiEvents<OreSiloClientComponent>(LatheUiKey.Key,
+            subs => subs.Event<EnableSiloButtonPressed>(OnSiloButtonPressed));
 
         SubscribeLocalEvent<OreSiloClientComponent, GetStoredMaterialsEvent>(OnGetStoredMaterials);
         SubscribeLocalEvent<OreSiloClientComponent, ConsumeStoredMaterialsEvent>(OnConsumeStoredMaterials);
         SubscribeLocalEvent<OreSiloClientComponent, ComponentShutdown>(OnClientShutdown);
+        SubscribeLocalEvent<OreSiloClientComponent, LatheFinishPrintingEvent>(OnLatheFinishPrinting); // L5
 
         _clientQuery = GetEntityQuery<OreSiloClientComponent>();
     }
@@ -52,14 +57,18 @@ public abstract class SharedOreSiloSystem : EntitySystem
             if (!CanTransmitMaterials((ent, ent), client))
                 return;
 
-            var clientMats = _materialStorage.GetStoredMaterials(client, true);
-            var inverseMats = new Dictionary<string, int>();
-            foreach (var (mat, amount) in clientMats)
+            // L5 - ore processor silo support; add if source
+            if (!clientComp.Source)
             {
-                inverseMats.Add(mat, -amount);
+                var clientMats = _materialStorage.GetStoredMaterials(client, true);
+                var inverseMats = new Dictionary<string, int>();
+                foreach (var (mat, amount) in clientMats)
+                {
+                    inverseMats.Add(mat, -amount);
+                }
+                _materialStorage.TryChangeMaterialAmount(client, inverseMats, localOnly: true);
+                _materialStorage.TryChangeMaterialAmount(ent.Owner, clientMats);
             }
-            _materialStorage.TryChangeMaterialAmount(client, inverseMats, localOnly: true);
-            _materialStorage.TryChangeMaterialAmount(ent.Owner, clientMats);
 
             ent.Comp.Clients.Add(client);
             Dirty(ent);
@@ -97,6 +106,10 @@ public abstract class SharedOreSiloSystem : EntitySystem
         if (args.LocalOnly)
             return;
 
+        // L5
+        if (ent.Comp.Source)
+            return;
+
         if (ent.Comp.Silo is not { } silo)
             return;
 
@@ -119,6 +132,10 @@ public abstract class SharedOreSiloSystem : EntitySystem
     private void OnConsumeStoredMaterials(Entity<OreSiloClientComponent> ent, ref ConsumeStoredMaterialsEvent args)
     {
         if (args.LocalOnly)
+            return;
+
+        // L5
+        if (ent.Comp.Source)
             return;
 
         if (ent.Comp.Silo is not { } silo || !TryComp<MaterialStorageComponent>(silo, out var materialStorage))

--- a/Content.Shared/_L5/Materials/OreSilo/OreSiloClientComponent.cs
+++ b/Content.Shared/_L5/Materials/OreSilo/OreSiloClientComponent.cs
@@ -1,0 +1,17 @@
+namespace Content.Shared.Materials.OreSilo;
+
+public sealed partial class OreSiloClientComponent
+{
+    /// <summary>
+    /// Whether this is a silo that only pushes materials (ore processor)
+    /// </summary>
+    [DataField]
+    public bool Source;
+
+    /// <summary>
+    /// If this is a <see cref="Source"/>, this temporarily disables its
+    /// material pushing.
+    /// </summary>
+    [DataField, AutoNetworkedField]
+    public bool Enabled = true;
+}

--- a/Content.Shared/_L5/Materials/OreSilo/SharedOreSiloSystem.cs
+++ b/Content.Shared/_L5/Materials/OreSilo/SharedOreSiloSystem.cs
@@ -1,0 +1,53 @@
+using Content.Shared.Lathe;
+using Robust.Shared.Prototypes;
+using Robust.Shared.Serialization;
+
+namespace Content.Shared.Materials.OreSilo;
+
+public abstract partial class SharedOreSiloSystem
+{
+    [Dependency] private readonly IComponentFactory _factory = default!;
+    [Dependency] private readonly IPrototypeManager _prototype = default!;
+
+    private void OnLatheFinishPrinting(Entity<OreSiloClientComponent> ent, ref LatheFinishPrintingEvent args)
+    {
+        if (args.Handled)
+            return;
+
+        if (!TryComp<OreSiloClientComponent>(ent, out var client)
+            || !client.Enabled)
+            return;
+
+        if (client.Silo is not { } silo
+            || !TryComp<MaterialStorageComponent>(silo, out var siloStorage))
+            return;
+
+        if (!CanTransmitMaterials(silo, ent))
+            return;
+
+        var latheComp = args.Lathe.Comp;
+        if (latheComp.CurrentRecipe is { Result: { } resultProtoId }
+            && _prototype.TryIndex(resultProtoId, out var resultProto)
+            && resultProto.TryGetComponent<PhysicalCompositionComponent>(out var composition, _factory))
+        {
+            args.Handled = _materialStorage.TryChangeMaterialAmount((silo, siloStorage), composition.MaterialComposition);
+        }
+    }
+
+    private void OnSiloButtonPressed(Entity<OreSiloClientComponent> ent, ref EnableSiloButtonPressed args)
+    {
+        if (!ent.Comp.Source)
+            return;
+        ent.Comp.Enabled = !ent.Comp.Enabled;
+        Dirty(ent);
+    }
+}
+
+[ByRefEvent]
+public record struct LatheFinishPrintingEvent(Entity<LatheComponent> Lathe, bool Handled);
+
+[Serializable, NetSerializable]
+public sealed class EnableSiloButtonPressed(bool enabled) : BoundUserInterfaceMessage
+{
+    public bool Enabled { get; } = enabled;
+}

--- a/Resources/Locale/en-US/_L5/lathe/ui/lathe-menu.ftl
+++ b/Resources/Locale/en-US/_L5/lathe/ui/lathe-menu.ftl
@@ -1,0 +1,1 @@
+lathe-menu-silo-enabled = Enable

--- a/Resources/Prototypes/Entities/Structures/Machines/lathe.yml
+++ b/Resources/Prototypes/Entities/Structures/Machines/lathe.yml
@@ -682,6 +682,8 @@
     - type: MiningPointsLathe # DeltaV
     - type: PlaceableSurface # DeltaV - Allow ore bags to dump into it directly
       isPlaceable: false # but not place on it if you just click it with a random item
+    - type: OreSiloClient # L5 - ore silo support
+      source: true
 
 - type: entity
   parent: OreProcessor


### PR DESCRIPTION
<!-- If you are new to the Delta-V repository, please read the [Contributing Guidelines](https://github.com/DeltaV-Station/Delta-v/blob/master/CONTRIBUTING.md) -->

## About the PR
<!-- What did you change? -->
Makes ore processor able to link to ore silos and then print to them. Also it's toggleable.

## Why / Balance
<!-- Discuss how this would affect game balance or explain why it was changed. Link any relevant discussions or issues. -->
RSI gaming.

## Technical details
<!-- Summary of code changes for easier review. -->

Not 100% sure on the "Enable" label. Thoughts?

## Media
<!-- Attach media if the PR makes ingame changes (clothing, items, features, etc).
Small fixes/refactors are exempt. -->

https://github.com/user-attachments/assets/f3150d7c-27a3-46e1-a52e-7c3f42f84eaa


## Requirements
<!-- Confirm the following by placing an X in the brackets [X]: -->
- [X] I have tested all added content and changes.
- [X] I have added media to this PR or it does not require an ingame showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->

## Breaking changes
<!-- List any breaking changes, including namespaces, public class/method/field changes, prototype renames; and provide instructions for fixing them. -->

**Changelog**
<!-- Add a Changelog entry to make players aware of new features or changes that could affect gameplay.
Make sure to read the guidelines and take this Changelog template out of the comment block in order for it to show up.
Changelogs must have a :cl: symbol, so the bot recognizes the changes and adds them to the game's changelog. -->
<!--
:cl:
- add: Added fun!
- remove: Removed fun!
- tweak: Changed fun!
- fix: Fixed fun!
-->
:cl:
- add: You can now link material silos to ore processors, allowing you to skip the step of inserting printed materials.