### PR TITLE
fix: make N14 tree hitboxes make sense

### DIFF
--- a/Resources/Prototypes/_Nuclear14/Entities/Structures/Misc/floradesert.yml
+++ b/Resources/Prototypes/_Nuclear14/Entities/Structures/Misc/floradesert.yml
@@ -7,13 +7,13 @@
   - type: Sprite
     sprite: _Nuclear14/Structures/Misc/floradesert.rsi
     state: cactus
-    offset: 0,0
+    offset: 0.5,0.6 # L5
   - type: Fixtures
     fixtures:
       fix1:
         shape:
           !type:PhysShapeAabb
-            bounds: "-0.7,-0.3,-0.4,-1.2"
+            bounds: "-0.15,-0.2,0.15,0.2" # L5
         density: 1000
         layer:
         - WallLayer
@@ -26,12 +26,13 @@
   components:
   - type: Sprite
     state: joshua_1
+    offset: 0,0.6 # L5
   - type: Fixtures
     fixtures:
       fix1:
         shape:
           !type:PhysShapeAabb
-            bounds: "0.3,-0.3,-0.2,-1.2"
+            bounds: "-0.15,-0.2,0.15,0.2" # L5
         density: 1000
         layer:
         - WallLayer
@@ -66,12 +67,13 @@
   - type: Sprite
     sprite: _Nuclear14/Structures/Misc/trees-ms.rsi
     state: bald
+    offset: 0,1.9 # L5
   - type: Fixtures
     fixtures:
       fix1:
         shape:
           !type:PhysShapeAabb
-            bounds: "0.2,-1.4,-0.2,-1.8"
+            bounds: "-0.15,-0.1,0.15,0.3" # L5
         density: 1000
         layer:
         - WallLayer


### PR DESCRIPTION
<!-- If you are new to the Delta-V repository, please read the [Contributing Guidelines](https://github.com/DeltaV-Station/Delta-v/blob/master/CONTRIBUTING.md) -->

## About the PR
<!-- What did you change? -->
Fixes N14 tree hitboxes and sprite offsets.

## Why / Balance
<!-- Discuss how this would affect game balance or explain why it was changed. Link any relevant discussions or issues. -->
Hitboxes aren't supposed to be like 3.5 tiles away from the part that you would run into. Seriously that's how far off some of these were.

## Technical details
<!-- Summary of code changes for easier review. -->

## Media
<!-- Attach media if the PR makes ingame changes (clothing, items, features, etc).
Small fixes/refactors are exempt. -->

Guess which is before and which is after.

![image](https://github.com/user-attachments/assets/a4aaf195-bc71-439b-b9a7-866854f9e2f8)

![image](https://github.com/user-attachments/assets/e6fb235d-a1d8-4d7d-aa7c-2799000fc227)


## Requirements
<!-- Confirm the following by placing an X in the brackets [X]: -->
- [X] I have tested all added content and changes.
- [X] I have added media to this PR or it does not require an ingame showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->

## Breaking changes
<!-- List any breaking changes, including namespaces, public class/method/field changes, prototype renames; and provide instructions for fixing them. -->

**Changelog**
<!-- Add a Changelog entry to make players aware of new features or changes that could affect gameplay.
Make sure to read the guidelines and take this Changelog template out of the comment block in order for it to show up.
Changelogs must have a :cl: symbol, so the bot recognizes the changes and adds them to the game's changelog. -->
<!--
:cl:
- add: Added fun!
- remove: Removed fun!
- tweak: Changed fun!
- fix: Fixed fun!
-->

nah