### PR TITLE
fix: don't let CPR audio loop forever

### DIFF
--- a/Content.Server/_EE/Medical/CPR/CPRSystem.cs
+++ b/Content.Server/_EE/Medical/CPR/CPRSystem.cs
@@ -41,9 +41,16 @@ public sealed class CPRSystem : EntitySystem
 
     private void AddCPRVerb(Entity<CPRTrainingComponent> performer, ref GetVerbsEvent<InnateVerb> args)
     {
-        // L5 - respect CVar
+        // Begin L5 additions
+        // Respect CVar
         if (!_configuration.GetCVar(CPRCCVars.EnableCPR))
             return;
+
+        // Track doafter being active
+        if (performer.Comp.DoAfter is not null)
+            return;
+        // End L5 additions
+
 
         if (!args.CanInteract || !args.CanAccess || !TryComp<MobStateComponent>(args.Target, out var targetState)
             || targetState.CurrentState == MobState.Alive)
@@ -63,6 +70,11 @@ public sealed class CPRSystem : EntitySystem
 
     private void StartCPR(Entity<CPRTrainingComponent> performer, EntityUid target)
     {
+        // Begin L5 additions - track doafter being active (should be unreachable)
+        if (performer.Comp.DoAfter is not null)
+            return;
+        // End L5 additions
+
         if (HasComp<RottingComponent>(target))
         {
             _popupSystem.PopupEntity(Loc.GetString("cpr-target-rotting", ("entity", target)), performer, performer);
@@ -90,7 +102,10 @@ public sealed class CPRSystem : EntitySystem
             BlockDuplicate = true
         };
 
-        _doAfterSystem.TryStartDoAfter(doAfterArgs);
+        // Begin L5 modifications - track doafter
+        _doAfterSystem.TryStartDoAfter(doAfterArgs, out var id);
+        performer.Comp.DoAfter = id;
+        // End L5 modifications
 
         var playingStream = _audio.PlayPvs(performer.Comp.CPRSound, performer, AudioParams.Default.WithLoop(true));
         if (!playingStream.HasValue)
@@ -104,6 +119,7 @@ public sealed class CPRSystem : EntitySystem
         if (args.Cancelled || args.Handled || !args.Target.HasValue)
         {
             performer.Comp.CPRPlayingStream = _audio.Stop(performer.Comp.CPRPlayingStream);
+            performer.Comp.DoAfter = null; // L5 - track doafter
             return;
         }
 
@@ -129,7 +145,13 @@ public sealed class CPRSystem : EntitySystem
 
         var isAlive = _mobStateSystem.IsAlive(args.Target.Value);
         args.Repeat = !isAlive;
+
+        // Begin L5 modifications - track doafter
         if (isAlive)
+        {
             performer.Comp.CPRPlayingStream = _audio.Stop(performer.Comp.CPRPlayingStream);
+            performer.Comp.DoAfter = null;
+        }
+        // End L5 modifications
     }
 }

--- a/Content.Server/_EE/Medical/CPR/CPRTrainingComponent.cs
+++ b/Content.Server/_EE/Medical/CPR/CPRTrainingComponent.cs
@@ -1,4 +1,5 @@
 using Content.Shared.Damage;
+using Content.Shared.DoAfter;
 using Robust.Shared.Audio;
 // ReSharper disable InconsistentNaming
 
@@ -12,6 +13,12 @@ public sealed partial class CPRTrainingComponent : Component
 
     [DataField]
     public TimeSpan DoAfterDuration = TimeSpan.FromSeconds(3);
+
+    /// <summary>
+    /// L5 - track doafter being active.
+    /// </summary>
+    [DataField]
+    public DoAfterId? DoAfter;
 
     public EntityUid? CPRPlayingStream;
 }


### PR DESCRIPTION
<!-- If you are new to the Delta-V repository, please read the [Contributing Guidelines](https://github.com/DeltaV-Station/Delta-v/blob/master/CONTRIBUTING.md) -->

## About the PR
<!-- What did you change? -->
Makes it so you can't start CPR via the verb if you're already CPRing.

## Why / Balance
<!-- Discuss how this would affect game balance or explain why it was changed. Link any relevant discussions or issues. -->
Fixes #403.

## Technical details
<!-- Summary of code changes for easier review. -->
Track the doafter being active and don't allow handling the stuff if it is.

## Media
<!-- Attach media if the PR makes ingame changes (clothing, items, features, etc).
Small fixes/refactors are exempt. -->

## Requirements
<!-- Confirm the following by placing an X in the brackets [X]: -->
- [X] I have tested all added content and changes.
- [X] I have added media to this PR or it does not require an ingame showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->

## Breaking changes
<!-- List any breaking changes, including namespaces, public class/method/field changes, prototype renames; and provide instructions for fixing them. -->

**Changelog**
<!-- Add a Changelog entry to make players aware of new features or changes that could affect gameplay.
Make sure to read the guidelines and take this Changelog template out of the comment block in order for it to show up.
Changelogs must have a :cl: symbol, so the bot recognizes the changes and adds them to the game's changelog. -->
<!--
:cl:
- add: Added fun!
- remove: Removed fun!
- tweak: Changed fun!
- fix: Fixed fun!
-->
:cl:
- fix: CPR audio will no loop if activated twice via the right-click menu.