### PR TITLE
fix: Missing whitelist component added to food fridge

### DIFF
--- a/Resources/Prototypes/_L5/Entities/Structures/Machines/foodfridge.yml
+++ b/Resources/Prototypes/_L5/Entities/Structures/Machines/foodfridge.yml
@@ -11,3 +11,4 @@
       - Food
       - Drink
       - Seed
+      - Produce

--- a/Resources/Prototypes/_L5/Entities/Structures/Machines/foodfridge.yml
+++ b/Resources/Prototypes/_L5/Entities/Structures/Machines/foodfridge.yml
@@ -12,3 +12,4 @@
       - Drink
       - Seed
       - Produce
+      - Edible


### PR DESCRIPTION
<!-- If you are new to the Delta-V repository, please read the [Contributing Guidelines](https://github.com/DeltaV-Station/Delta-v/blob/master/CONTRIBUTING.md) -->

## About the PR
<!-- What did you change? -->
I thought produce had the food component, missed this in testing.

## Why / Balance
<!-- Discuss how this would affect game balance or explain why it was changed. Link any relevant discussions or issues. -->

## Technical details
<!-- Summary of code changes for easier review. -->

## Media
<!-- Attach media if the PR makes ingame changes (clothing, items, features, etc).
Small fixes/refactors are exempt. -->

## Requirements
<!-- Confirm the following by placing an X in the brackets [X]: -->
- [X] I have tested all added content and changes.
- [X] I have added media to this PR or it does not require an ingame showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->

## Breaking changes
<!-- List any breaking changes, including namespaces, public class/method/field changes, prototype renames; and provide instructions for fixing them. -->

**Changelog**
<!-- Add a Changelog entry to make players aware of new features or changes that could affect gameplay.
Make sure to read the guidelines and take this Changelog template out of the comment block in order for it to show up.
Changelogs must have a :cl: symbol, so the bot recognizes the changes and adds them to the game's changelog. -->
<!--
:cl:
- add: Added fun!
- remove: Removed fun!
- tweak: Changed fun!
- fix: Fixed fun!
-->
:cl:
- fix: FoodMate fridges can now accept raw produce.