### PR TITLE
feat: add old style scale command back

### DIFF
--- a/Content.Server/_L5/Commands/ScaleCommand.cs
+++ b/Content.Server/_L5/Commands/ScaleCommand.cs
@@ -1,0 +1,64 @@
+using Content.Server.Administration;
+using Content.Shared.Administration;
+using Content.Shared.Sprite;
+using Robust.Shared.Console;
+using Robust.Shared.Physics;
+using Robust.Shared.Physics.Systems;
+
+namespace Content.Server._L5.Commands;
+
+[AdminCommand(AdminFlags.Fun)]
+public sealed class ScaleCommand : LocalizedEntityCommands
+{
+    [Dependency] private readonly SharedScaleVisualsSystem _scaleVis = default!;
+    [Dependency] private readonly SharedPhysicsSystem _physics = default!;
+
+    public override string Command => "scale";
+
+    public override void Execute(IConsoleShell shell, string argStr, string[] args)
+    {
+        if (args.Length != 2)
+        {
+            shell.WriteError(Loc.GetString("shell-wrong-arguments-number-need-specific",
+                ("properAmount", 2),
+                ("currentAmount", args.Length)));
+            return;
+        }
+
+        if (!NetEntity.TryParse(args[0], out var netEntity))
+        {
+            shell.WriteError(Loc.GetString("shell-invalid-entity-id"));
+            return;
+        }
+
+        if (!float.TryParse(args[1], out var scale))
+        {
+            shell.WriteError(Loc.GetString("shell-argument-must-be-number"));
+            return;
+        }
+
+        if (scale <= 0)
+        {
+            shell.WriteError(Loc.GetString("shell-argument-must-be-positive"));
+            return;
+        }
+
+        var ent = EntityManager.GetEntity(netEntity);
+        var scaleVec = _scaleVis.GetSpriteScale(ent) * scale;
+        _scaleVis.SetSpriteScale(ent, scaleVec);
+        if (!EntityManager.TryGetComponent<FixturesComponent>(ent, out var fix))
+            return;
+
+        _physics.ScaleFixtures((ent, fix), scale);
+    }
+
+    public override CompletionResult GetCompletion(IConsoleShell shell, string[] args)
+    {
+        return args.Length switch
+        {
+            1 => CompletionResult.FromOptions(CompletionHelper.NetEntities(args[0], EntityManager)),
+            2 => CompletionResult.FromHint(Loc.GetString("cmd-hint-float")),
+            _ => CompletionResult.Empty,
+        };
+    }
+}

--- a/Resources/Locale/en-US/_L5/shell.ftl
+++ b/Resources/Locale/en-US/_L5/shell.ftl
@@ -1,0 +1,4 @@
+shell-argument-must-be-positive = Argument must be positive
+
+cmd-scale-help = scale <entityUid> <float>
+cmd-scale-desc = Increases or decreases an entity's size and its fixtures.


### PR DESCRIPTION
<!-- If you are new to the Delta-V repository, please read the [Contributing Guidelines](https://github.com/DeltaV-Station/Delta-v/blob/master/CONTRIBUTING.md) -->

## About the PR
<!-- What did you change? -->
Adds back old style scale command.

## Why / Balance
<!-- Discuss how this would affect game balance or explain why it was changed. Link any relevant discussions or issues. -->
Fixes #442.

## Technical details
<!-- Summary of code changes for easier review. -->
There's a weird fixture mass mispredict going on but pretty sure it's an engine bug. Also I didn't test all the code paths because I'm lazy.

## Media
<!-- Attach media if the PR makes ingame changes (clothing, items, features, etc).
Small fixes/refactors are exempt. -->

## Requirements
<!-- Confirm the following by placing an X in the brackets [X]: -->
- [X] I have tested all added content and changes.
- [X] I have added media to this PR or it does not require an ingame showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->

## Breaking changes
<!-- List any breaking changes, including namespaces, public class/method/field changes, prototype renames; and provide instructions for fixing them. -->

**Changelog**
<!-- Add a Changelog entry to make players aware of new features or changes that could affect gameplay.
Make sure to read the guidelines and take this Changelog template out of the comment block in order for it to show up.
Changelogs must have a :cl: symbol, so the bot recognizes the changes and adds them to the game's changelog. -->
<!--
:cl:
- add: Added fun!
- remove: Removed fun!
- tweak: Changed fun!
- fix: Fixed fun!
-->
:cl:
- add: You can use `/scale` once again.
