### PR TITLE
Ensure Gemini's power suppliers are fully ramped at round start

### DIFF
--- a/Resources/Maps/_L5/Outposts/gemini.yml
+++ b/Resources/Maps/_L5/Outposts/gemini.yml
@@ -4,7 +4,7 @@ meta:
   engineVersion: 266.0.0
   forkId: ""
   forkVersion: ""
-  time: 08/22/2025 07:23:27
+  time: 08/23/2025 18:34:07
   entityCount: 6447
 maps:
 - 1
@@ -729,21 +729,21 @@ entities:
       parent: 2
     - type: DeviceList
       devices:
-      - 5294
-      - 5273
-      - 5292
-      - 5269
-      - 5267
-      - 5289
-      - 5290
-      - 5266
-      - 5291
-      - 5268
-      - 5288
-      - 5272
-      - 5270
-      - 5293
-      - 5271
+      - 5596
+      - 5575
+      - 5594
+      - 5571
+      - 5569
+      - 5591
+      - 5592
+      - 5568
+      - 5593
+      - 5570
+      - 5590
+      - 5574
+      - 5572
+      - 5595
+      - 5573
     - type: Fixtures
       fixtures: {}
   - uid: 4
@@ -754,34 +754,34 @@ entities:
       parent: 2
     - type: DeviceList
       devices:
-      - 5252
-      - 5274
-      - 5265
-      - 5275
-      - 5264
-      - 5276
-      - 5277
-      - 5262
-      - 5258
-      - 5278
-      - 5261
-      - 5279
-      - 5282
-      - 5260
-      - 5283
-      - 5263
-      - 5286
-      - 5253
-      - 5255
-      - 5284
-      - 5287
-      - 5254
-      - 5256
-      - 5285
-      - 5281
-      - 5257
-      - 5259
-      - 5280
+      - 5554
+      - 5576
+      - 5567
+      - 5577
+      - 5566
+      - 5578
+      - 5579
+      - 5564
+      - 5560
+      - 5580
+      - 5563
+      - 5581
+      - 5584
+      - 5562
+      - 5585
+      - 5565
+      - 5588
+      - 5555
+      - 5557
+      - 5586
+      - 5589
+      - 5556
+      - 5558
+      - 5587
+      - 5583
+      - 5559
+      - 5561
+      - 5582
     - type: Fixtures
       fixtures: {}
   - uid: 5
@@ -855,7 +855,7 @@ entities:
       pos: -29.5,-41.5
       parent: 2
     - type: Door
-      secondsUntilStateChange: -14622.555
+      secondsUntilStateChange: -14732.64
       state: Opening
     - type: DeviceLinkSource
       lastSignals:
@@ -941,7 +941,7 @@ entities:
         22:
         - - DoorStatus
           - DoorBolt
-        4742:
+        5044:
         - - DoorStatus
           - Input
   - uid: 25
@@ -960,7 +960,7 @@ entities:
         22:
         - - DoorStatus
           - DoorBolt
-        4740:
+        5042:
         - - DoorStatus
           - Input
   - uid: 26
@@ -979,7 +979,7 @@ entities:
         28:
         - - DoorStatus
           - DoorBolt
-        4741:
+        5043:
         - - DoorStatus
           - Input
   - uid: 27
@@ -1030,7 +1030,7 @@ entities:
         28:
         - - DoorStatus
           - DoorBolt
-        4743:
+        5045:
         - - DoorStatus
           - Input
 - proto: AirlockGlass
@@ -1153,6 +1153,8 @@ entities:
     - type: Transform
       pos: -86.5,-0.5
       parent: 2
+    - type: PowerNetworkBattery
+      supplyRampPosition: 10000
     - type: Fixtures
       fixtures: {}
   - uid: 48
@@ -1161,6 +1163,8 @@ entities:
       rot: -1.5707963267948966 rad
       pos: -35.5,-39.5
       parent: 2
+    - type: PowerNetworkBattery
+      supplyRampPosition: 10000
     - type: Fixtures
       fixtures: {}
   - uid: 49
@@ -1168,6 +1172,8 @@ entities:
     - type: Transform
       pos: -61.5,-1.5
       parent: 2
+    - type: PowerNetworkBattery
+      supplyRampPosition: 10000
     - type: Fixtures
       fixtures: {}
 - proto: AsteroidAltRock
@@ -13276,7396 +13282,7396 @@ entities:
     - type: Transform
       pos: -42.5,3.5
       parent: 2
-  - uid: 2469
+  - uid: 2468
     components:
     - type: Transform
       pos: -49.5,7.5
       parent: 2
-  - uid: 2470
+  - uid: 2469
     components:
     - type: Transform
       pos: -15.5,2.5
       parent: 2
-  - uid: 2471
+  - uid: 2470
     components:
     - type: Transform
       pos: -25.5,44.5
       parent: 2
-  - uid: 2472
+  - uid: 2471
     components:
     - type: Transform
       pos: 17.5,3.5
       parent: 2
-  - uid: 2473
+  - uid: 2472
     components:
     - type: Transform
       pos: 3.5,2.5
       parent: 2
-  - uid: 2474
+  - uid: 2473
     components:
     - type: Transform
       pos: -2.5,-6.5
       parent: 2
-  - uid: 2475
+  - uid: 2474
     components:
     - type: Transform
       pos: -50.5,4.5
       parent: 2
-  - uid: 2476
+  - uid: 2475
     components:
     - type: Transform
       pos: -45.5,36.5
       parent: 2
-  - uid: 2477
+  - uid: 2476
     components:
     - type: Transform
       pos: -40.5,-11.5
       parent: 2
-  - uid: 2478
+  - uid: 2477
     components:
     - type: Transform
       pos: 7.5,3.5
       parent: 2
-  - uid: 2479
+  - uid: 2478
     components:
     - type: Transform
       pos: -61.5,-13.5
       parent: 2
-  - uid: 2480
+  - uid: 2479
     components:
     - type: Transform
       pos: -71.5,-8.5
       parent: 2
-  - uid: 2481
+  - uid: 2480
     components:
     - type: Transform
       pos: 10.5,13.5
       parent: 2
-  - uid: 2482
+  - uid: 2481
     components:
     - type: Transform
       pos: -27.5,-5.5
       parent: 2
-  - uid: 2483
+  - uid: 2482
     components:
     - type: Transform
       pos: -4.5,44.5
       parent: 2
-  - uid: 2484
+  - uid: 2483
     components:
     - type: Transform
       pos: 3.5,20.5
       parent: 2
-  - uid: 2485
+  - uid: 2484
     components:
     - type: Transform
       pos: -34.5,-13.5
       parent: 2
-  - uid: 2486
+  - uid: 2485
     components:
     - type: Transform
       pos: -66.5,3.5
       parent: 2
-  - uid: 2487
+  - uid: 2486
     components:
     - type: Transform
       pos: -43.5,28.5
       parent: 2
-  - uid: 2488
+  - uid: 2487
     components:
     - type: Transform
       pos: -69.5,2.5
       parent: 2
-  - uid: 2489
+  - uid: 2488
     components:
     - type: Transform
       pos: -30.5,-6.5
       parent: 2
-  - uid: 2490
+  - uid: 2489
     components:
     - type: Transform
       pos: -52.5,0.5
       parent: 2
-  - uid: 2491
+  - uid: 2490
     components:
     - type: Transform
       pos: 2.5,16.5
       parent: 2
-  - uid: 2492
+  - uid: 2491
     components:
     - type: Transform
       pos: -36.5,-10.5
       parent: 2
-  - uid: 2493
+  - uid: 2492
     components:
     - type: Transform
       pos: 1.5,36.5
       parent: 2
-  - uid: 2494
+  - uid: 2493
     components:
     - type: Transform
       pos: -66.5,-11.5
       parent: 2
-  - uid: 2495
+  - uid: 2494
     components:
     - type: Transform
       pos: -41.5,-30.5
       parent: 2
-  - uid: 2496
+  - uid: 2495
     components:
     - type: Transform
       pos: 3.5,45.5
       parent: 2
-  - uid: 2497
+  - uid: 2496
     components:
     - type: Transform
       pos: -65.5,-13.5
       parent: 2
-  - uid: 2498
+  - uid: 2497
     components:
     - type: Transform
       pos: -51.5,-12.5
       parent: 2
-  - uid: 2499
+  - uid: 2498
     components:
     - type: Transform
       pos: -42.5,31.5
       parent: 2
-  - uid: 2500
+  - uid: 2499
     components:
     - type: Transform
       pos: -65.5,0.5
       parent: 2
-  - uid: 2501
+  - uid: 2500
     components:
     - type: Transform
       pos: -9.5,44.5
       parent: 2
-  - uid: 2502
+  - uid: 2501
     components:
     - type: Transform
       pos: -40.5,-5.5
       parent: 2
-  - uid: 2503
+  - uid: 2502
     components:
     - type: Transform
       pos: -36.5,-33.5
       parent: 2
-  - uid: 2504
+  - uid: 2503
     components:
     - type: Transform
       pos: -10.5,45.5
       parent: 2
-  - uid: 2505
+  - uid: 2504
     components:
     - type: Transform
       pos: -50.5,-19.5
       parent: 2
-  - uid: 2506
+  - uid: 2505
     components:
     - type: Transform
       pos: -62.5,2.5
       parent: 2
-  - uid: 2507
+  - uid: 2506
     components:
     - type: Transform
       pos: 10.5,12.5
       parent: 2
-  - uid: 2508
+  - uid: 2507
     components:
     - type: Transform
       pos: -14.5,4.5
       parent: 2
-  - uid: 2509
+  - uid: 2508
     components:
     - type: Transform
       pos: -2.5,17.5
       parent: 2
-  - uid: 2510
+  - uid: 2509
     components:
     - type: Transform
       pos: -30.5,-4.5
       parent: 2
-  - uid: 2512
+  - uid: 2510
     components:
     - type: Transform
       pos: -28.5,0.5
       parent: 2
-  - uid: 2513
+  - uid: 2511
     components:
     - type: Transform
       pos: -40.5,-30.5
       parent: 2
-  - uid: 2514
+  - uid: 2512
     components:
     - type: Transform
       pos: -30.5,-14.5
       parent: 2
-  - uid: 2515
+  - uid: 2513
     components:
     - type: Transform
       pos: -66.5,-16.5
       parent: 2
-  - uid: 2516
+  - uid: 2514
     components:
     - type: Transform
       pos: -42.5,38.5
       parent: 2
-  - uid: 2517
+  - uid: 2515
     components:
     - type: Transform
       pos: -22.5,-17.5
       parent: 2
-  - uid: 2518
+  - uid: 2516
     components:
     - type: Transform
       pos: -43.5,32.5
       parent: 2
-  - uid: 2519
+  - uid: 2517
     components:
     - type: Transform
       pos: -54.5,-16.5
       parent: 2
-  - uid: 2520
+  - uid: 2518
     components:
     - type: Transform
       pos: -51.5,-23.5
       parent: 2
-  - uid: 2521
+  - uid: 2519
     components:
     - type: Transform
       pos: -54.5,11.5
       parent: 2
-  - uid: 2522
+  - uid: 2520
     components:
     - type: Transform
       pos: -62.5,-0.5
       parent: 2
-  - uid: 2523
+  - uid: 2521
     components:
     - type: Transform
       pos: -21.5,-19.5
       parent: 2
-  - uid: 2524
+  - uid: 2522
     components:
     - type: Transform
       pos: -58.5,-19.5
       parent: 2
-  - uid: 2525
+  - uid: 2523
     components:
     - type: Transform
       pos: -35.5,24.5
       parent: 2
-  - uid: 2527
+  - uid: 2524
     components:
     - type: Transform
       pos: -6.5,44.5
       parent: 2
-  - uid: 2529
+  - uid: 2525
     components:
     - type: Transform
       pos: -4.5,-6.5
       parent: 2
-  - uid: 2530
+  - uid: 2526
     components:
     - type: Transform
       pos: -42.5,-27.5
       parent: 2
-  - uid: 2531
+  - uid: 2527
     components:
     - type: Transform
       pos: -6.5,4.5
       parent: 2
-  - uid: 2532
+  - uid: 2528
     components:
     - type: Transform
       pos: -12.5,4.5
       parent: 2
-  - uid: 2533
+  - uid: 2529
     components:
     - type: Transform
       pos: -6.5,11.5
       parent: 2
-  - uid: 2534
+  - uid: 2530
     components:
     - type: Transform
       pos: 2.5,20.5
       parent: 2
-  - uid: 2536
+  - uid: 2531
     components:
     - type: Transform
       pos: -4.5,-9.5
       parent: 2
-  - uid: 2538
+  - uid: 2532
     components:
     - type: Transform
       pos: 0.5,-14.5
       parent: 2
-  - uid: 2539
+  - uid: 2533
     components:
     - type: Transform
       pos: 6.5,45.5
       parent: 2
-  - uid: 2540
+  - uid: 2534
     components:
     - type: Transform
       pos: -6.5,-6.5
       parent: 2
-  - uid: 2541
+  - uid: 2535
     components:
     - type: Transform
       pos: -2.5,-11.5
       parent: 2
-  - uid: 2542
+  - uid: 2536
     components:
     - type: Transform
       pos: -3.5,-10.5
       parent: 2
-  - uid: 2543
+  - uid: 2537
     components:
     - type: Transform
       pos: -66.5,-10.5
       parent: 2
-  - uid: 2544
+  - uid: 2538
     components:
     - type: Transform
       pos: -37.5,5.5
       parent: 2
-  - uid: 2545
+  - uid: 2539
     components:
     - type: Transform
       pos: -6.5,-9.5
       parent: 2
-  - uid: 2546
+  - uid: 2540
     components:
     - type: Transform
       pos: -23.5,37.5
       parent: 2
-  - uid: 2547
+  - uid: 2541
     components:
     - type: Transform
       pos: -8.5,-7.5
       parent: 2
-  - uid: 2549
+  - uid: 2542
     components:
     - type: Transform
       pos: -14.5,6.5
       parent: 2
-  - uid: 2550
+  - uid: 2543
     components:
     - type: Transform
       pos: 6.5,-5.5
       parent: 2
-  - uid: 2551
+  - uid: 2544
     components:
     - type: Transform
       pos: -37.5,-7.5
       parent: 2
-  - uid: 2552
+  - uid: 2545
     components:
     - type: Transform
       pos: -5.5,-6.5
       parent: 2
-  - uid: 2553
+  - uid: 2546
     components:
     - type: Transform
       pos: -47.5,3.5
       parent: 2
-  - uid: 2555
+  - uid: 2547
     components:
     - type: Transform
       pos: -24.5,32.5
       parent: 2
-  - uid: 2556
+  - uid: 2548
     components:
     - type: Transform
       pos: -9.5,5.5
       parent: 2
-  - uid: 2558
+  - uid: 2549
     components:
     - type: Transform
       pos: -7.5,-7.5
       parent: 2
-  - uid: 2559
+  - uid: 2550
     components:
     - type: Transform
       pos: -48.5,32.5
       parent: 2
-  - uid: 2560
+  - uid: 2551
     components:
     - type: Transform
       pos: 0.5,18.5
       parent: 2
-  - uid: 2561
+  - uid: 2552
     components:
     - type: Transform
       pos: 2.5,4.5
       parent: 2
-  - uid: 2562
+  - uid: 2553
     components:
     - type: Transform
       pos: -4.5,-7.5
       parent: 2
-  - uid: 2563
+  - uid: 2554
     components:
     - type: Transform
       pos: -3.5,-13.5
       parent: 2
-  - uid: 2564
+  - uid: 2555
     components:
     - type: Transform
       pos: -33.5,-24.5
       parent: 2
-  - uid: 2565
+  - uid: 2556
     components:
     - type: Transform
       pos: -18.5,34.5
       parent: 2
-  - uid: 2566
+  - uid: 2557
     components:
     - type: Transform
       pos: -61.5,8.5
       parent: 2
-  - uid: 2567
+  - uid: 2558
     components:
     - type: Transform
       pos: -71.5,-11.5
       parent: 2
-  - uid: 2568
+  - uid: 2559
     components:
     - type: Transform
       pos: 13.5,-2.5
       parent: 2
-  - uid: 2569
+  - uid: 2560
     components:
     - type: Transform
       pos: -32.5,-13.5
       parent: 2
-  - uid: 2570
+  - uid: 2561
     components:
     - type: Transform
       pos: 2.5,8.5
       parent: 2
-  - uid: 2571
+  - uid: 2562
     components:
     - type: Transform
       pos: 8.5,-10.5
       parent: 2
-  - uid: 2572
+  - uid: 2563
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: -50.5,-14.5
       parent: 2
-  - uid: 2573
+  - uid: 2564
     components:
     - type: Transform
       pos: -64.5,-14.5
       parent: 2
-  - uid: 2574
+  - uid: 2565
     components:
     - type: Transform
       pos: 6.5,-7.5
       parent: 2
-  - uid: 2575
+  - uid: 2566
     components:
     - type: Transform
       pos: -51.5,3.5
       parent: 2
-  - uid: 2576
+  - uid: 2567
     components:
     - type: Transform
       pos: -43.5,-6.5
       parent: 2
-  - uid: 2577
+  - uid: 2568
     components:
     - type: Transform
       pos: -58.5,-14.5
       parent: 2
-  - uid: 2578
+  - uid: 2569
     components:
     - type: Transform
       pos: -27.5,-20.5
       parent: 2
-  - uid: 2579
+  - uid: 2570
     components:
     - type: Transform
       pos: -26.5,-30.5
       parent: 2
-  - uid: 2580
+  - uid: 2571
     components:
     - type: Transform
       pos: -70.5,-14.5
       parent: 2
-  - uid: 2581
+  - uid: 2572
     components:
     - type: Transform
       pos: -46.5,11.5
       parent: 2
-  - uid: 2582
+  - uid: 2573
     components:
     - type: Transform
       pos: 3.5,48.5
       parent: 2
-  - uid: 2583
+  - uid: 2574
     components:
     - type: Transform
       pos: -60.5,3.5
       parent: 2
-  - uid: 2584
+  - uid: 2575
     components:
     - type: Transform
       pos: -55.5,4.5
       parent: 2
-  - uid: 2586
+  - uid: 2576
     components:
     - type: Transform
       pos: 4.5,-6.5
       parent: 2
-  - uid: 2587
+  - uid: 2577
     components:
     - type: Transform
       pos: -51.5,-0.5
       parent: 2
-  - uid: 2588
+  - uid: 2578
     components:
     - type: Transform
       pos: 0.5,-16.5
       parent: 2
-  - uid: 2589
+  - uid: 2579
     components:
     - type: Transform
       pos: -45.5,-6.5
       parent: 2
-  - uid: 2591
+  - uid: 2580
     components:
     - type: Transform
       pos: 7.5,2.5
       parent: 2
-  - uid: 2592
+  - uid: 2581
     components:
     - type: Transform
       pos: 2.5,-11.5
       parent: 2
-  - uid: 2593
+  - uid: 2582
     components:
     - type: Transform
       pos: -28.5,29.5
       parent: 2
-  - uid: 2594
+  - uid: 2583
     components:
     - type: Transform
       pos: -27.5,-11.5
       parent: 2
-  - uid: 2595
+  - uid: 2584
     components:
     - type: Transform
       pos: -50.5,-0.5
       parent: 2
-  - uid: 2597
+  - uid: 2585
     components:
     - type: Transform
       pos: -35.5,-28.5
       parent: 2
-  - uid: 2598
+  - uid: 2586
     components:
     - type: Transform
       pos: -25.5,-18.5
       parent: 2
-  - uid: 2599
+  - uid: 2587
     components:
     - type: Transform
       pos: 13.5,13.5
       parent: 2
-  - uid: 2600
+  - uid: 2588
     components:
     - type: Transform
       pos: -53.5,3.5
       parent: 2
-  - uid: 2601
+  - uid: 2589
     components:
     - type: Transform
       pos: -41.5,33.5
       parent: 2
-  - uid: 2602
+  - uid: 2590
     components:
     - type: Transform
       pos: -29.5,39.5
       parent: 2
-  - uid: 2603
+  - uid: 2591
     components:
     - type: Transform
       pos: -7.5,43.5
       parent: 2
-  - uid: 2604
+  - uid: 2592
     components:
     - type: Transform
       pos: -10.5,2.5
       parent: 2
-  - uid: 2605
+  - uid: 2593
     components:
     - type: Transform
       pos: -22.5,-22.5
       parent: 2
-  - uid: 2606
+  - uid: 2594
     components:
     - type: Transform
       pos: -40.5,3.5
       parent: 2
-  - uid: 2607
+  - uid: 2595
     components:
     - type: Transform
       pos: -42.5,-24.5
       parent: 2
-  - uid: 2608
+  - uid: 2596
     components:
     - type: Transform
       pos: -28.5,-4.5
       parent: 2
-  - uid: 2609
+  - uid: 2597
     components:
     - type: Transform
       pos: -40.5,-9.5
       parent: 2
-  - uid: 2610
+  - uid: 2598
     components:
     - type: Transform
       pos: -28.5,-16.5
       parent: 2
-  - uid: 2611
+  - uid: 2599
     components:
     - type: Transform
       pos: -10.5,43.5
       parent: 2
-  - uid: 2612
+  - uid: 2600
     components:
     - type: Transform
       pos: -6.5,-1.5
       parent: 2
-  - uid: 2613
+  - uid: 2601
     components:
     - type: Transform
       pos: -20.5,32.5
       parent: 2
-  - uid: 2614
+  - uid: 2602
     components:
     - type: Transform
       pos: -33.5,-6.5
       parent: 2
-  - uid: 2615
+  - uid: 2603
     components:
     - type: Transform
       pos: -48.5,-0.5
       parent: 2
-  - uid: 2616
+  - uid: 2604
     components:
     - type: Transform
       pos: -42.5,-29.5
       parent: 2
-  - uid: 2617
+  - uid: 2605
     components:
     - type: Transform
       pos: -41.5,-32.5
       parent: 2
-  - uid: 2618
+  - uid: 2606
     components:
     - type: Transform
       pos: -7.5,-8.5
       parent: 2
-  - uid: 2619
+  - uid: 2607
     components:
     - type: Transform
       pos: -25.5,25.5
       parent: 2
-  - uid: 2620
+  - uid: 2608
     components:
     - type: Transform
       pos: -40.5,33.5
       parent: 2
-  - uid: 2621
+  - uid: 2609
     components:
     - type: Transform
       pos: -35.5,44.5
       parent: 2
-  - uid: 2622
+  - uid: 2610
     components:
     - type: Transform
       pos: -13.5,11.5
       parent: 2
-  - uid: 2623
+  - uid: 2611
     components:
     - type: Transform
       pos: -37.5,6.5
       parent: 2
-  - uid: 2625
+  - uid: 2612
     components:
     - type: Transform
       pos: 8.5,14.5
       parent: 2
-  - uid: 2626
+  - uid: 2613
     components:
     - type: Transform
       pos: -4.5,-11.5
       parent: 2
-  - uid: 2627
+  - uid: 2614
     components:
     - type: Transform
       pos: -22.5,38.5
       parent: 2
-  - uid: 2628
+  - uid: 2615
     components:
     - type: Transform
       pos: -55.5,-24.5
       parent: 2
-  - uid: 2629
+  - uid: 2616
     components:
     - type: Transform
       pos: 15.5,12.5
       parent: 2
-  - uid: 2630
+  - uid: 2617
     components:
     - type: Transform
       pos: 14.5,-6.5
       parent: 2
-  - uid: 2631
+  - uid: 2618
     components:
     - type: Transform
       pos: -43.5,38.5
       parent: 2
-  - uid: 2632
+  - uid: 2619
     components:
     - type: Transform
       pos: -36.5,46.5
       parent: 2
-  - uid: 2633
+  - uid: 2620
     components:
     - type: Transform
       pos: 2.5,43.5
       parent: 2
-  - uid: 2634
+  - uid: 2621
     components:
     - type: Transform
       pos: -53.5,7.5
       parent: 2
-  - uid: 2635
+  - uid: 2622
     components:
     - type: Transform
       pos: -63.5,-10.5
       parent: 2
-  - uid: 2636
+  - uid: 2623
     components:
     - type: Transform
       pos: -66.5,5.5
       parent: 2
-  - uid: 2637
+  - uid: 2624
     components:
     - type: Transform
       pos: 5.5,8.5
       parent: 2
-  - uid: 2638
+  - uid: 2625
     components:
     - type: Transform
       pos: 3.5,18.5
       parent: 2
-  - uid: 2639
+  - uid: 2626
     components:
     - type: Transform
       pos: -37.5,-33.5
       parent: 2
-  - uid: 2641
+  - uid: 2627
     components:
     - type: Transform
       pos: -22.5,-13.5
       parent: 2
-  - uid: 2642
+  - uid: 2628
     components:
     - type: Transform
       pos: -24.5,-17.5
       parent: 2
-  - uid: 2643
+  - uid: 2629
     components:
     - type: Transform
       pos: -47.5,-5.5
       parent: 2
-  - uid: 2644
+  - uid: 2630
     components:
     - type: Transform
       pos: -22.5,-18.5
       parent: 2
-  - uid: 2645
+  - uid: 2631
     components:
     - type: Transform
       pos: -43.5,31.5
       parent: 2
-  - uid: 2646
+  - uid: 2632
     components:
     - type: Transform
       pos: -33.5,7.5
       parent: 2
-  - uid: 2647
+  - uid: 2633
     components:
     - type: Transform
       pos: -3.5,4.5
       parent: 2
-  - uid: 2648
+  - uid: 2634
     components:
     - type: Transform
       pos: -48.5,13.5
       parent: 2
-  - uid: 2649
+  - uid: 2635
     components:
     - type: Transform
       pos: -42.5,-18.5
       parent: 2
-  - uid: 2650
+  - uid: 2636
     components:
     - type: Transform
       pos: -2.5,-1.5
       parent: 2
-  - uid: 2651
+  - uid: 2637
     components:
     - type: Transform
       pos: -30.5,-15.5
       parent: 2
-  - uid: 2652
+  - uid: 2638
     components:
     - type: Transform
       pos: -43.5,-27.5
       parent: 2
-  - uid: 2653
+  - uid: 2639
     components:
     - type: Transform
       pos: 7.5,-8.5
       parent: 2
-  - uid: 2654
+  - uid: 2640
     components:
     - type: Transform
       pos: -41.5,3.5
       parent: 2
-  - uid: 2655
+  - uid: 2641
     components:
     - type: Transform
       pos: -54.5,14.5
       parent: 2
-  - uid: 2656
+  - uid: 2642
     components:
     - type: Transform
       pos: -62.5,6.5
       parent: 2
-  - uid: 2657
+  - uid: 2643
     components:
     - type: Transform
       pos: -41.5,39.5
       parent: 2
-  - uid: 2658
+  - uid: 2644
     components:
     - type: Transform
       pos: 12.5,-7.5
       parent: 2
-  - uid: 2659
+  - uid: 2645
     components:
     - type: Transform
       pos: 11.5,10.5
       parent: 2
-  - uid: 2660
+  - uid: 2646
     components:
     - type: Transform
       pos: 12.5,-8.5
       parent: 2
-  - uid: 2661
+  - uid: 2647
     components:
     - type: Transform
       pos: -35.5,-27.5
       parent: 2
-  - uid: 2662
+  - uid: 2648
     components:
     - type: Transform
       pos: -29.5,23.5
       parent: 2
-  - uid: 2663
+  - uid: 2649
     components:
     - type: Transform
       pos: 10.5,16.5
       parent: 2
-  - uid: 2664
+  - uid: 2650
     components:
     - type: Transform
       pos: 13.5,14.5
       parent: 2
-  - uid: 2665
+  - uid: 2651
     components:
     - type: Transform
       pos: -41.5,11.5
       parent: 2
-  - uid: 2666
+  - uid: 2652
     components:
     - type: Transform
       pos: -55.5,-29.5
       parent: 2
-  - uid: 2667
+  - uid: 2653
     components:
     - type: Transform
       pos: -60.5,6.5
       parent: 2
-  - uid: 2668
+  - uid: 2654
     components:
     - type: Transform
       pos: -1.5,-11.5
       parent: 2
-  - uid: 2669
+  - uid: 2655
     components:
     - type: Transform
       pos: -24.5,-25.5
       parent: 2
-  - uid: 2670
+  - uid: 2656
     components:
     - type: Transform
       pos: -46.5,-25.5
       parent: 2
-  - uid: 2671
+  - uid: 2657
     components:
     - type: Transform
       pos: 14.5,-4.5
       parent: 2
-  - uid: 2672
+  - uid: 2658
     components:
     - type: Transform
       pos: -19.5,-23.5
       parent: 2
-  - uid: 2673
+  - uid: 2659
     components:
     - type: Transform
       pos: -37.5,3.5
       parent: 2
-  - uid: 2674
+  - uid: 2660
     components:
     - type: Transform
       pos: -53.5,-14.5
       parent: 2
-  - uid: 2675
+  - uid: 2661
     components:
     - type: Transform
       pos: -48.5,31.5
       parent: 2
-  - uid: 2677
+  - uid: 2662
     components:
     - type: Transform
       pos: -57.5,2.5
       parent: 2
-  - uid: 2678
+  - uid: 2663
     components:
     - type: Transform
       pos: -64.5,-16.5
       parent: 2
-  - uid: 2679
+  - uid: 2664
     components:
     - type: Transform
       pos: -47.5,44.5
       parent: 2
-  - uid: 2680
+  - uid: 2665
     components:
     - type: Transform
       pos: -23.5,29.5
       parent: 2
-  - uid: 2681
+  - uid: 2666
     components:
     - type: Transform
       pos: -22.5,35.5
       parent: 2
-  - uid: 2682
+  - uid: 2667
     components:
     - type: Transform
       pos: -40.5,48.5
       parent: 2
-  - uid: 2683
+  - uid: 2668
     components:
     - type: Transform
       pos: -15.5,4.5
       parent: 2
-  - uid: 2684
+  - uid: 2669
     components:
     - type: Transform
       pos: -63.5,-19.5
       parent: 2
-  - uid: 2685
+  - uid: 2670
     components:
     - type: Transform
       pos: 17.5,8.5
       parent: 2
-  - uid: 2686
+  - uid: 2671
     components:
     - type: Transform
       pos: 1.5,-4.5
       parent: 2
-  - uid: 2688
+  - uid: 2672
     components:
     - type: Transform
       pos: -37.5,49.5
       parent: 2
-  - uid: 2689
+  - uid: 2673
     components:
     - type: Transform
       pos: -37.5,27.5
       parent: 2
-  - uid: 2690
+  - uid: 2674
     components:
     - type: Transform
       pos: -3.5,48.5
       parent: 2
-  - uid: 2691
+  - uid: 2675
     components:
     - type: Transform
       pos: -10.5,7.5
       parent: 2
-  - uid: 2692
+  - uid: 2676
     components:
     - type: Transform
       pos: -50.5,13.5
       parent: 2
-  - uid: 2693
+  - uid: 2677
     components:
     - type: Transform
       pos: -3.5,-12.5
       parent: 2
-  - uid: 2694
+  - uid: 2678
     components:
     - type: Transform
       pos: -43.5,8.5
       parent: 2
-  - uid: 2695
+  - uid: 2679
     components:
     - type: Transform
       pos: -49.5,33.5
       parent: 2
-  - uid: 2696
+  - uid: 2680
     components:
     - type: Transform
       pos: 11.5,-7.5
       parent: 2
-  - uid: 2697
+  - uid: 2681
     components:
     - type: Transform
       pos: -27.5,-12.5
       parent: 2
-  - uid: 2698
+  - uid: 2682
     components:
     - type: Transform
       pos: -70.5,-1.5
       parent: 2
-  - uid: 2700
+  - uid: 2683
     components:
     - type: Transform
       pos: -5.5,47.5
       parent: 2
-  - uid: 2701
+  - uid: 2684
     components:
     - type: Transform
       pos: -4.5,-12.5
       parent: 2
-  - uid: 2703
+  - uid: 2685
     components:
     - type: Transform
       pos: 1.5,8.5
       parent: 2
-  - uid: 2704
+  - uid: 2686
     components:
     - type: Transform
       pos: -54.5,-11.5
       parent: 2
-  - uid: 2705
+  - uid: 2687
     components:
     - type: Transform
       pos: 6.5,46.5
       parent: 2
-  - uid: 2706
+  - uid: 2688
     components:
     - type: Transform
       pos: -8.5,9.5
       parent: 2
-  - uid: 2708
+  - uid: 2689
     components:
     - type: Transform
       pos: -71.5,-9.5
       parent: 2
-  - uid: 2709
+  - uid: 2690
     components:
     - type: Transform
       pos: -8.5,11.5
       parent: 2
-  - uid: 2710
+  - uid: 2691
     components:
     - type: Transform
       pos: -52.5,-12.5
       parent: 2
-  - uid: 2712
+  - uid: 2692
     components:
     - type: Transform
       pos: -2.5,16.5
       parent: 2
-  - uid: 2713
+  - uid: 2693
     components:
     - type: Transform
       pos: -35.5,-8.5
       parent: 2
-  - uid: 2714
+  - uid: 2694
     components:
     - type: Transform
       pos: -21.5,37.5
       parent: 2
-  - uid: 2715
+  - uid: 2695
     components:
     - type: Transform
       pos: -58.5,-5.5
       parent: 2
-  - uid: 2717
+  - uid: 2696
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: -44.5,-14.5
       parent: 2
-  - uid: 2718
+  - uid: 2697
     components:
     - type: Transform
       pos: -21.5,26.5
       parent: 2
-  - uid: 2719
+  - uid: 2698
     components:
     - type: Transform
       pos: -37.5,-18.5
       parent: 2
-  - uid: 2720
+  - uid: 2699
     components:
     - type: Transform
       pos: -68.5,-12.5
       parent: 2
-  - uid: 2721
+  - uid: 2700
     components:
     - type: Transform
       pos: -44.5,25.5
       parent: 2
-  - uid: 2722
+  - uid: 2701
     components:
     - type: Transform
       pos: -31.5,4.5
       parent: 2
-  - uid: 2723
+  - uid: 2702
     components:
     - type: Transform
       pos: -63.5,-16.5
       parent: 2
-  - uid: 2724
+  - uid: 2703
     components:
     - type: Transform
       pos: -22.5,-12.5
       parent: 2
-  - uid: 2725
+  - uid: 2704
     components:
     - type: Transform
       pos: -57.5,-25.5
       parent: 2
-  - uid: 2726
+  - uid: 2705
     components:
     - type: Transform
       pos: -24.5,-8.5
       parent: 2
-  - uid: 2727
+  - uid: 2706
     components:
     - type: Transform
       pos: -36.5,-29.5
       parent: 2
-  - uid: 2728
+  - uid: 2707
     components:
     - type: Transform
       pos: -9.5,2.5
       parent: 2
-  - uid: 2729
+  - uid: 2708
     components:
     - type: Transform
       pos: -44.5,-15.5
       parent: 2
-  - uid: 2730
+  - uid: 2709
     components:
     - type: Transform
       pos: 1.5,7.5
       parent: 2
-  - uid: 2731
+  - uid: 2710
     components:
     - type: Transform
       pos: -48.5,41.5
       parent: 2
-  - uid: 2732
+  - uid: 2711
     components:
     - type: Transform
       pos: -33.5,-5.5
       parent: 2
-  - uid: 2733
+  - uid: 2712
     components:
     - type: Transform
       pos: -14.5,10.5
       parent: 2
-  - uid: 2734
+  - uid: 2713
     components:
     - type: Transform
       pos: -65.5,8.5
       parent: 2
-  - uid: 2735
+  - uid: 2714
     components:
     - type: Transform
       pos: -7.5,10.5
       parent: 2
-  - uid: 2736
+  - uid: 2715
     components:
     - type: Transform
       pos: -46.5,31.5
       parent: 2
-  - uid: 2737
+  - uid: 2716
     components:
     - type: Transform
       pos: -52.5,-14.5
       parent: 2
-  - uid: 2738
+  - uid: 2717
     components:
     - type: Transform
       pos: 2.5,-10.5
       parent: 2
-  - uid: 2739
+  - uid: 2718
     components:
     - type: Transform
       pos: -48.5,-11.5
       parent: 2
-  - uid: 2740
+  - uid: 2719
     components:
     - type: Transform
       pos: -32.5,-5.5
       parent: 2
-  - uid: 2741
+  - uid: 2720
     components:
     - type: Transform
       pos: -37.5,-0.5
       parent: 2
-  - uid: 2743
+  - uid: 2721
     components:
     - type: Transform
       pos: 6.5,18.5
       parent: 2
-  - uid: 2744
+  - uid: 2722
     components:
     - type: Transform
       pos: -43.5,-16.5
       parent: 2
-  - uid: 2745
+  - uid: 2723
     components:
     - type: Transform
       pos: -36.5,31.5
       parent: 2
-  - uid: 2746
+  - uid: 2724
     components:
     - type: Transform
       pos: -55.5,-13.5
       parent: 2
-  - uid: 2747
+  - uid: 2725
     components:
     - type: Transform
       pos: -51.5,-13.5
       parent: 2
-  - uid: 2748
+  - uid: 2726
     components:
     - type: Transform
       pos: -58.5,9.5
       parent: 2
-  - uid: 2749
+  - uid: 2727
     components:
     - type: Transform
       pos: -65.5,-19.5
       parent: 2
-  - uid: 2750
+  - uid: 2728
     components:
     - type: Transform
       pos: 1.5,38.5
       parent: 2
-  - uid: 2751
+  - uid: 2729
     components:
     - type: Transform
       pos: -55.5,-10.5
       parent: 2
-  - uid: 2752
+  - uid: 2730
     components:
     - type: Transform
       pos: -28.5,38.5
       parent: 2
-  - uid: 2753
+  - uid: 2731
     components:
     - type: Transform
       pos: -26.5,-15.5
       parent: 2
-  - uid: 2754
+  - uid: 2732
     components:
     - type: Transform
       pos: -28.5,-1.5
       parent: 2
-  - uid: 2755
+  - uid: 2733
     components:
     - type: Transform
       pos: -44.5,10.5
       parent: 2
-  - uid: 2756
+  - uid: 2734
     components:
     - type: Transform
       pos: -19.5,35.5
       parent: 2
-  - uid: 2757
+  - uid: 2735
     components:
     - type: Transform
       pos: -58.5,-1.5
       parent: 2
-  - uid: 2758
+  - uid: 2736
     components:
     - type: Transform
       pos: 4.5,8.5
       parent: 2
-  - uid: 2759
+  - uid: 2737
     components:
     - type: Transform
       pos: -45.5,37.5
       parent: 2
-  - uid: 2760
+  - uid: 2738
     components:
     - type: Transform
       pos: -43.5,6.5
       parent: 2
-  - uid: 2761
+  - uid: 2739
     components:
     - type: Transform
       pos: -46.5,28.5
       parent: 2
-  - uid: 2762
+  - uid: 2740
     components:
     - type: Transform
       pos: -7.5,-6.5
       parent: 2
-  - uid: 2763
+  - uid: 2741
     components:
     - type: Transform
       pos: -51.5,1.5
       parent: 2
-  - uid: 2764
+  - uid: 2742
     components:
     - type: Transform
       pos: -40.5,-4.5
       parent: 2
-  - uid: 2765
+  - uid: 2743
     components:
     - type: Transform
       pos: -43.5,-19.5
       parent: 2
-  - uid: 2766
+  - uid: 2744
     components:
     - type: Transform
       pos: -29.5,35.5
       parent: 2
-  - uid: 2767
+  - uid: 2745
     components:
     - type: Transform
       pos: 1.5,17.5
       parent: 2
-  - uid: 2768
+  - uid: 2746
     components:
     - type: Transform
       pos: -41.5,35.5
       parent: 2
-  - uid: 2769
+  - uid: 2747
     components:
     - type: Transform
       pos: -12.5,-5.5
       parent: 2
-  - uid: 2770
+  - uid: 2748
     components:
     - type: Transform
       pos: -62.5,-7.5
       parent: 2
-  - uid: 2771
+  - uid: 2749
     components:
     - type: Transform
       pos: -31.5,-4.5
       parent: 2
-  - uid: 2772
+  - uid: 2750
     components:
     - type: Transform
       pos: -26.5,37.5
       parent: 2
-  - uid: 2773
+  - uid: 2751
     components:
     - type: Transform
       pos: -61.5,-7.5
       parent: 2
-  - uid: 2774
+  - uid: 2752
     components:
     - type: Transform
       pos: -1.5,-10.5
       parent: 2
-  - uid: 2775
+  - uid: 2753
     components:
     - type: Transform
       pos: -40.5,5.5
       parent: 2
-  - uid: 2776
+  - uid: 2754
     components:
     - type: Transform
       pos: 5.5,-11.5
       parent: 2
-  - uid: 2777
+  - uid: 2755
     components:
     - type: Transform
       pos: 6.5,2.5
       parent: 2
-  - uid: 2779
+  - uid: 2756
     components:
     - type: Transform
       pos: -17.5,4.5
       parent: 2
-  - uid: 2780
+  - uid: 2757
     components:
     - type: Transform
       pos: -44.5,-12.5
       parent: 2
-  - uid: 2781
+  - uid: 2758
     components:
     - type: Transform
       pos: -53.5,6.5
       parent: 2
-  - uid: 2782
+  - uid: 2759
     components:
     - type: Transform
       pos: -60.5,9.5
       parent: 2
-  - uid: 2783
+  - uid: 2760
     components:
     - type: Transform
       pos: -0.5,-11.5
       parent: 2
-  - uid: 2784
+  - uid: 2761
     components:
     - type: Transform
       pos: -29.5,-5.5
       parent: 2
-  - uid: 2785
+  - uid: 2762
     components:
     - type: Transform
       pos: -26.5,27.5
       parent: 2
-  - uid: 2786
+  - uid: 2763
     components:
     - type: Transform
       pos: -35.5,-30.5
       parent: 2
-  - uid: 2787
+  - uid: 2764
     components:
     - type: Transform
       pos: -29.5,-23.5
       parent: 2
-  - uid: 2788
+  - uid: 2765
     components:
     - type: Transform
       pos: 1.5,4.5
       parent: 2
-  - uid: 2789
+  - uid: 2766
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: -50.5,-13.5
       parent: 2
-  - uid: 2790
+  - uid: 2767
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: -49.5,-13.5
       parent: 2
-  - uid: 2791
+  - uid: 2768
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: -41.5,-13.5
       parent: 2
-  - uid: 2792
+  - uid: 2769
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: -40.5,-13.5
       parent: 2
-  - uid: 2793
+  - uid: 2770
     components:
     - type: Transform
       pos: -67.5,-7.5
       parent: 2
-  - uid: 2794
+  - uid: 2771
     components:
     - type: Transform
       pos: -4.5,-13.5
       parent: 2
-  - uid: 2795
+  - uid: 2772
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: -43.5,-13.5
       parent: 2
-  - uid: 2796
+  - uid: 2773
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: -42.5,-14.5
       parent: 2
-  - uid: 2797
+  - uid: 2774
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: -44.5,-13.5
       parent: 2
-  - uid: 2798
+  - uid: 2775
     components:
     - type: Transform
       pos: 0.5,-4.5
       parent: 2
-  - uid: 2799
+  - uid: 2776
     components:
     - type: Transform
       pos: -2.5,43.5
       parent: 2
-  - uid: 2800
+  - uid: 2777
     components:
     - type: Transform
       pos: 1.5,13.5
       parent: 2
-  - uid: 2801
+  - uid: 2778
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: -40.5,-14.5
       parent: 2
-  - uid: 2802
+  - uid: 2779
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: -45.5,-13.5
       parent: 2
-  - uid: 2803
+  - uid: 2780
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: -41.5,-14.5
       parent: 2
-  - uid: 2804
+  - uid: 2781
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: -43.5,-14.5
       parent: 2
-  - uid: 2805
+  - uid: 2782
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: -42.5,-13.5
       parent: 2
-  - uid: 2806
+  - uid: 2783
     components:
     - type: Transform
       pos: -31.5,39.5
       parent: 2
-  - uid: 2807
+  - uid: 2784
     components:
     - type: Transform
       pos: -33.5,-25.5
       parent: 2
-  - uid: 2808
+  - uid: 2785
     components:
     - type: Transform
       pos: -53.5,-10.5
       parent: 2
-  - uid: 2809
+  - uid: 2786
     components:
     - type: Transform
       pos: -49.5,-30.5
       parent: 2
-  - uid: 2810
+  - uid: 2787
     components:
     - type: Transform
       pos: -45.5,32.5
       parent: 2
-  - uid: 2811
+  - uid: 2788
     components:
     - type: Transform
       pos: 15.5,0.5
       parent: 2
-  - uid: 2812
+  - uid: 2789
     components:
     - type: Transform
       pos: -46.5,-24.5
       parent: 2
-  - uid: 2813
+  - uid: 2790
     components:
     - type: Transform
       pos: -47.5,26.5
       parent: 2
-  - uid: 2814
+  - uid: 2791
     components:
     - type: Transform
       pos: -41.5,-10.5
       parent: 2
-  - uid: 2815
+  - uid: 2792
     components:
     - type: Transform
       pos: -37.5,38.5
       parent: 2
-  - uid: 2816
+  - uid: 2793
     components:
     - type: Transform
       pos: -24.5,30.5
       parent: 2
-  - uid: 2817
+  - uid: 2794
     components:
     - type: Transform
       pos: -8.5,5.5
       parent: 2
-  - uid: 2818
+  - uid: 2795
     components:
     - type: Transform
       pos: 4.5,20.5
       parent: 2
-  - uid: 2819
+  - uid: 2796
     components:
     - type: Transform
       pos: 5.5,14.5
       parent: 2
-  - uid: 2821
+  - uid: 2797
     components:
     - type: Transform
       pos: -41.5,24.5
       parent: 2
-  - uid: 2822
+  - uid: 2798
     components:
     - type: Transform
       pos: 11.5,-8.5
       parent: 2
-  - uid: 2823
+  - uid: 2799
     components:
     - type: Transform
       pos: -32.5,48.5
       parent: 2
-  - uid: 2824
+  - uid: 2800
     components:
     - type: Transform
       pos: -36.5,28.5
       parent: 2
-  - uid: 2825
+  - uid: 2801
     components:
     - type: Transform
       pos: -40.5,-10.5
       parent: 2
-  - uid: 2826
+  - uid: 2802
     components:
     - type: Transform
       pos: -46.5,4.5
       parent: 2
-  - uid: 2827
+  - uid: 2803
     components:
     - type: Transform
       pos: -18.5,-23.5
       parent: 2
-  - uid: 2829
+  - uid: 2804
     components:
     - type: Transform
       pos: -34.5,4.5
       parent: 2
-  - uid: 2830
+  - uid: 2805
     components:
     - type: Transform
       pos: -62.5,10.5
       parent: 2
-  - uid: 2831
+  - uid: 2806
     components:
     - type: Transform
       pos: -4.5,6.5
       parent: 2
-  - uid: 2832
+  - uid: 2807
     components:
     - type: Transform
       pos: -61.5,-16.5
       parent: 2
-  - uid: 2833
+  - uid: 2808
     components:
     - type: Transform
       pos: -21.5,36.5
       parent: 2
-  - uid: 2834
+  - uid: 2809
     components:
     - type: Transform
       pos: -21.5,38.5
       parent: 2
-  - uid: 2835
+  - uid: 2810
     components:
     - type: Transform
       pos: 1.5,40.5
       parent: 2
-  - uid: 2836
+  - uid: 2811
     components:
     - type: Transform
       pos: -23.5,-22.5
       parent: 2
-  - uid: 2837
+  - uid: 2812
     components:
     - type: Transform
       pos: 10.5,-7.5
       parent: 2
-  - uid: 2838
+  - uid: 2813
     components:
     - type: Transform
       pos: -40.5,-18.5
       parent: 2
-  - uid: 2839
+  - uid: 2814
     components:
     - type: Transform
       pos: -56.5,0.5
       parent: 2
-  - uid: 2840
+  - uid: 2815
     components:
     - type: Transform
       pos: -35.5,37.5
       parent: 2
-  - uid: 2841
+  - uid: 2816
     components:
     - type: Transform
       pos: -56.5,-23.5
       parent: 2
-  - uid: 2842
+  - uid: 2817
     components:
     - type: Transform
       pos: -43.5,-20.5
       parent: 2
-  - uid: 2843
+  - uid: 2818
     components:
     - type: Transform
       pos: 13.5,-5.5
       parent: 2
-  - uid: 2844
+  - uid: 2819
     components:
     - type: Transform
       pos: -54.5,-0.5
       parent: 2
-  - uid: 2845
+  - uid: 2820
     components:
     - type: Transform
       pos: -41.5,29.5
       parent: 2
-  - uid: 2846
+  - uid: 2821
     components:
     - type: Transform
       pos: -24.5,31.5
       parent: 2
-  - uid: 2847
+  - uid: 2822
     components:
     - type: Transform
       pos: -24.5,37.5
       parent: 2
-  - uid: 2848
+  - uid: 2823
     components:
     - type: Transform
       pos: 8.5,0.5
       parent: 2
-  - uid: 2849
+  - uid: 2824
     components:
     - type: Transform
       pos: -65.5,-20.5
       parent: 2
-  - uid: 2850
+  - uid: 2825
     components:
     - type: Transform
       pos: 0.5,54.5
       parent: 2
-  - uid: 2851
+  - uid: 2826
     components:
     - type: Transform
       pos: -56.5,-15.5
       parent: 2
-  - uid: 2852
+  - uid: 2827
     components:
     - type: Transform
       pos: -65.5,9.5
       parent: 2
-  - uid: 2853
+  - uid: 2828
     components:
     - type: Transform
       pos: -40.5,-22.5
       parent: 2
-  - uid: 2854
+  - uid: 2829
     components:
     - type: Transform
       pos: -66.5,-4.5
       parent: 2
-  - uid: 2855
+  - uid: 2830
     components:
     - type: Transform
       pos: 5.5,43.5
       parent: 2
-  - uid: 2856
+  - uid: 2831
     components:
     - type: Transform
       pos: -41.5,-28.5
       parent: 2
-  - uid: 2857
+  - uid: 2832
     components:
     - type: Transform
       pos: -42.5,-17.5
       parent: 2
-  - uid: 2858
+  - uid: 2833
     components:
     - type: Transform
       pos: -25.5,-29.5
       parent: 2
-  - uid: 2859
+  - uid: 2834
     components:
     - type: Transform
       pos: -40.5,46.5
       parent: 2
-  - uid: 2860
+  - uid: 2835
     components:
     - type: Transform
       pos: -35.5,-26.5
       parent: 2
-  - uid: 2861
+  - uid: 2836
     components:
     - type: Transform
       pos: 0.5,-13.5
       parent: 2
-  - uid: 2862
+  - uid: 2837
     components:
     - type: Transform
       pos: -53.5,1.5
       parent: 2
-  - uid: 2863
+  - uid: 2838
     components:
     - type: Transform
       pos: -50.5,28.5
       parent: 2
-  - uid: 2864
+  - uid: 2839
     components:
     - type: Transform
       pos: 1.5,18.5
       parent: 2
-  - uid: 2865
+  - uid: 2840
     components:
     - type: Transform
       pos: -29.5,38.5
       parent: 2
-  - uid: 2866
+  - uid: 2841
     components:
     - type: Transform
       pos: -48.5,3.5
       parent: 2
-  - uid: 2867
+  - uid: 2842
     components:
     - type: Transform
       pos: 6.5,-4.5
       parent: 2
-  - uid: 2868
+  - uid: 2843
     components:
     - type: Transform
       pos: 6.5,-0.5
       parent: 2
-  - uid: 2869
+  - uid: 2844
     components:
     - type: Transform
       pos: -42.5,-23.5
       parent: 2
-  - uid: 2870
+  - uid: 2845
     components:
     - type: Transform
       pos: -48.5,-1.5
       parent: 2
-  - uid: 2871
+  - uid: 2846
     components:
     - type: Transform
       pos: -65.5,5.5
       parent: 2
-  - uid: 2872
+  - uid: 2847
     components:
     - type: Transform
       pos: -37.5,-31.5
       parent: 2
-  - uid: 2873
+  - uid: 2848
     components:
     - type: Transform
       pos: -43.5,22.5
       parent: 2
-  - uid: 2874
+  - uid: 2849
     components:
     - type: Transform
       pos: -38.5,51.5
       parent: 2
-  - uid: 2875
+  - uid: 2850
     components:
     - type: Transform
       pos: -52.5,8.5
       parent: 2
-  - uid: 2876
+  - uid: 2851
     components:
     - type: Transform
       pos: -6.5,8.5
       parent: 2
-  - uid: 2877
+  - uid: 2852
     components:
     - type: Transform
       pos: -43.5,-21.5
       parent: 2
-  - uid: 2878
+  - uid: 2853
     components:
     - type: Transform
       pos: 4.5,48.5
       parent: 2
-  - uid: 2879
+  - uid: 2854
     components:
     - type: Transform
       pos: -44.5,34.5
       parent: 2
-  - uid: 2880
+  - uid: 2855
     components:
     - type: Transform
       pos: 11.5,-0.5
       parent: 2
-  - uid: 2881
+  - uid: 2856
     components:
     - type: Transform
       pos: -24.5,44.5
       parent: 2
-  - uid: 2882
+  - uid: 2857
     components:
     - type: Transform
       pos: 1.5,45.5
       parent: 2
-  - uid: 2883
+  - uid: 2858
     components:
     - type: Transform
       pos: -68.5,-19.5
       parent: 2
-  - uid: 2884
+  - uid: 2859
     components:
     - type: Transform
       pos: -28.5,-6.5
       parent: 2
-  - uid: 2885
+  - uid: 2860
     components:
     - type: Transform
       pos: -36.5,-15.5
       parent: 2
-  - uid: 2886
+  - uid: 2861
     components:
     - type: Transform
       pos: -2.5,-5.5
       parent: 2
-  - uid: 2887
+  - uid: 2862
     components:
     - type: Transform
       pos: -37.5,-12.5
       parent: 2
-  - uid: 2888
+  - uid: 2863
     components:
     - type: Transform
       pos: -41.5,30.5
       parent: 2
-  - uid: 2889
+  - uid: 2864
     components:
     - type: Transform
       pos: -36.5,50.5
       parent: 2
-  - uid: 2890
+  - uid: 2865
     components:
     - type: Transform
       pos: -52.5,7.5
       parent: 2
-  - uid: 2891
+  - uid: 2866
     components:
     - type: Transform
       pos: 10.5,-5.5
       parent: 2
-  - uid: 2892
+  - uid: 2867
     components:
     - type: Transform
       pos: -47.5,-10.5
       parent: 2
-  - uid: 2893
+  - uid: 2868
     components:
     - type: Transform
       pos: -20.5,37.5
       parent: 2
-  - uid: 2894
+  - uid: 2869
     components:
     - type: Transform
       pos: -55.5,-22.5
       parent: 2
-  - uid: 2895
+  - uid: 2870
     components:
     - type: Transform
       pos: -49.5,-10.5
       parent: 2
-  - uid: 2896
+  - uid: 2871
     components:
     - type: Transform
       pos: -28.5,-21.5
       parent: 2
-  - uid: 2897
+  - uid: 2872
     components:
     - type: Transform
       pos: -46.5,27.5
       parent: 2
-  - uid: 2899
+  - uid: 2873
     components:
     - type: Transform
       pos: -32.5,39.5
       parent: 2
-  - uid: 2900
+  - uid: 2874
     components:
     - type: Transform
       pos: -31.5,-22.5
       parent: 2
-  - uid: 2901
+  - uid: 2875
     components:
     - type: Transform
       pos: -43.5,-11.5
       parent: 2
-  - uid: 2902
+  - uid: 2876
     components:
     - type: Transform
       pos: -29.5,-31.5
       parent: 2
-  - uid: 2903
+  - uid: 2877
     components:
     - type: Transform
       pos: -8.5,-8.5
       parent: 2
-  - uid: 2904
+  - uid: 2878
     components:
     - type: Transform
       pos: -30.5,2.5
       parent: 2
-  - uid: 2905
+  - uid: 2879
     components:
     - type: Transform
       pos: -45.5,-1.5
       parent: 2
-  - uid: 2906
+  - uid: 2880
     components:
     - type: Transform
       pos: -40.5,22.5
       parent: 2
-  - uid: 2907
+  - uid: 2881
     components:
     - type: Transform
       pos: -55.5,-17.5
       parent: 2
-  - uid: 2908
+  - uid: 2882
     components:
     - type: Transform
       pos: -27.5,-27.5
       parent: 2
-  - uid: 2909
+  - uid: 2883
     components:
     - type: Transform
       pos: -2.5,8.5
       parent: 2
-  - uid: 2910
+  - uid: 2884
     components:
     - type: Transform
       pos: 8.5,-4.5
       parent: 2
-  - uid: 2911
+  - uid: 2885
     components:
     - type: Transform
       pos: 10.5,8.5
       parent: 2
-  - uid: 2912
+  - uid: 2886
     components:
     - type: Transform
       pos: -42.5,24.5
       parent: 2
-  - uid: 2913
+  - uid: 2887
     components:
     - type: Transform
       pos: -63.5,-6.5
       parent: 2
-  - uid: 2914
+  - uid: 2888
     components:
     - type: Transform
       pos: -61.5,-11.5
       parent: 2
-  - uid: 2915
+  - uid: 2889
     components:
     - type: Transform
       pos: -40.5,2.5
       parent: 2
-  - uid: 2916
+  - uid: 2890
     components:
     - type: Transform
       pos: -37.5,-27.5
       parent: 2
-  - uid: 2917
+  - uid: 2891
     components:
     - type: Transform
       pos: -40.5,26.5
       parent: 2
-  - uid: 2919
+  - uid: 2892
     components:
     - type: Transform
       pos: -51.5,31.5
       parent: 2
-  - uid: 2920
+  - uid: 2893
     components:
     - type: Transform
       pos: -3.5,17.5
       parent: 2
-  - uid: 2921
+  - uid: 2894
     components:
     - type: Transform
       pos: -2.5,45.5
       parent: 2
-  - uid: 2922
+  - uid: 2895
     components:
     - type: Transform
       pos: -46.5,34.5
       parent: 2
-  - uid: 2923
+  - uid: 2896
     components:
     - type: Transform
       pos: -67.5,-13.5
       parent: 2
-  - uid: 2924
+  - uid: 2897
     components:
     - type: Transform
       pos: -62.5,-16.5
       parent: 2
-  - uid: 2925
+  - uid: 2898
     components:
     - type: Transform
       pos: 14.5,-8.5
       parent: 2
-  - uid: 2926
+  - uid: 2899
     components:
     - type: Transform
       pos: -43.5,33.5
       parent: 2
-  - uid: 2927
+  - uid: 2900
     components:
     - type: Transform
       pos: -50.5,7.5
       parent: 2
-  - uid: 2928
+  - uid: 2901
     components:
     - type: Transform
       pos: -45.5,-28.5
       parent: 2
-  - uid: 2929
+  - uid: 2902
     components:
     - type: Transform
       pos: 0.5,41.5
       parent: 2
-  - uid: 2930
+  - uid: 2903
     components:
     - type: Transform
       pos: -70.5,-9.5
       parent: 2
-  - uid: 2931
+  - uid: 2904
     components:
     - type: Transform
       pos: -26.5,33.5
       parent: 2
-  - uid: 2932
+  - uid: 2905
     components:
     - type: Transform
       pos: -46.5,-5.5
       parent: 2
-  - uid: 2933
+  - uid: 2906
     components:
     - type: Transform
       pos: -43.5,48.5
       parent: 2
-  - uid: 2934
+  - uid: 2907
     components:
     - type: Transform
       pos: -46.5,36.5
       parent: 2
-  - uid: 2935
+  - uid: 2908
     components:
     - type: Transform
       pos: -36.5,22.5
       parent: 2
-  - uid: 2937
+  - uid: 2909
     components:
     - type: Transform
       pos: -0.5,50.5
       parent: 2
-  - uid: 2938
+  - uid: 2910
     components:
     - type: Transform
       pos: -22.5,39.5
       parent: 2
-  - uid: 2940
+  - uid: 2911
     components:
     - type: Transform
       pos: -28.5,37.5
       parent: 2
-  - uid: 2941
+  - uid: 2912
     components:
     - type: Transform
       pos: -50.5,-8.5
       parent: 2
-  - uid: 2943
+  - uid: 2913
     components:
     - type: Transform
       pos: -49.5,-12.5
       parent: 2
-  - uid: 2944
+  - uid: 2914
     components:
     - type: Transform
       pos: -69.5,-6.5
       parent: 2
-  - uid: 2945
+  - uid: 2915
     components:
     - type: Transform
       pos: -46.5,-6.5
       parent: 2
-  - uid: 2946
+  - uid: 2916
     components:
     - type: Transform
       pos: -32.5,-20.5
       parent: 2
-  - uid: 2947
+  - uid: 2917
     components:
     - type: Transform
       pos: 8.5,-8.5
       parent: 2
-  - uid: 2948
+  - uid: 2918
     components:
     - type: Transform
       pos: 4.5,3.5
       parent: 2
-  - uid: 2949
+  - uid: 2919
     components:
     - type: Transform
       pos: -38.5,49.5
       parent: 2
-  - uid: 2950
+  - uid: 2920
     components:
     - type: Transform
       pos: -45.5,29.5
       parent: 2
-  - uid: 2951
+  - uid: 2921
     components:
     - type: Transform
       pos: -32.5,-15.5
       parent: 2
-  - uid: 2952
+  - uid: 2922
     components:
     - type: Transform
       pos: -43.5,-23.5
       parent: 2
-  - uid: 2953
+  - uid: 2923
     components:
     - type: Transform
       pos: -0.5,-4.5
       parent: 2
-  - uid: 2954
+  - uid: 2924
     components:
     - type: Transform
       pos: -6.5,-4.5
       parent: 2
-  - uid: 2955
+  - uid: 2925
     components:
     - type: Transform
       pos: -3.5,37.5
       parent: 2
-  - uid: 2956
+  - uid: 2926
     components:
     - type: Transform
       pos: -42.5,7.5
       parent: 2
-  - uid: 2957
+  - uid: 2927
     components:
     - type: Transform
       pos: -9.5,0.5
       parent: 2
-  - uid: 2958
+  - uid: 2928
     components:
     - type: Transform
       pos: -23.5,31.5
       parent: 2
-  - uid: 2959
+  - uid: 2929
     components:
     - type: Transform
       pos: -50.5,-12.5
       parent: 2
-  - uid: 2960
+  - uid: 2930
     components:
     - type: Transform
       pos: 0.5,15.5
       parent: 2
-  - uid: 2962
+  - uid: 2931
     components:
     - type: Transform
       pos: -35.5,29.5
       parent: 2
-  - uid: 2963
+  - uid: 2932
     components:
     - type: Transform
       pos: -46.5,-9.5
       parent: 2
-  - uid: 2964
+  - uid: 2933
     components:
     - type: Transform
       pos: -2.5,-9.5
       parent: 2
-  - uid: 2965
+  - uid: 2934
     components:
     - type: Transform
       pos: 7.5,12.5
       parent: 2
-  - uid: 2966
+  - uid: 2935
     components:
     - type: Transform
       pos: 4.5,-10.5
       parent: 2
-  - uid: 2967
+  - uid: 2936
     components:
     - type: Transform
       pos: -72.5,-12.5
       parent: 2
-  - uid: 2968
+  - uid: 2937
     components:
     - type: Transform
       pos: -62.5,11.5
       parent: 2
-  - uid: 2969
+  - uid: 2938
     components:
     - type: Transform
       pos: -57.5,-22.5
       parent: 2
-  - uid: 2970
+  - uid: 2939
     components:
     - type: Transform
       pos: 13.5,-1.5
       parent: 2
-  - uid: 2971
+  - uid: 2940
     components:
     - type: Transform
       pos: 4.5,-4.5
       parent: 2
-  - uid: 2973
+  - uid: 2941
     components:
     - type: Transform
       pos: -58.5,-16.5
       parent: 2
-  - uid: 2975
+  - uid: 2942
     components:
     - type: Transform
       pos: 14.5,-0.5
       parent: 2
-  - uid: 2976
+  - uid: 2943
     components:
     - type: Transform
       pos: -40.5,0.5
       parent: 2
-  - uid: 2977
+  - uid: 2944
     components:
     - type: Transform
       pos: -11.5,2.5
       parent: 2
-  - uid: 2978
+  - uid: 2945
     components:
     - type: Transform
       pos: -32.5,37.5
       parent: 2
-  - uid: 2979
+  - uid: 2946
     components:
     - type: Transform
       pos: -51.5,-30.5
       parent: 2
-  - uid: 2980
+  - uid: 2947
     components:
     - type: Transform
       pos: -47.5,5.5
       parent: 2
-  - uid: 2981
+  - uid: 2948
     components:
     - type: Transform
       pos: -42.5,6.5
       parent: 2
-  - uid: 2982
+  - uid: 2949
     components:
     - type: Transform
       pos: -35.5,-10.5
       parent: 2
-  - uid: 2983
+  - uid: 2950
     components:
     - type: Transform
       pos: -47.5,28.5
       parent: 2
-  - uid: 2984
+  - uid: 2951
     components:
     - type: Transform
       pos: -7.5,-12.5
       parent: 2
-  - uid: 2985
+  - uid: 2952
     components:
     - type: Transform
       pos: -42.5,34.5
       parent: 2
-  - uid: 2986
+  - uid: 2953
     components:
     - type: Transform
       pos: -58.5,-15.5
       parent: 2
-  - uid: 2987
+  - uid: 2954
     components:
     - type: Transform
       pos: -27.5,-4.5
       parent: 2
-  - uid: 2988
+  - uid: 2955
     components:
     - type: Transform
       pos: -47.5,24.5
       parent: 2
-  - uid: 2989
+  - uid: 2956
     components:
     - type: Transform
       pos: 13.5,1.5
       parent: 2
-  - uid: 2990
+  - uid: 2957
     components:
     - type: Transform
       pos: 0.5,-12.5
       parent: 2
-  - uid: 2992
+  - uid: 2958
     components:
     - type: Transform
       pos: 9.5,2.5
       parent: 2
-  - uid: 2993
+  - uid: 2959
     components:
     - type: Transform
       pos: -62.5,3.5
       parent: 2
-  - uid: 2994
+  - uid: 2960
     components:
     - type: Transform
       pos: -25.5,-8.5
       parent: 2
-  - uid: 2995
+  - uid: 2961
     components:
     - type: Transform
       pos: -53.5,-9.5
       parent: 2
-  - uid: 2996
+  - uid: 2962
     components:
     - type: Transform
       pos: -41.5,5.5
       parent: 2
-  - uid: 2997
+  - uid: 2963
     components:
     - type: Transform
       pos: -7.5,3.5
       parent: 2
-  - uid: 2998
+  - uid: 2964
     components:
     - type: Transform
       pos: 10.5,2.5
       parent: 2
-  - uid: 2999
+  - uid: 2965
     components:
     - type: Transform
       pos: -42.5,-15.5
       parent: 2
-  - uid: 3000
+  - uid: 2966
     components:
     - type: Transform
       pos: -37.5,-28.5
       parent: 2
-  - uid: 3001
+  - uid: 2967
     components:
     - type: Transform
       pos: 0.5,11.5
       parent: 2
-  - uid: 3002
+  - uid: 2968
     components:
     - type: Transform
       pos: -58.5,-17.5
       parent: 2
-  - uid: 3003
+  - uid: 2969
     components:
     - type: Transform
       pos: -32.5,4.5
       parent: 2
-  - uid: 3004
+  - uid: 2970
     components:
     - type: Transform
       pos: -37.5,-5.5
       parent: 2
-  - uid: 3005
+  - uid: 2971
     components:
     - type: Transform
       pos: 11.5,15.5
       parent: 2
-  - uid: 3006
+  - uid: 2972
     components:
     - type: Transform
       pos: 7.5,45.5
       parent: 2
-  - uid: 3007
+  - uid: 2973
     components:
     - type: Transform
       pos: -46.5,3.5
       parent: 2
-  - uid: 3008
+  - uid: 2974
     components:
     - type: Transform
       pos: 9.5,0.5
       parent: 2
-  - uid: 3009
+  - uid: 2975
     components:
     - type: Transform
       pos: 10.5,-0.5
       parent: 2
-  - uid: 3010
+  - uid: 2976
     components:
     - type: Transform
       pos: 5.5,13.5
       parent: 2
-  - uid: 3011
+  - uid: 2977
     components:
     - type: Transform
       pos: 15.5,4.5
       parent: 2
-  - uid: 3012
+  - uid: 2978
     components:
     - type: Transform
       pos: -49.5,-23.5
       parent: 2
-  - uid: 3013
+  - uid: 2979
     components:
     - type: Transform
       pos: -21.5,-23.5
       parent: 2
-  - uid: 3014
+  - uid: 2980
     components:
     - type: Transform
       pos: -3.5,8.5
       parent: 2
-  - uid: 3015
+  - uid: 2981
     components:
     - type: Transform
       pos: -33.5,5.5
       parent: 2
-  - uid: 3016
+  - uid: 2982
     components:
     - type: Transform
       pos: 16.5,11.5
       parent: 2
-  - uid: 3017
+  - uid: 2983
     components:
     - type: Transform
       pos: 12.5,0.5
       parent: 2
-  - uid: 3018
+  - uid: 2984
     components:
     - type: Transform
       pos: -33.5,6.5
       parent: 2
-  - uid: 3019
+  - uid: 2985
     components:
     - type: Transform
       pos: 12.5,11.5
       parent: 2
-  - uid: 3020
+  - uid: 2986
     components:
     - type: Transform
       pos: -37.5,35.5
       parent: 2
-  - uid: 3021
+  - uid: 2987
     components:
     - type: Transform
       pos: -55.5,-18.5
       parent: 2
-  - uid: 3022
+  - uid: 2988
     components:
     - type: Transform
       pos: -42.5,11.5
       parent: 2
-  - uid: 3023
+  - uid: 2989
     components:
     - type: Transform
       pos: -32.5,-16.5
       parent: 2
-  - uid: 3024
+  - uid: 2990
     components:
     - type: Transform
       pos: 4.5,19.5
       parent: 2
-  - uid: 3025
+  - uid: 2991
     components:
     - type: Transform
       pos: -33.5,45.5
       parent: 2
-  - uid: 3027
+  - uid: 2992
     components:
     - type: Transform
       pos: -30.5,-22.5
       parent: 2
-  - uid: 3028
+  - uid: 2993
     components:
     - type: Transform
       pos: -11.5,9.5
       parent: 2
-  - uid: 3029
+  - uid: 2994
     components:
     - type: Transform
       pos: -37.5,50.5
       parent: 2
-  - uid: 3030
+  - uid: 2995
     components:
     - type: Transform
       pos: -24.5,-10.5
       parent: 2
-  - uid: 3031
+  - uid: 2996
     components:
     - type: Transform
       pos: -6.5,5.5
       parent: 2
-  - uid: 3032
+  - uid: 2997
     components:
     - type: Transform
       pos: -63.5,-12.5
       parent: 2
-  - uid: 3033
+  - uid: 2998
     components:
     - type: Transform
       pos: 6.5,43.5
       parent: 2
-  - uid: 3034
+  - uid: 2999
     components:
     - type: Transform
       pos: -42.5,22.5
       parent: 2
-  - uid: 3035
+  - uid: 3000
     components:
     - type: Transform
       pos: -8.5,3.5
       parent: 2
-  - uid: 3036
+  - uid: 3001
     components:
     - type: Transform
       pos: -36.5,32.5
       parent: 2
-  - uid: 3037
+  - uid: 3002
     components:
     - type: Transform
       pos: -5.5,-0.5
       parent: 2
-  - uid: 3038
+  - uid: 3003
     components:
     - type: Transform
       pos: -27.5,-29.5
       parent: 2
-  - uid: 3039
+  - uid: 3004
     components:
     - type: Transform
       pos: -1.5,51.5
       parent: 2
-  - uid: 3040
+  - uid: 3005
     components:
     - type: Transform
       pos: 0.5,8.5
       parent: 2
-  - uid: 3041
+  - uid: 3006
     components:
     - type: Transform
       pos: -35.5,-15.5
       parent: 2
-  - uid: 3042
+  - uid: 3007
     components:
     - type: Transform
       pos: 2.5,17.5
       parent: 2
-  - uid: 3043
+  - uid: 3008
     components:
     - type: Transform
       pos: -0.5,-5.5
       parent: 2
-  - uid: 3044
+  - uid: 3009
     components:
     - type: Transform
       pos: 7.5,6.5
       parent: 2
-  - uid: 3045
+  - uid: 3010
     components:
     - type: Transform
       pos: -5.5,-12.5
       parent: 2
-  - uid: 3046
+  - uid: 3011
     components:
     - type: Transform
       pos: 3.5,46.5
       parent: 2
-  - uid: 3047
+  - uid: 3012
     components:
     - type: Transform
       pos: -61.5,0.5
       parent: 2
-  - uid: 3048
+  - uid: 3013
     components:
     - type: Transform
       pos: -48.5,1.5
       parent: 2
-  - uid: 3049
+  - uid: 3014
     components:
     - type: Transform
       pos: -34.5,-12.5
       parent: 2
-  - uid: 3050
+  - uid: 3015
     components:
     - type: Transform
       pos: -28.5,-27.5
       parent: 2
-  - uid: 3052
+  - uid: 3016
     components:
     - type: Transform
       pos: -33.5,-29.5
       parent: 2
-  - uid: 3053
+  - uid: 3017
     components:
     - type: Transform
       pos: -40.5,24.5
       parent: 2
-  - uid: 3054
+  - uid: 3018
     components:
     - type: Transform
       pos: -37.5,51.5
       parent: 2
-  - uid: 3055
+  - uid: 3019
     components:
     - type: Transform
       pos: -24.5,35.5
       parent: 2
-  - uid: 3056
+  - uid: 3020
     components:
     - type: Transform
       pos: -64.5,10.5
       parent: 2
-  - uid: 3057
+  - uid: 3021
     components:
     - type: Transform
       pos: -42.5,-19.5
       parent: 2
-  - uid: 3058
+  - uid: 3022
     components:
     - type: Transform
       pos: -29.5,-18.5
       parent: 2
-  - uid: 3059
+  - uid: 3023
     components:
     - type: Transform
       pos: 1.5,-15.5
       parent: 2
-  - uid: 3060
+  - uid: 3024
     components:
     - type: Transform
       pos: -64.5,-25.5
       parent: 2
-  - uid: 3061
+  - uid: 3025
     components:
     - type: Transform
       pos: -13.5,6.5
       parent: 2
-  - uid: 3062
+  - uid: 3026
     components:
     - type: Transform
       pos: -30.5,-10.5
       parent: 2
-  - uid: 3063
+  - uid: 3027
     components:
     - type: Transform
       pos: -52.5,13.5
       parent: 2
-  - uid: 3064
+  - uid: 3028
     components:
     - type: Transform
       pos: 4.5,0.5
       parent: 2
-  - uid: 3065
+  - uid: 3029
     components:
     - type: Transform
       pos: 5.5,6.5
       parent: 2
-  - uid: 3066
+  - uid: 3030
     components:
     - type: Transform
       pos: -11.5,4.5
       parent: 2
-  - uid: 3067
+  - uid: 3031
     components:
     - type: Transform
       pos: -43.5,42.5
       parent: 2
-  - uid: 3068
+  - uid: 3032
     components:
     - type: Transform
       pos: -48.5,-5.5
       parent: 2
-  - uid: 3069
+  - uid: 3033
     components:
     - type: Transform
       pos: -44.5,27.5
       parent: 2
-  - uid: 3070
+  - uid: 3034
     components:
     - type: Transform
       pos: -21.5,32.5
       parent: 2
-  - uid: 3071
+  - uid: 3035
     components:
     - type: Transform
       pos: -43.5,-17.5
       parent: 2
-  - uid: 3073
+  - uid: 3036
     components:
     - type: Transform
       pos: -2.5,47.5
       parent: 2
-  - uid: 3074
+  - uid: 3037
     components:
     - type: Transform
       pos: -49.5,36.5
       parent: 2
-  - uid: 3075
+  - uid: 3038
     components:
     - type: Transform
       pos: 18.5,-5.5
       parent: 2
-  - uid: 3076
+  - uid: 3039
     components:
     - type: Transform
       pos: -40.5,50.5
       parent: 2
-  - uid: 3077
+  - uid: 3040
     components:
     - type: Transform
       pos: -58.5,5.5
       parent: 2
-  - uid: 3078
+  - uid: 3041
     components:
     - type: Transform
       pos: -68.5,-17.5
       parent: 2
-  - uid: 3080
+  - uid: 3042
     components:
     - type: Transform
       pos: 8.5,11.5
       parent: 2
-  - uid: 3082
+  - uid: 3043
     components:
     - type: Transform
       pos: -45.5,3.5
       parent: 2
-  - uid: 3083
+  - uid: 3044
     components:
     - type: Transform
       pos: -50.5,-11.5
       parent: 2
-  - uid: 3084
+  - uid: 3045
     components:
     - type: Transform
       pos: -59.5,6.5
       parent: 2
-  - uid: 3085
+  - uid: 3046
     components:
     - type: Transform
       pos: -40.5,-28.5
       parent: 2
-  - uid: 3086
+  - uid: 3047
     components:
     - type: Transform
       pos: 6.5,47.5
       parent: 2
-  - uid: 3087
+  - uid: 3048
     components:
     - type: Transform
       pos: -48.5,-29.5
       parent: 2
-  - uid: 3088
+  - uid: 3049
     components:
     - type: Transform
       pos: -66.5,-0.5
       parent: 2
-  - uid: 3089
+  - uid: 3050
     components:
     - type: Transform
       pos: -23.5,-13.5
       parent: 2
-  - uid: 3090
+  - uid: 3051
     components:
     - type: Transform
       pos: 6.5,-10.5
       parent: 2
-  - uid: 3091
+  - uid: 3052
     components:
     - type: Transform
       pos: -45.5,7.5
       parent: 2
-  - uid: 3092
+  - uid: 3053
     components:
     - type: Transform
       pos: -42.5,-25.5
       parent: 2
-  - uid: 3093
+  - uid: 3054
     components:
     - type: Transform
       pos: -48.5,33.5
       parent: 2
-  - uid: 3095
+  - uid: 3055
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: -45.5,-14.5
       parent: 2
-  - uid: 3096
+  - uid: 3056
     components:
     - type: Transform
       pos: -56.5,4.5
       parent: 2
-  - uid: 3097
+  - uid: 3057
     components:
     - type: Transform
       pos: 15.5,11.5
       parent: 2
-  - uid: 3098
+  - uid: 3058
     components:
     - type: Transform
       pos: 7.5,1.5
       parent: 2
-  - uid: 3099
+  - uid: 3059
     components:
     - type: Transform
       pos: -64.5,-11.5
       parent: 2
-  - uid: 3100
+  - uid: 3060
     components:
     - type: Transform
       pos: -22.5,-14.5
       parent: 2
-  - uid: 3101
+  - uid: 3061
     components:
     - type: Transform
       pos: 4.5,46.5
       parent: 2
-  - uid: 3102
+  - uid: 3062
     components:
     - type: Transform
       pos: 4.5,43.5
       parent: 2
-  - uid: 3103
+  - uid: 3063
     components:
     - type: Transform
       pos: -49.5,-25.5
       parent: 2
-  - uid: 3104
+  - uid: 3064
     components:
     - type: Transform
       pos: -40.5,-1.5
       parent: 2
-  - uid: 3105
+  - uid: 3065
     components:
     - type: Transform
       pos: -50.5,-24.5
       parent: 2
-  - uid: 3106
+  - uid: 3066
     components:
     - type: Transform
       pos: -69.5,-10.5
       parent: 2
-  - uid: 3107
+  - uid: 3067
     components:
     - type: Transform
       pos: 3.5,17.5
       parent: 2
-  - uid: 3108
+  - uid: 3068
     components:
     - type: Transform
       pos: 14.5,-7.5
       parent: 2
-  - uid: 3109
+  - uid: 3069
     components:
     - type: Transform
       pos: -56.5,-16.5
       parent: 2
-  - uid: 3110
+  - uid: 3070
     components:
     - type: Transform
       pos: -59.5,-1.5
       parent: 2
-  - uid: 5365
+  - uid: 3071
     components:
     - type: Transform
       pos: -41.5,-5.5
       parent: 2
-  - uid: 5366
+  - uid: 3072
     components:
     - type: Transform
       pos: -42.5,28.5
       parent: 2
-  - uid: 5367
+  - uid: 3073
     components:
     - type: Transform
       pos: -31.5,32.5
       parent: 2
-  - uid: 5369
+  - uid: 3074
     components:
     - type: Transform
       pos: -18.5,-21.5
       parent: 2
-  - uid: 5371
+  - uid: 3075
     components:
     - type: Transform
       pos: -68.5,-18.5
       parent: 2
-  - uid: 5373
+  - uid: 3076
     components:
     - type: Transform
       pos: -6.5,47.5
       parent: 2
-  - uid: 5375
+  - uid: 3077
     components:
     - type: Transform
       pos: 16.5,8.5
       parent: 2
-  - uid: 5376
+  - uid: 3078
     components:
     - type: Transform
       pos: -54.5,5.5
       parent: 2
-  - uid: 5377
+  - uid: 3079
     components:
     - type: Transform
       pos: -14.5,8.5
       parent: 2
-  - uid: 5378
+  - uid: 3080
     components:
     - type: Transform
       pos: -4.5,0.5
       parent: 2
-  - uid: 5379
+  - uid: 3081
     components:
     - type: Transform
       pos: 7.5,-1.5
       parent: 2
-  - uid: 5380
+  - uid: 3082
     components:
     - type: Transform
       pos: -44.5,5.5
       parent: 2
-  - uid: 5381
+  - uid: 3083
     components:
     - type: Transform
       pos: -0.5,-10.5
       parent: 2
-  - uid: 5382
+  - uid: 3084
     components:
     - type: Transform
       pos: -31.5,0.5
       parent: 2
-  - uid: 5383
+  - uid: 3085
     components:
     - type: Transform
       pos: -23.5,-23.5
       parent: 2
-  - uid: 5384
+  - uid: 3086
     components:
     - type: Transform
       pos: -16.5,3.5
       parent: 2
-  - uid: 5385
+  - uid: 3087
     components:
     - type: Transform
       pos: 7.5,-7.5
       parent: 2
-  - uid: 5386
+  - uid: 3088
     components:
     - type: Transform
       pos: -10.5,6.5
       parent: 2
-  - uid: 5387
+  - uid: 3089
     components:
     - type: Transform
       pos: -58.5,-9.5
       parent: 2
-  - uid: 5388
+  - uid: 3090
     components:
     - type: Transform
       pos: -60.5,1.5
       parent: 2
-  - uid: 5390
+  - uid: 3091
     components:
     - type: Transform
       pos: -42.5,-5.5
       parent: 2
-  - uid: 5391
+  - uid: 3092
     components:
     - type: Transform
       pos: -47.5,15.5
       parent: 2
-  - uid: 5392
+  - uid: 3093
     components:
     - type: Transform
       pos: 2.5,6.5
       parent: 2
-  - uid: 5393
+  - uid: 3094
     components:
     - type: Transform
       pos: -53.5,-5.5
       parent: 2
-  - uid: 5394
+  - uid: 3095
     components:
     - type: Transform
       pos: -30.5,42.5
       parent: 2
-  - uid: 5395
+  - uid: 3096
     components:
     - type: Transform
       pos: -2.5,50.5
       parent: 2
-  - uid: 5396
+  - uid: 3097
     components:
     - type: Transform
       pos: -35.5,-29.5
       parent: 2
-  - uid: 5397
+  - uid: 3098
     components:
     - type: Transform
       pos: 12.5,-9.5
       parent: 2
-  - uid: 5398
+  - uid: 3099
     components:
     - type: Transform
       pos: -62.5,-1.5
       parent: 2
-  - uid: 5399
+  - uid: 3100
     components:
     - type: Transform
       pos: -7.5,1.5
       parent: 2
-  - uid: 5401
+  - uid: 3101
     components:
     - type: Transform
       pos: -29.5,-9.5
       parent: 2
-  - uid: 5404
+  - uid: 3102
     components:
     - type: Transform
       pos: -18.5,-22.5
       parent: 2
-  - uid: 5405
+  - uid: 3103
     components:
     - type: Transform
       pos: -11.5,-4.5
       parent: 2
-  - uid: 5407
+  - uid: 3104
     components:
     - type: Transform
       pos: -34.5,-11.5
       parent: 2
-  - uid: 5408
+  - uid: 3105
     components:
     - type: Transform
       pos: -67.5,-11.5
       parent: 2
-  - uid: 5409
+  - uid: 3106
     components:
     - type: Transform
       pos: 3.5,49.5
       parent: 2
-  - uid: 5410
+  - uid: 3107
     components:
     - type: Transform
       pos: -8.5,6.5
       parent: 2
-  - uid: 5411
+  - uid: 3108
     components:
     - type: Transform
       pos: -53.5,34.5
       parent: 2
-  - uid: 5412
+  - uid: 3109
     components:
     - type: Transform
       pos: -32.5,-22.5
       parent: 2
-  - uid: 5413
+  - uid: 3110
     components:
     - type: Transform
       pos: -53.5,35.5
       parent: 2
-  - uid: 5414
+  - uid: 3111
     components:
     - type: Transform
       pos: 2.5,38.5
       parent: 2
-  - uid: 5415
+  - uid: 3112
     components:
     - type: Transform
       pos: -31.5,35.5
       parent: 2
-  - uid: 5416
+  - uid: 3113
     components:
     - type: Transform
       pos: -36.5,-23.5
       parent: 2
-  - uid: 5417
+  - uid: 3114
     components:
     - type: Transform
       pos: -49.5,28.5
       parent: 2
-  - uid: 5419
+  - uid: 3115
     components:
     - type: Transform
       pos: -52.5,-7.5
       parent: 2
-  - uid: 5420
+  - uid: 3116
     components:
     - type: Transform
       pos: -36.5,-25.5
       parent: 2
-  - uid: 5421
+  - uid: 3117
     components:
     - type: Transform
       pos: -33.5,-33.5
       parent: 2
-  - uid: 5422
+  - uid: 3118
     components:
     - type: Transform
       pos: -42.5,5.5
       parent: 2
-  - uid: 5423
+  - uid: 3119
     components:
     - type: Transform
       pos: -43.5,11.5
       parent: 2
-  - uid: 5424
+  - uid: 3120
     components:
     - type: Transform
       pos: 5.5,46.5
       parent: 2
-  - uid: 5425
+  - uid: 3121
     components:
     - type: Transform
       pos: -25.5,-14.5
       parent: 2
-  - uid: 5426
+  - uid: 3122
     components:
     - type: Transform
       pos: -48.5,-25.5
       parent: 2
-  - uid: 5427
+  - uid: 3123
     components:
     - type: Transform
       pos: -25.5,-6.5
       parent: 2
-  - uid: 5428
+  - uid: 3124
     components:
     - type: Transform
       pos: 2.5,46.5
       parent: 2
-  - uid: 5429
+  - uid: 3125
     components:
     - type: Transform
       pos: -41.5,42.5
       parent: 2
-  - uid: 5431
+  - uid: 3126
     components:
     - type: Transform
       pos: -26.5,24.5
       parent: 2
-  - uid: 5432
+  - uid: 3127
     components:
     - type: Transform
       pos: -40.5,-34.5
       parent: 2
-  - uid: 5433
+  - uid: 3128
     components:
     - type: Transform
       pos: -45.5,27.5
       parent: 2
-  - uid: 5434
+  - uid: 3129
     components:
     - type: Transform
       pos: -55.5,-14.5
       parent: 2
-  - uid: 5435
+  - uid: 3130
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: -46.5,-13.5
       parent: 2
-  - uid: 5436
+  - uid: 3131
     components:
     - type: Transform
       pos: 12.5,-6.5
       parent: 2
-  - uid: 5437
+  - uid: 3132
     components:
     - type: Transform
       pos: -34.5,35.5
       parent: 2
-  - uid: 5438
+  - uid: 3133
     components:
     - type: Transform
       pos: 13.5,5.5
       parent: 2
-  - uid: 5439
+  - uid: 3134
     components:
     - type: Transform
       pos: -40.5,42.5
       parent: 2
-  - uid: 5440
+  - uid: 3135
     components:
     - type: Transform
       pos: -69.5,-18.5
       parent: 2
-  - uid: 5441
+  - uid: 3136
     components:
     - type: Transform
       pos: -30.5,37.5
       parent: 2
-  - uid: 5442
+  - uid: 3137
     components:
     - type: Transform
       pos: -54.5,1.5
       parent: 2
-  - uid: 5443
+  - uid: 3138
     components:
     - type: Transform
       pos: -28.5,-19.5
       parent: 2
-  - uid: 5444
+  - uid: 3139
     components:
     - type: Transform
       pos: -65.5,3.5
       parent: 2
-  - uid: 5447
+  - uid: 3140
     components:
     - type: Transform
       pos: -0.5,-16.5
       parent: 2
-  - uid: 5448
+  - uid: 3141
     components:
     - type: Transform
       pos: -27.5,-8.5
       parent: 2
-  - uid: 5449
+  - uid: 3142
     components:
     - type: Transform
       pos: -7.5,9.5
       parent: 2
-  - uid: 5451
+  - uid: 3143
     components:
     - type: Transform
       pos: -63.5,6.5
       parent: 2
-  - uid: 5452
+  - uid: 3144
     components:
     - type: Transform
       pos: -4.5,47.5
       parent: 2
-  - uid: 5453
+  - uid: 3145
     components:
     - type: Transform
       pos: 10.5,-9.5
       parent: 2
-  - uid: 5454
+  - uid: 3146
     components:
     - type: Transform
       pos: -6.5,3.5
       parent: 2
-  - uid: 5455
+  - uid: 3147
     components:
     - type: Transform
       pos: -24.5,36.5
       parent: 2
-  - uid: 5456
+  - uid: 3148
     components:
     - type: Transform
       pos: -53.5,-7.5
       parent: 2
-  - uid: 5457
+  - uid: 3149
     components:
     - type: Transform
       pos: -48.5,44.5
       parent: 2
-  - uid: 5460
+  - uid: 3150
     components:
     - type: Transform
       pos: -31.5,-31.5
       parent: 2
-  - uid: 5461
+  - uid: 3151
     components:
     - type: Transform
       pos: -50.5,33.5
       parent: 2
-  - uid: 5462
+  - uid: 3152
     components:
     - type: Transform
       pos: -28.5,-17.5
       parent: 2
-  - uid: 5463
+  - uid: 3153
     components:
     - type: Transform
       pos: -36.5,26.5
       parent: 2
-  - uid: 5464
+  - uid: 3154
     components:
     - type: Transform
       pos: -10.5,48.5
       parent: 2
-  - uid: 5465
+  - uid: 3155
     components:
     - type: Transform
       pos: -33.5,24.5
       parent: 2
-  - uid: 5466
+  - uid: 3156
     components:
     - type: Transform
       pos: -56.5,-13.5
       parent: 2
-  - uid: 5470
+  - uid: 3157
     components:
     - type: Transform
       pos: 1.5,46.5
       parent: 2
-  - uid: 5471
+  - uid: 3158
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: -15.5,-4.5
       parent: 2
-  - uid: 5473
+  - uid: 3159
     components:
     - type: Transform
       pos: -69.5,-7.5
       parent: 2
-  - uid: 5474
+  - uid: 3160
     components:
     - type: Transform
       pos: -62.5,4.5
       parent: 2
-  - uid: 5475
+  - uid: 3161
     components:
     - type: Transform
       pos: -67.5,-10.5
       parent: 2
-  - uid: 5479
+  - uid: 3162
     components:
     - type: Transform
       pos: 8.5,3.5
       parent: 2
-  - uid: 5480
+  - uid: 3163
     components:
     - type: Transform
       pos: 9.5,6.5
       parent: 2
-  - uid: 5481
+  - uid: 3164
     components:
     - type: Transform
       pos: -43.5,12.5
       parent: 2
-  - uid: 5482
+  - uid: 3165
     components:
     - type: Transform
       pos: 0.5,47.5
       parent: 2
-  - uid: 5483
+  - uid: 3166
     components:
     - type: Transform
       pos: -57.5,-11.5
       parent: 2
-  - uid: 5484
+  - uid: 3167
     components:
     - type: Transform
       pos: 13.5,8.5
       parent: 2
-  - uid: 5485
+  - uid: 3168
     components:
     - type: Transform
       pos: -67.5,-4.5
       parent: 2
-  - uid: 5487
+  - uid: 3169
     components:
     - type: Transform
       pos: -28.5,31.5
       parent: 2
-  - uid: 5488
+  - uid: 3170
     components:
     - type: Transform
       pos: -49.5,4.5
       parent: 2
-  - uid: 5489
+  - uid: 3171
     components:
     - type: Transform
       pos: 15.5,8.5
       parent: 2
-  - uid: 5490
+  - uid: 3172
     components:
     - type: Transform
       pos: -35.5,-23.5
       parent: 2
-  - uid: 5492
+  - uid: 3173
     components:
     - type: Transform
       pos: 8.5,5.5
       parent: 2
-  - uid: 5493
+  - uid: 3174
     components:
     - type: Transform
       pos: -41.5,2.5
       parent: 2
-  - uid: 5494
+  - uid: 3175
     components:
     - type: Transform
       pos: -44.5,36.5
       parent: 2
-  - uid: 5495
+  - uid: 3176
     components:
     - type: Transform
       pos: -10.5,5.5
       parent: 2
-  - uid: 5496
+  - uid: 3177
     components:
     - type: Transform
       pos: 14.5,11.5
       parent: 2
-  - uid: 5497
+  - uid: 3178
     components:
     - type: Transform
       pos: 17.5,6.5
       parent: 2
-  - uid: 5498
+  - uid: 3179
     components:
     - type: Transform
       pos: -68.5,-5.5
       parent: 2
-  - uid: 5499
+  - uid: 3180
     components:
     - type: Transform
       pos: -28.5,-8.5
       parent: 2
-  - uid: 5500
+  - uid: 3181
     components:
     - type: Transform
       pos: -57.5,-10.5
       parent: 2
-  - uid: 5501
+  - uid: 3182
     components:
     - type: Transform
       pos: -9.5,1.5
       parent: 2
-  - uid: 5502
+  - uid: 3183
     components:
     - type: Transform
       pos: 3.5,14.5
       parent: 2
-  - uid: 5503
+  - uid: 3184
     components:
     - type: Transform
       pos: 1.5,44.5
       parent: 2
-  - uid: 5505
+  - uid: 3185
     components:
     - type: Transform
       pos: -6.5,49.5
       parent: 2
-  - uid: 5506
+  - uid: 3186
     components:
     - type: Transform
       pos: 12.5,-5.5
       parent: 2
-  - uid: 5507
+  - uid: 3187
     components:
     - type: Transform
       pos: -0.5,53.5
       parent: 2
-  - uid: 5508
+  - uid: 3188
     components:
     - type: Transform
       pos: -22.5,34.5
       parent: 2
-  - uid: 5509
+  - uid: 3189
     components:
     - type: Transform
       pos: -29.5,31.5
       parent: 2
-  - uid: 5510
+  - uid: 3190
     components:
     - type: Transform
       pos: -68.5,-14.5
       parent: 2
-  - uid: 5511
+  - uid: 3191
     components:
     - type: Transform
       pos: -52.5,-5.5
       parent: 2
-  - uid: 5512
+  - uid: 3192
     components:
     - type: Transform
       pos: 3.5,38.5
       parent: 2
-  - uid: 5517
+  - uid: 3193
     components:
     - type: Transform
       pos: 3.5,-7.5
       parent: 2
-  - uid: 5518
+  - uid: 3194
     components:
     - type: Transform
       pos: -57.5,-15.5
       parent: 2
-  - uid: 5519
+  - uid: 3195
     components:
     - type: Transform
       pos: -9.5,13.5
       parent: 2
-  - uid: 5520
+  - uid: 3196
     components:
     - type: Transform
       pos: -30.5,-18.5
       parent: 2
-  - uid: 5521
+  - uid: 3197
     components:
     - type: Transform
       pos: -55.5,-19.5
       parent: 2
-  - uid: 5522
+  - uid: 3198
     components:
     - type: Transform
       pos: -2.5,0.5
       parent: 2
-  - uid: 5523
+  - uid: 3199
     components:
     - type: Transform
       pos: -35.5,-11.5
       parent: 2
-  - uid: 5524
+  - uid: 3200
     components:
     - type: Transform
       pos: 15.5,-2.5
       parent: 2
-  - uid: 5525
+  - uid: 3201
     components:
     - type: Transform
       pos: 9.5,-6.5
       parent: 2
-  - uid: 5526
+  - uid: 3202
     components:
     - type: Transform
       pos: -44.5,35.5
       parent: 2
-  - uid: 5527
+  - uid: 3203
     components:
     - type: Transform
       pos: -16.5,-0.5
       parent: 2
-  - uid: 5528
+  - uid: 3204
     components:
     - type: Transform
       pos: -14.5,7.5
       parent: 2
-  - uid: 5530
+  - uid: 3205
     components:
     - type: Transform
       pos: -50.5,-29.5
       parent: 2
-  - uid: 5531
+  - uid: 3206
     components:
     - type: Transform
       pos: -29.5,-29.5
       parent: 2
-  - uid: 5533
+  - uid: 3207
     components:
     - type: Transform
       pos: -22.5,-20.5
       parent: 2
-  - uid: 5535
+  - uid: 3208
     components:
     - type: Transform
       pos: -50.5,34.5
       parent: 2
-  - uid: 5536
+  - uid: 3209
     components:
     - type: Transform
       pos: -48.5,38.5
       parent: 2
-  - uid: 5537
+  - uid: 3210
     components:
     - type: Transform
       pos: -8.5,-9.5
       parent: 2
-  - uid: 5539
+  - uid: 3211
     components:
     - type: Transform
       pos: -49.5,-29.5
       parent: 2
-  - uid: 5541
+  - uid: 3212
     components:
     - type: Transform
       pos: -53.5,-23.5
       parent: 2
-  - uid: 5542
+  - uid: 3213
     components:
     - type: Transform
       pos: 11.5,12.5
       parent: 2
-  - uid: 5544
+  - uid: 3214
     components:
     - type: Transform
       pos: -11.5,7.5
       parent: 2
-  - uid: 5545
+  - uid: 3215
     components:
     - type: Transform
       pos: 11.5,13.5
       parent: 2
-  - uid: 5547
+  - uid: 3216
     components:
     - type: Transform
       pos: -24.5,-13.5
       parent: 2
-  - uid: 5548
+  - uid: 3217
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: -6.5,38.5
       parent: 2
-  - uid: 5549
+  - uid: 3218
     components:
     - type: Transform
       pos: -32.5,-7.5
       parent: 2
-  - uid: 5550
+  - uid: 3219
     components:
     - type: Transform
       pos: 15.5,13.5
       parent: 2
-  - uid: 5552
+  - uid: 3220
     components:
     - type: Transform
       pos: -46.5,-30.5
       parent: 2
-  - uid: 5553
+  - uid: 3221
     components:
     - type: Transform
       pos: -11.5,11.5
       parent: 2
-  - uid: 5554
+  - uid: 3222
     components:
     - type: Transform
       pos: 2.5,-6.5
       parent: 2
-  - uid: 5555
+  - uid: 3223
     components:
     - type: Transform
       pos: -56.5,-14.5
       parent: 2
-  - uid: 5557
+  - uid: 3224
     components:
     - type: Transform
       pos: -31.5,-30.5
       parent: 2
-  - uid: 5558
+  - uid: 3225
     components:
     - type: Transform
       pos: -44.5,30.5
       parent: 2
-  - uid: 5559
+  - uid: 3226
     components:
     - type: Transform
       pos: -30.5,-26.5
       parent: 2
-  - uid: 5560
+  - uid: 3227
     components:
     - type: Transform
       pos: -30.5,29.5
       parent: 2
-  - uid: 5561
+  - uid: 3228
     components:
     - type: Transform
       pos: -31.5,23.5
       parent: 2
-  - uid: 5562
+  - uid: 3229
     components:
     - type: Transform
       pos: -17.5,3.5
       parent: 2
-  - uid: 5563
+  - uid: 3230
     components:
     - type: Transform
       pos: 1.5,37.5
       parent: 2
-  - uid: 5564
+  - uid: 3231
     components:
     - type: Transform
       pos: -60.5,11.5
       parent: 2
-  - uid: 5565
+  - uid: 3232
     components:
     - type: Transform
       pos: -37.5,-10.5
       parent: 2
-  - uid: 5566
+  - uid: 3233
     components:
     - type: Transform
       pos: -4.5,46.5
       parent: 2
-  - uid: 5567
+  - uid: 3234
     components:
     - type: Transform
       pos: -21.5,28.5
       parent: 2
-  - uid: 5568
+  - uid: 3235
     components:
     - type: Transform
       pos: -7.5,-9.5
       parent: 2
-  - uid: 5569
+  - uid: 3236
     components:
     - type: Transform
       pos: -13.5,-5.5
       parent: 2
-  - uid: 5572
+  - uid: 3237
     components:
     - type: Transform
       pos: -47.5,0.5
       parent: 2
-  - uid: 5573
+  - uid: 3238
     components:
     - type: Transform
       pos: -65.5,-23.5
       parent: 2
-  - uid: 6198
+  - uid: 3239
     components:
     - type: Transform
       pos: -62.5,-27.5
       parent: 2
-  - uid: 6199
+  - uid: 3240
     components:
     - type: Transform
       pos: -36.5,49.5
       parent: 2
-  - uid: 6200
+  - uid: 3241
     components:
     - type: Transform
       pos: -44.5,-29.5
       parent: 2
-  - uid: 6201
+  - uid: 3242
     components:
     - type: Transform
       pos: -59.5,5.5
       parent: 2
-  - uid: 6202
+  - uid: 3243
     components:
     - type: Transform
       pos: -52.5,34.5
       parent: 2
-  - uid: 6203
+  - uid: 3244
     components:
     - type: Transform
       pos: -40.5,-8.5
       parent: 2
-  - uid: 6204
+  - uid: 3245
     components:
     - type: Transform
       pos: 1.5,16.5
       parent: 2
-  - uid: 6205
+  - uid: 3246
     components:
     - type: Transform
       pos: -44.5,-32.5
       parent: 2
-  - uid: 6206
+  - uid: 3247
     components:
     - type: Transform
       pos: -32.5,47.5
       parent: 2
-  - uid: 6207
+  - uid: 3248
     components:
     - type: Transform
       pos: -41.5,9.5
       parent: 2
-  - uid: 6208
+  - uid: 3249
     components:
     - type: Transform
       pos: -61.5,-15.5
       parent: 2
-  - uid: 6209
+  - uid: 3250
     components:
     - type: Transform
       pos: -59.5,9.5
       parent: 2
-  - uid: 6210
+  - uid: 3251
     components:
     - type: Transform
       pos: 13.5,-3.5
       parent: 2
-  - uid: 6211
+  - uid: 3252
     components:
     - type: Transform
       pos: -36.5,-28.5
       parent: 2
-  - uid: 6212
+  - uid: 3253
     components:
     - type: Transform
       pos: -41.5,-20.5
       parent: 2
-  - uid: 6213
+  - uid: 3254
     components:
     - type: Transform
       pos: -42.5,30.5
       parent: 2
-  - uid: 6214
+  - uid: 3255
     components:
     - type: Transform
       pos: -23.5,-10.5
       parent: 2
-  - uid: 6215
+  - uid: 3256
     components:
     - type: Transform
       pos: 11.5,7.5
       parent: 2
-  - uid: 6216
+  - uid: 3257
     components:
     - type: Transform
       pos: 7.5,17.5
       parent: 2
-  - uid: 6217
+  - uid: 3258
     components:
     - type: Transform
       pos: -47.5,-25.5
       parent: 2
-  - uid: 6218
+  - uid: 3259
     components:
     - type: Transform
       pos: -61.5,3.5
       parent: 2
-  - uid: 6219
+  - uid: 3260
     components:
     - type: Transform
       pos: 19.5,-4.5
       parent: 2
-  - uid: 6221
+  - uid: 3261
     components:
     - type: Transform
       pos: -23.5,26.5
       parent: 2
-  - uid: 6222
+  - uid: 3262
     components:
     - type: Transform
       pos: 9.5,-9.5
       parent: 2
-  - uid: 6224
+  - uid: 3263
     components:
     - type: Transform
       pos: 8.5,18.5
       parent: 2
-  - uid: 6225
+  - uid: 3264
     components:
     - type: Transform
       pos: -24.5,29.5
       parent: 2
-  - uid: 6226
+  - uid: 3265
     components:
     - type: Transform
       pos: -21.5,-25.5
       parent: 2
-  - uid: 6227
+  - uid: 3266
     components:
     - type: Transform
       pos: -49.5,1.5
       parent: 2
-  - uid: 6228
+  - uid: 3267
     components:
     - type: Transform
       pos: -28.5,-28.5
       parent: 2
-  - uid: 6229
+  - uid: 3268
     components:
     - type: Transform
       pos: -13.5,-6.5
       parent: 2
-  - uid: 6230
+  - uid: 3269
     components:
     - type: Transform
       pos: -33.5,25.5
       parent: 2
-  - uid: 6231
+  - uid: 3270
     components:
     - type: Transform
       pos: -33.5,26.5
       parent: 2
-  - uid: 6232
+  - uid: 3271
     components:
     - type: Transform
       pos: -25.5,34.5
       parent: 2
-  - uid: 6233
+  - uid: 3272
     components:
     - type: Transform
       pos: -47.5,-30.5
       parent: 2
-  - uid: 6234
+  - uid: 3273
     components:
     - type: Transform
       pos: -23.5,-17.5
       parent: 2
-  - uid: 6235
+  - uid: 3274
     components:
     - type: Transform
       pos: -35.5,6.5
       parent: 2
-  - uid: 6236
+  - uid: 3275
     components:
     - type: Transform
       pos: -48.5,29.5
       parent: 2
-  - uid: 6237
+  - uid: 3276
     components:
     - type: Transform
       pos: -31.5,-19.5
       parent: 2
-  - uid: 6238
+  - uid: 3277
     components:
     - type: Transform
       pos: -28.5,46.5
       parent: 2
-  - uid: 6239
+  - uid: 3278
     components:
     - type: Transform
       pos: -53.5,9.5
       parent: 2
-  - uid: 6240
+  - uid: 3279
     components:
     - type: Transform
       pos: -4.5,38.5
       parent: 2
-  - uid: 6241
+  - uid: 3280
     components:
     - type: Transform
       pos: 10.5,14.5
       parent: 2
-  - uid: 6242
+  - uid: 3281
     components:
     - type: Transform
       pos: -52.5,30.5
       parent: 2
-  - uid: 6243
+  - uid: 3282
     components:
     - type: Transform
       pos: -48.5,-28.5
       parent: 2
-  - uid: 6245
+  - uid: 3283
     components:
     - type: Transform
       pos: -29.5,-30.5
       parent: 2
-  - uid: 6246
+  - uid: 3284
     components:
     - type: Transform
       pos: -45.5,46.5
       parent: 2
-  - uid: 6247
+  - uid: 3285
     components:
     - type: Transform
       pos: -69.5,-1.5
       parent: 2
-  - uid: 6248
+  - uid: 3286
     components:
     - type: Transform
       pos: -21.5,29.5
       parent: 2
-  - uid: 6249
+  - uid: 3287
     components:
     - type: Transform
       pos: -66.5,-9.5
       parent: 2
-  - uid: 6252
+  - uid: 3288
     components:
     - type: Transform
       pos: -50.5,-9.5
       parent: 2
-  - uid: 6253
+  - uid: 3289
     components:
     - type: Transform
       pos: -55.5,11.5
       parent: 2
-  - uid: 6254
+  - uid: 3290
     components:
     - type: Transform
       pos: -44.5,-16.5
       parent: 2
-  - uid: 6255
+  - uid: 3291
     components:
     - type: Transform
       pos: -43.5,43.5
       parent: 2
-  - uid: 6256
+  - uid: 3292
     components:
     - type: Transform
       pos: -50.5,-17.5
       parent: 2
-  - uid: 6257
+  - uid: 3293
     components:
     - type: Transform
       pos: -5.5,7.5
       parent: 2
-  - uid: 6258
+  - uid: 3294
     components:
     - type: Transform
       pos: -37.5,-23.5
       parent: 2
-  - uid: 6263
+  - uid: 3295
     components:
     - type: Transform
       pos: 0.5,-1.5
       parent: 2
-  - uid: 6265
+  - uid: 3296
     components:
     - type: Transform
       pos: -65.5,2.5
       parent: 2
-  - uid: 6266
+  - uid: 3297
     components:
     - type: Transform
       pos: -60.5,0.5
       parent: 2
-  - uid: 6268
+  - uid: 3298
     components:
     - type: Transform
       pos: -30.5,-29.5
       parent: 2
-  - uid: 6269
+  - uid: 3299
     components:
     - type: Transform
       pos: -59.5,2.5
       parent: 2
-  - uid: 6270
+  - uid: 3300
     components:
     - type: Transform
       pos: -11.5,6.5
       parent: 2
-  - uid: 6271
+  - uid: 3301
     components:
     - type: Transform
       pos: -1.5,-6.5
       parent: 2
-  - uid: 6272
+  - uid: 3302
     components:
     - type: Transform
       pos: -11.5,-9.5
       parent: 2
-  - uid: 6273
+  - uid: 3303
     components:
     - type: Transform
       pos: -26.5,25.5
       parent: 2
-  - uid: 6274
+  - uid: 3304
     components:
     - type: Transform
       pos: 0.5,52.5
       parent: 2
-  - uid: 6277
+  - uid: 3305
     components:
     - type: Transform
       pos: -35.5,-21.5
       parent: 2
-  - uid: 6278
+  - uid: 3306
     components:
     - type: Transform
       pos: -62.5,-5.5
       parent: 2
-  - uid: 6279
+  - uid: 3307
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: -48.5,-13.5
       parent: 2
-  - uid: 6280
+  - uid: 3308
     components:
     - type: Transform
       pos: -10.5,10.5
       parent: 2
-  - uid: 6282
+  - uid: 3309
     components:
     - type: Transform
       pos: -3.5,1.5
       parent: 2
-  - uid: 6288
+  - uid: 3310
     components:
     - type: Transform
       pos: -58.5,-4.5
       parent: 2
-  - uid: 6290
+  - uid: 3311
     components:
     - type: Transform
       pos: -70.5,-5.5
       parent: 2
-  - uid: 6292
+  - uid: 3312
     components:
     - type: Transform
       pos: -49.5,-6.5
       parent: 2
-  - uid: 6293
+  - uid: 3313
     components:
     - type: Transform
       pos: 1.5,48.5
       parent: 2
-  - uid: 6297
+  - uid: 3314
     components:
     - type: Transform
       pos: -37.5,-25.5
       parent: 2
-  - uid: 6299
+  - uid: 3315
     components:
     - type: Transform
       pos: -42.5,43.5
       parent: 2
-  - uid: 6301
+  - uid: 3316
     components:
     - type: Transform
       pos: -50.5,-5.5
       parent: 2
-  - uid: 6302
+  - uid: 3317
     components:
     - type: Transform
       pos: -10.5,-7.5
       parent: 2
-  - uid: 6304
+  - uid: 3318
     components:
     - type: Transform
       pos: -32.5,26.5
       parent: 2
-  - uid: 6305
+  - uid: 3319
     components:
     - type: Transform
       pos: -50.5,40.5
       parent: 2
-  - uid: 6306
+  - uid: 3320
     components:
     - type: Transform
       pos: 15.5,6.5
       parent: 2
-  - uid: 6307
+  - uid: 3321
     components:
     - type: Transform
       pos: -44.5,13.5
       parent: 2
-  - uid: 6308
+  - uid: 3322
     components:
     - type: Transform
       pos: -59.5,12.5
       parent: 2
-  - uid: 6309
+  - uid: 3323
     components:
     - type: Transform
       pos: -32.5,-10.5
       parent: 2
-  - uid: 6310
+  - uid: 3324
     components:
     - type: Transform
       pos: -62.5,-8.5
       parent: 2
-  - uid: 6311
+  - uid: 3325
     components:
     - type: Transform
       pos: -7.5,-1.5
       parent: 2
-  - uid: 6314
+  - uid: 3326
     components:
     - type: Transform
       pos: -47.5,-12.5
       parent: 2
-  - uid: 6316
+  - uid: 3327
     components:
     - type: Transform
       pos: -29.5,-8.5
       parent: 2
-  - uid: 6317
+  - uid: 3328
     components:
     - type: Transform
       pos: -50.5,-21.5
       parent: 2
-  - uid: 6321
+  - uid: 3329
     components:
     - type: Transform
       pos: -45.5,-15.5
       parent: 2
-  - uid: 6324
+  - uid: 3330
     components:
     - type: Transform
       pos: -4.5,2.5
       parent: 2
-  - uid: 6325
+  - uid: 3331
     components:
     - type: Transform
       pos: -30.5,-31.5
       parent: 2
-  - uid: 6326
+  - uid: 3332
     components:
     - type: Transform
       pos: -45.5,11.5
       parent: 2
-  - uid: 6327
+  - uid: 3333
     components:
     - type: Transform
       pos: -31.5,-32.5
       parent: 2
-  - uid: 6328
+  - uid: 3334
     components:
     - type: Transform
       pos: -56.5,6.5
       parent: 2
-  - uid: 6330
+  - uid: 3335
     components:
     - type: Transform
       pos: -12.5,-8.5
       parent: 2
-  - uid: 6332
+  - uid: 3336
     components:
     - type: Transform
       pos: -37.5,-22.5
       parent: 2
-  - uid: 6334
+  - uid: 3337
     components:
     - type: Transform
       pos: -57.5,-5.5
       parent: 2
-  - uid: 6335
+  - uid: 3338
     components:
     - type: Transform
       pos: -23.5,27.5
       parent: 2
-  - uid: 6336
+  - uid: 3339
     components:
     - type: Transform
       pos: -11.5,-8.5
       parent: 2
-  - uid: 6338
+  - uid: 3340
     components:
     - type: Transform
       pos: -62.5,5.5
       parent: 2
-  - uid: 6339
+  - uid: 3341
     components:
     - type: Transform
       pos: -34.5,-21.5
       parent: 2
-  - uid: 6340
+  - uid: 3342
     components:
     - type: Transform
       pos: -9.5,-10.5
       parent: 2
-  - uid: 6341
+  - uid: 3343
     components:
     - type: Transform
       pos: -43.5,44.5
       parent: 2
-  - uid: 6342
+  - uid: 3344
     components:
     - type: Transform
       pos: -58.5,2.5
       parent: 2
-  - uid: 6346
+  - uid: 3345
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: -46.5,-14.5
       parent: 2
-  - uid: 6347
+  - uid: 3346
     components:
     - type: Transform
       pos: -67.5,-0.5
       parent: 2
-  - uid: 6348
+  - uid: 3347
     components:
     - type: Transform
       pos: -55.5,10.5
       parent: 2
-  - uid: 6349
+  - uid: 3348
     components:
     - type: Transform
       pos: -57.5,1.5
       parent: 2
-  - uid: 6350
+  - uid: 3349
     components:
     - type: Transform
       pos: -34.5,25.5
       parent: 2
-  - uid: 6351
+  - uid: 3350
     components:
     - type: Transform
       pos: -23.5,-25.5
       parent: 2
-  - uid: 6352
+  - uid: 3351
     components:
     - type: Transform
       pos: -51.5,-19.5
       parent: 2
-  - uid: 6354
+  - uid: 3352
     components:
     - type: Transform
       pos: 8.5,8.5
       parent: 2
-  - uid: 6358
+  - uid: 3353
     components:
     - type: Transform
       pos: -37.5,-21.5
       parent: 2
-  - uid: 6359
+  - uid: 3354
     components:
     - type: Transform
       pos: 13.5,10.5
       parent: 2
-  - uid: 6361
+  - uid: 3355
     components:
     - type: Transform
       pos: 14.5,7.5
       parent: 2
-  - uid: 6363
+  - uid: 3356
     components:
     - type: Transform
       pos: -30.5,-30.5
       parent: 2
-  - uid: 6364
+  - uid: 3357
     components:
     - type: Transform
       pos: -6.5,0.5
       parent: 2
-  - uid: 6365
+  - uid: 3358
     components:
     - type: Transform
       pos: -61.5,4.5
       parent: 2
-  - uid: 6366
+  - uid: 3359
     components:
     - type: Transform
       pos: -30.5,23.5
       parent: 2
-  - uid: 6368
+  - uid: 3360
     components:
     - type: Transform
       pos: -33.5,-21.5
       parent: 2
-  - uid: 6369
+  - uid: 3361
     components:
     - type: Transform
       pos: -30.5,32.5
       parent: 2
-  - uid: 6372
+  - uid: 3362
     components:
     - type: Transform
       pos: 2.5,47.5
       parent: 2
-  - uid: 6373
+  - uid: 3363
     components:
     - type: Transform
       pos: -20.5,28.5
       parent: 2
-  - uid: 6374
+  - uid: 3364
     components:
     - type: Transform
       pos: -23.5,-24.5
       parent: 2
-  - uid: 6375
+  - uid: 3365
     components:
     - type: Transform
       pos: -53.5,-28.5
       parent: 2
-  - uid: 6376
+  - uid: 3366
     components:
     - type: Transform
       pos: -13.5,-0.5
       parent: 2
-  - uid: 6379
+  - uid: 3367
     components:
     - type: Transform
       pos: -65.5,-5.5
       parent: 2
-  - uid: 6380
+  - uid: 3368
     components:
     - type: Transform
       pos: -61.5,9.5
       parent: 2
-  - uid: 6381
+  - uid: 3369
     components:
     - type: Transform
       pos: -50.5,9.5
       parent: 2
-  - uid: 6383
+  - uid: 3370
     components:
     - type: Transform
       pos: -24.5,-26.5
       parent: 2
-  - uid: 6384
+  - uid: 3371
     components:
     - type: Transform
       pos: -31.5,-9.5
       parent: 2
-  - uid: 6385
+  - uid: 3372
     components:
     - type: Transform
       pos: -67.5,-1.5
       parent: 2
-  - uid: 6387
+  - uid: 3373
     components:
     - type: Transform
       pos: -58.5,1.5
       parent: 2
-  - uid: 6388
+  - uid: 3374
     components:
     - type: Transform
       pos: -36.5,25.5
       parent: 2
-  - uid: 6389
+  - uid: 3375
     components:
     - type: Transform
       pos: -58.5,12.5
       parent: 2
-  - uid: 6391
+  - uid: 3376
     components:
     - type: Transform
       pos: -22.5,-26.5
       parent: 2
-  - uid: 6392
+  - uid: 3377
     components:
     - type: Transform
       pos: -8.5,8.5
       parent: 2
-  - uid: 6393
+  - uid: 3378
     components:
     - type: Transform
       pos: -45.5,-0.5
       parent: 2
-  - uid: 6394
+  - uid: 3379
     components:
     - type: Transform
       pos: -44.5,43.5
       parent: 2
-  - uid: 6395
+  - uid: 3380
     components:
     - type: Transform
       pos: 18.5,1.5
       parent: 2
-  - uid: 6396
+  - uid: 3381
     components:
     - type: Transform
       pos: 0.5,-7.5
       parent: 2
-  - uid: 6398
+  - uid: 3382
     components:
     - type: Transform
       pos: -65.5,7.5
       parent: 2
-  - uid: 6399
+  - uid: 3383
     components:
     - type: Transform
       pos: -61.5,7.5
       parent: 2
-  - uid: 6400
+  - uid: 3384
     components:
     - type: Transform
       pos: -65.5,-21.5
       parent: 2
-  - uid: 6403
+  - uid: 3385
     components:
     - type: Transform
       pos: 2.5,48.5
       parent: 2
-  - uid: 6404
+  - uid: 3386
     components:
     - type: Transform
       pos: -34.5,23.5
       parent: 2
-  - uid: 6405
+  - uid: 3387
     components:
     - type: Transform
       pos: -11.5,10.5
       parent: 2
-  - uid: 6406
+  - uid: 3388
     components:
     - type: Transform
       pos: -43.5,-0.5
       parent: 2
-  - uid: 6407
+  - uid: 3389
     components:
     - type: Transform
       pos: -61.5,-9.5
       parent: 2
-  - uid: 6408
+  - uid: 3390
     components:
     - type: Transform
       pos: 14.5,9.5
       parent: 2
-  - uid: 6409
+  - uid: 3391
     components:
     - type: Transform
       pos: -36.5,36.5
       parent: 2
-  - uid: 6411
+  - uid: 3392
     components:
     - type: Transform
       pos: 11.5,8.5
       parent: 2
-  - uid: 6415
+  - uid: 3393
     components:
     - type: Transform
       pos: -9.5,8.5
       parent: 2
-  - uid: 6419
+  - uid: 3394
     components:
     - type: Transform
       pos: 2.5,-0.5
       parent: 2
-  - uid: 6422
+  - uid: 3395
     components:
     - type: Transform
       pos: -26.5,45.5
       parent: 2
-  - uid: 6423
+  - uid: 3396
     components:
     - type: Transform
       pos: -25.5,-26.5
       parent: 2
-  - uid: 6425
+  - uid: 3397
     components:
     - type: Transform
       pos: 16.5,-4.5
       parent: 2
-  - uid: 6426
+  - uid: 3398
     components:
     - type: Transform
       pos: 1.5,-1.5
       parent: 2
-  - uid: 6427
+  - uid: 3399
     components:
     - type: Transform
       pos: -36.5,24.5
       parent: 2
-  - uid: 6428
+  - uid: 3400
     components:
     - type: Transform
       pos: -58.5,-8.5
       parent: 2
-  - uid: 6429
+  - uid: 3401
     components:
     - type: Transform
       pos: 12.5,10.5
       parent: 2
-  - uid: 6430
+  - uid: 3402
     components:
     - type: Transform
       pos: -10.5,12.5
       parent: 2
-  - uid: 6431
+  - uid: 3403
     components:
     - type: Transform
       pos: -1.5,49.5
       parent: 2
-  - uid: 6434
+  - uid: 3404
     components:
     - type: Transform
       pos: -51.5,-7.5
       parent: 2
-  - uid: 6435
+  - uid: 3405
     components:
     - type: Transform
       pos: -17.5,1.5
       parent: 2
-  - uid: 6437
+  - uid: 3406
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: -47.5,-13.5
       parent: 2
-  - uid: 6440
+  - uid: 3407
     components:
     - type: Transform
       pos: -12.5,-4.5
       parent: 2
-  - uid: 6442
+  - uid: 3408
     components:
     - type: Transform
       pos: -11.5,0.5
       parent: 2
-  - uid: 6443
+  - uid: 3409
     components:
     - type: Transform
       pos: -14.5,0.5
       parent: 2
-  - uid: 6444
+  - uid: 3410
     components:
     - type: Transform
       pos: 0.5,-9.5
       parent: 2
-  - uid: 6445
+  - uid: 3411
     components:
     - type: Transform
       pos: -15.5,-0.5
       parent: 2
-  - uid: 6446
+  - uid: 3412
     components:
     - type: Transform
       pos: 1.5,14.5
       parent: 2
 - proto: AtmosFixBlockerMarker
   entities:
-  - uid: 3111
+  - uid: 3413
     components:
     - type: Transform
       pos: -8.5,41.5
       parent: 2
-  - uid: 3112
+  - uid: 3414
     components:
     - type: Transform
       pos: -70.5,-2.5
       parent: 2
-  - uid: 3113
+  - uid: 3415
     components:
     - type: Transform
       pos: -70.5,-3.5
       parent: 2
-  - uid: 3114
+  - uid: 3416
     components:
     - type: Transform
       pos: -69.5,-2.5
       parent: 2
-  - uid: 3115
+  - uid: 3417
     components:
     - type: Transform
       pos: -69.5,-3.5
       parent: 2
-  - uid: 3116
+  - uid: 3418
     components:
     - type: Transform
       pos: -68.5,-3.5
       parent: 2
-  - uid: 3117
+  - uid: 3419
     components:
     - type: Transform
       pos: -67.5,-2.5
       parent: 2
-  - uid: 3118
+  - uid: 3420
     components:
     - type: Transform
       pos: -67.5,-3.5
       parent: 2
-  - uid: 3119
+  - uid: 3421
     components:
     - type: Transform
       pos: -66.5,-2.5
       parent: 2
-  - uid: 3120
+  - uid: 3422
     components:
     - type: Transform
       pos: -66.5,-3.5
       parent: 2
-  - uid: 3121
+  - uid: 3423
     components:
     - type: Transform
       pos: -65.5,-2.5
       parent: 2
-  - uid: 3122
+  - uid: 3424
     components:
     - type: Transform
       pos: -65.5,-3.5
       parent: 2
-  - uid: 3123
+  - uid: 3425
     components:
     - type: Transform
       pos: -64.5,-2.5
       parent: 2
-  - uid: 3124
+  - uid: 3426
     components:
     - type: Transform
       pos: -64.5,-3.5
       parent: 2
-  - uid: 3125
+  - uid: 3427
     components:
     - type: Transform
       pos: -68.5,-2.5
       parent: 2
-  - uid: 3126
+  - uid: 3428
     components:
     - type: Transform
       pos: -63.5,-2.5
       parent: 2
-  - uid: 3127
+  - uid: 3429
     components:
     - type: Transform
       pos: -62.5,-2.5
       parent: 2
-  - uid: 3128
+  - uid: 3430
     components:
     - type: Transform
       pos: -62.5,-3.5
       parent: 2
-  - uid: 3129
+  - uid: 3431
     components:
     - type: Transform
       pos: -63.5,-3.5
       parent: 2
-  - uid: 3130
+  - uid: 3432
     components:
     - type: Transform
       pos: -61.5,-2.5
       parent: 2
-  - uid: 3131
+  - uid: 3433
     components:
     - type: Transform
       pos: -61.5,-3.5
       parent: 2
-  - uid: 3132
+  - uid: 3434
     components:
     - type: Transform
       pos: -60.5,-3.5
       parent: 2
-  - uid: 3133
+  - uid: 3435
     components:
     - type: Transform
       pos: -59.5,-2.5
       parent: 2
-  - uid: 3134
+  - uid: 3436
     components:
     - type: Transform
       pos: -58.5,-2.5
       parent: 2
-  - uid: 3135
+  - uid: 3437
     components:
     - type: Transform
       pos: -60.5,-2.5
       parent: 2
-  - uid: 3136
+  - uid: 3438
     components:
     - type: Transform
       pos: -57.5,-2.5
       parent: 2
-  - uid: 3137
+  - uid: 3439
     components:
     - type: Transform
       pos: -56.5,-2.5
       parent: 2
-  - uid: 3138
+  - uid: 3440
     components:
     - type: Transform
       pos: -57.5,-3.5
       parent: 2
-  - uid: 3139
+  - uid: 3441
     components:
     - type: Transform
       pos: -58.5,-3.5
       parent: 2
-  - uid: 3140
+  - uid: 3442
     components:
     - type: Transform
       pos: -56.5,-3.5
       parent: 2
-  - uid: 3141
+  - uid: 3443
     components:
     - type: Transform
       pos: -55.5,-2.5
       parent: 2
-  - uid: 3142
+  - uid: 3444
     components:
     - type: Transform
       pos: -59.5,-3.5
       parent: 2
-  - uid: 3143
+  - uid: 3445
     components:
     - type: Transform
       pos: -55.5,-3.5
       parent: 2
-  - uid: 3144
+  - uid: 3446
     components:
     - type: Transform
       pos: -54.5,-2.5
       parent: 2
-  - uid: 3145
+  - uid: 3447
     components:
     - type: Transform
       pos: -53.5,-2.5
       parent: 2
-  - uid: 3146
+  - uid: 3448
     components:
     - type: Transform
       pos: -53.5,-3.5
       parent: 2
-  - uid: 3147
+  - uid: 3449
     components:
     - type: Transform
       pos: -52.5,-2.5
       parent: 2
-  - uid: 3148
+  - uid: 3450
     components:
     - type: Transform
       pos: -52.5,-3.5
       parent: 2
-  - uid: 3149
+  - uid: 3451
     components:
     - type: Transform
       pos: -54.5,-3.5
       parent: 2
-  - uid: 3150
+  - uid: 3452
     components:
     - type: Transform
       pos: -51.5,-3.5
       parent: 2
-  - uid: 3151
+  - uid: 3453
     components:
     - type: Transform
       pos: -50.5,-2.5
       parent: 2
-  - uid: 3152
+  - uid: 3454
     components:
     - type: Transform
       pos: -51.5,-2.5
       parent: 2
-  - uid: 3153
+  - uid: 3455
     components:
     - type: Transform
       pos: -49.5,-2.5
       parent: 2
-  - uid: 3154
+  - uid: 3456
     components:
     - type: Transform
       pos: -49.5,-3.5
       parent: 2
-  - uid: 3155
+  - uid: 3457
     components:
     - type: Transform
       pos: -48.5,-2.5
       parent: 2
-  - uid: 3156
+  - uid: 3458
     components:
     - type: Transform
       pos: -48.5,-3.5
       parent: 2
-  - uid: 3157
+  - uid: 3459
     components:
     - type: Transform
       pos: -47.5,-2.5
       parent: 2
-  - uid: 3158
+  - uid: 3460
     components:
     - type: Transform
       pos: -47.5,-3.5
       parent: 2
-  - uid: 3159
+  - uid: 3461
     components:
     - type: Transform
       pos: -46.5,-2.5
       parent: 2
-  - uid: 3160
+  - uid: 3462
     components:
     - type: Transform
       pos: -50.5,-3.5
       parent: 2
-  - uid: 3161
+  - uid: 3463
     components:
     - type: Transform
       pos: -46.5,-3.5
       parent: 2
-  - uid: 3162
+  - uid: 3464
     components:
     - type: Transform
       pos: -45.5,-2.5
       parent: 2
-  - uid: 3163
+  - uid: 3465
     components:
     - type: Transform
       pos: -45.5,-3.5
       parent: 2
-  - uid: 3164
+  - uid: 3466
     components:
     - type: Transform
       pos: -44.5,-2.5
       parent: 2
-  - uid: 3165
+  - uid: 3467
     components:
     - type: Transform
       pos: -44.5,-3.5
       parent: 2
-  - uid: 3166
+  - uid: 3468
     components:
     - type: Transform
       pos: -43.5,-3.5
       parent: 2
-  - uid: 3167
+  - uid: 3469
     components:
     - type: Transform
       pos: -42.5,-2.5
       parent: 2
-  - uid: 3168
+  - uid: 3470
     components:
     - type: Transform
       pos: -42.5,-3.5
       parent: 2
-  - uid: 3169
+  - uid: 3471
     components:
     - type: Transform
       pos: -41.5,-2.5
       parent: 2
-  - uid: 3170
+  - uid: 3472
     components:
     - type: Transform
       pos: -41.5,-3.5
       parent: 2
-  - uid: 3171
+  - uid: 3473
     components:
     - type: Transform
       pos: -40.5,-2.5
       parent: 2
-  - uid: 3172
+  - uid: 3474
     components:
     - type: Transform
       pos: -40.5,-3.5
       parent: 2
-  - uid: 3173
+  - uid: 3475
     components:
     - type: Transform
       pos: -39.5,-2.5
       parent: 2
-  - uid: 3174
+  - uid: 3476
     components:
     - type: Transform
       pos: -39.5,-3.5
       parent: 2
-  - uid: 3175
+  - uid: 3477
     components:
     - type: Transform
       pos: -38.5,-2.5
       parent: 2
-  - uid: 3176
+  - uid: 3478
     components:
     - type: Transform
       pos: -38.5,-3.5
       parent: 2
-  - uid: 3177
+  - uid: 3479
     components:
     - type: Transform
       pos: -43.5,-2.5
       parent: 2
-  - uid: 3178
+  - uid: 3480
     components:
     - type: Transform
       pos: -36.5,-2.5
       parent: 2
-  - uid: 3179
+  - uid: 3481
     components:
     - type: Transform
       pos: -35.5,-2.5
       parent: 2
-  - uid: 3180
+  - uid: 3482
     components:
     - type: Transform
       pos: -37.5,-2.5
       parent: 2
-  - uid: 3181
+  - uid: 3483
     components:
     - type: Transform
       pos: -37.5,-3.5
       parent: 2
-  - uid: 3182
+  - uid: 3484
     components:
     - type: Transform
       pos: -34.5,-3.5
       parent: 2
-  - uid: 3183
+  - uid: 3485
     components:
     - type: Transform
       pos: -33.5,-2.5
       parent: 2
-  - uid: 3184
+  - uid: 3486
     components:
     - type: Transform
       pos: -36.5,-3.5
       parent: 2
-  - uid: 3185
+  - uid: 3487
     components:
     - type: Transform
       pos: -33.5,-3.5
       parent: 2
-  - uid: 3186
+  - uid: 3488
     components:
     - type: Transform
       pos: -31.5,-2.5
       parent: 2
-  - uid: 3187
+  - uid: 3489
     components:
     - type: Transform
       pos: -31.5,-3.5
       parent: 2
-  - uid: 3188
+  - uid: 3490
     components:
     - type: Transform
       pos: -30.5,-2.5
       parent: 2
-  - uid: 3189
+  - uid: 3491
     components:
     - type: Transform
       pos: -30.5,-3.5
       parent: 2
-  - uid: 3190
+  - uid: 3492
     components:
     - type: Transform
       pos: -32.5,-3.5
       parent: 2
-  - uid: 3191
+  - uid: 3493
     components:
     - type: Transform
       pos: -29.5,-3.5
       parent: 2
-  - uid: 3192
+  - uid: 3494
     components:
     - type: Transform
       pos: -28.5,-2.5
       parent: 2
-  - uid: 3193
+  - uid: 3495
     components:
     - type: Transform
       pos: -35.5,-3.5
       parent: 2
-  - uid: 3194
+  - uid: 3496
     components:
     - type: Transform
       pos: -28.5,-3.5
       parent: 2
-  - uid: 3195
+  - uid: 3497
     components:
     - type: Transform
       pos: -32.5,-2.5
       parent: 2
-  - uid: 3196
+  - uid: 3498
     components:
     - type: Transform
       pos: -26.5,-2.5
       parent: 2
-  - uid: 3197
+  - uid: 3499
     components:
     - type: Transform
       pos: -26.5,-3.5
       parent: 2
-  - uid: 3198
+  - uid: 3500
     components:
     - type: Transform
       pos: -27.5,-2.5
       parent: 2
-  - uid: 3199
+  - uid: 3501
     components:
     - type: Transform
       pos: -27.5,-3.5
       parent: 2
-  - uid: 3200
+  - uid: 3502
     components:
     - type: Transform
       pos: -29.5,-2.5
       parent: 2
-  - uid: 3201
+  - uid: 3503
     components:
     - type: Transform
       pos: -34.5,-2.5
       parent: 2
-  - uid: 3202
+  - uid: 3504
     components:
     - type: Transform
       pos: -38.5,-1.5
       parent: 2
-  - uid: 3203
+  - uid: 3505
     components:
     - type: Transform
       pos: -38.5,0.5
       parent: 2
-  - uid: 3204
+  - uid: 3506
     components:
     - type: Transform
       pos: -38.5,1.5
       parent: 2
-  - uid: 3205
+  - uid: 3507
     components:
     - type: Transform
       pos: -38.5,2.5
       parent: 2
-  - uid: 3206
+  - uid: 3508
     components:
     - type: Transform
       pos: -38.5,3.5
       parent: 2
-  - uid: 3207
+  - uid: 3509
     components:
     - type: Transform
       pos: -38.5,4.5
       parent: 2
-  - uid: 3208
+  - uid: 3510
     components:
     - type: Transform
       pos: -38.5,5.5
       parent: 2
-  - uid: 3209
+  - uid: 3511
     components:
     - type: Transform
       pos: -38.5,6.5
       parent: 2
-  - uid: 3210
+  - uid: 3512
     components:
     - type: Transform
       pos: -38.5,7.5
       parent: 2
-  - uid: 3211
+  - uid: 3513
     components:
     - type: Transform
       pos: -38.5,8.5
       parent: 2
-  - uid: 3212
+  - uid: 3514
     components:
     - type: Transform
       pos: -38.5,9.5
       parent: 2
-  - uid: 3213
+  - uid: 3515
     components:
     - type: Transform
       pos: -38.5,-0.5
       parent: 2
-  - uid: 3214
+  - uid: 3516
     components:
     - type: Transform
       pos: -39.5,-0.5
       parent: 2
-  - uid: 3215
+  - uid: 3517
     components:
     - type: Transform
       pos: -38.5,10.5
       parent: 2
-  - uid: 3216
+  - uid: 3518
     components:
     - type: Transform
       pos: -39.5,0.5
       parent: 2
-  - uid: 3217
+  - uid: 3519
     components:
     - type: Transform
       pos: -39.5,1.5
       parent: 2
-  - uid: 3218
+  - uid: 3520
     components:
     - type: Transform
       pos: -39.5,2.5
       parent: 2
-  - uid: 3219
+  - uid: 3521
     components:
     - type: Transform
       pos: -39.5,-1.5
       parent: 2
-  - uid: 3220
+  - uid: 3522
     components:
     - type: Transform
       pos: -39.5,4.5
       parent: 2
-  - uid: 3221
+  - uid: 3523
     components:
     - type: Transform
       pos: -39.5,5.5
       parent: 2
-  - uid: 3222
+  - uid: 3524
     components:
     - type: Transform
       pos: -39.5,3.5
       parent: 2
-  - uid: 3223
+  - uid: 3525
     components:
     - type: Transform
       pos: -39.5,7.5
       parent: 2
-  - uid: 3224
+  - uid: 3526
     components:
     - type: Transform
       pos: -39.5,8.5
       parent: 2
-  - uid: 3225
+  - uid: 3527
     components:
     - type: Transform
       pos: -39.5,9.5
       parent: 2
-  - uid: 3226
+  - uid: 3528
     components:
     - type: Transform
       pos: -39.5,10.5
       parent: 2
-  - uid: 3227
+  - uid: 3529
     components:
     - type: Transform
       pos: -39.5,6.5
       parent: 2
-  - uid: 3228
+  - uid: 3530
     components:
     - type: Transform
       pos: -39.5,-4.5
       parent: 2
-  - uid: 3229
+  - uid: 3531
     components:
     - type: Transform
       pos: -39.5,-5.5
       parent: 2
-  - uid: 3230
+  - uid: 3532
     components:
     - type: Transform
       pos: -39.5,-6.5
       parent: 2
-  - uid: 3231
+  - uid: 3533
     components:
     - type: Transform
       pos: -39.5,-7.5
       parent: 2
-  - uid: 3232
+  - uid: 3534
     components:
     - type: Transform
       pos: -39.5,-10.5
       parent: 2
-  - uid: 3233
+  - uid: 3535
     components:
     - type: Transform
       pos: -39.5,-9.5
       parent: 2
-  - uid: 3234
+  - uid: 3536
     components:
     - type: Transform
       pos: -39.5,-11.5
       parent: 2
-  - uid: 3235
+  - uid: 3537
     components:
     - type: Transform
       pos: -39.5,-12.5
       parent: 2
-  - uid: 3236
+  - uid: 3538
     components:
     - type: Transform
       pos: -39.5,-13.5
       parent: 2
-  - uid: 3237
+  - uid: 3539
     components:
     - type: Transform
       pos: -39.5,-14.5
       parent: 2
-  - uid: 3238
+  - uid: 3540
     components:
     - type: Transform
       pos: -39.5,-15.5
       parent: 2
-  - uid: 3239
+  - uid: 3541
     components:
     - type: Transform
       pos: -39.5,-16.5
       parent: 2
-  - uid: 3240
+  - uid: 3542
     components:
     - type: Transform
       pos: -39.5,-17.5
       parent: 2
-  - uid: 3241
+  - uid: 3543
     components:
     - type: Transform
       pos: -39.5,-18.5
       parent: 2
-  - uid: 3242
+  - uid: 3544
     components:
     - type: Transform
       pos: -39.5,-19.5
       parent: 2
-  - uid: 3243
+  - uid: 3545
     components:
     - type: Transform
       pos: -39.5,-20.5
       parent: 2
-  - uid: 3244
+  - uid: 3546
     components:
     - type: Transform
       pos: -39.5,-21.5
       parent: 2
-  - uid: 3245
+  - uid: 3547
     components:
     - type: Transform
       pos: -39.5,-8.5
       parent: 2
-  - uid: 3246
+  - uid: 3548
     components:
     - type: Transform
       pos: -39.5,-23.5
       parent: 2
-  - uid: 3247
+  - uid: 3549
     components:
     - type: Transform
       pos: -39.5,-24.5
       parent: 2
-  - uid: 3248
+  - uid: 3550
     components:
     - type: Transform
       pos: -39.5,-25.5
       parent: 2
-  - uid: 3249
+  - uid: 3551
     components:
     - type: Transform
       pos: -39.5,-26.5
       parent: 2
-  - uid: 3250
+  - uid: 3552
     components:
     - type: Transform
       pos: -39.5,-27.5
       parent: 2
-  - uid: 3251
+  - uid: 3553
     components:
     - type: Transform
       pos: -39.5,-28.5
       parent: 2
-  - uid: 3252
+  - uid: 3554
     components:
     - type: Transform
       pos: -39.5,-29.5
       parent: 2
-  - uid: 3253
+  - uid: 3555
     components:
     - type: Transform
       pos: -39.5,-22.5
       parent: 2
-  - uid: 3254
+  - uid: 3556
     components:
     - type: Transform
       pos: -39.5,-30.5
       parent: 2
-  - uid: 3255
+  - uid: 3557
     components:
     - type: Transform
       pos: -39.5,-31.5
       parent: 2
-  - uid: 3256
+  - uid: 3558
     components:
     - type: Transform
       pos: -39.5,-32.5
       parent: 2
-  - uid: 3257
+  - uid: 3559
     components:
     - type: Transform
       pos: -39.5,-33.5
       parent: 2
-  - uid: 3258
+  - uid: 3560
     components:
     - type: Transform
       pos: -39.5,-34.5
       parent: 2
-  - uid: 3259
+  - uid: 3561
     components:
     - type: Transform
       pos: -38.5,-4.5
       parent: 2
-  - uid: 3260
+  - uid: 3562
     components:
     - type: Transform
       pos: -38.5,-5.5
       parent: 2
-  - uid: 3261
+  - uid: 3563
     components:
     - type: Transform
       pos: -38.5,-7.5
       parent: 2
-  - uid: 3262
+  - uid: 3564
     components:
     - type: Transform
       pos: -38.5,-8.5
       parent: 2
-  - uid: 3263
+  - uid: 3565
     components:
     - type: Transform
       pos: -38.5,-9.5
       parent: 2
-  - uid: 3264
+  - uid: 3566
     components:
     - type: Transform
       pos: -38.5,-11.5
       parent: 2
-  - uid: 3265
+  - uid: 3567
     components:
     - type: Transform
       pos: -38.5,-6.5
       parent: 2
-  - uid: 3266
+  - uid: 3568
     components:
     - type: Transform
       pos: -38.5,-12.5
       parent: 2
-  - uid: 3267
+  - uid: 3569
     components:
     - type: Transform
       pos: -38.5,-13.5
       parent: 2
-  - uid: 3268
+  - uid: 3570
     components:
     - type: Transform
       pos: -38.5,-14.5
       parent: 2
-  - uid: 3269
+  - uid: 3571
     components:
     - type: Transform
       pos: -38.5,-16.5
       parent: 2
-  - uid: 3270
+  - uid: 3572
     components:
     - type: Transform
       pos: -38.5,-17.5
       parent: 2
-  - uid: 3271
+  - uid: 3573
     components:
     - type: Transform
       pos: -38.5,-18.5
       parent: 2
-  - uid: 3272
+  - uid: 3574
     components:
     - type: Transform
       pos: -38.5,-15.5
       parent: 2
-  - uid: 3273
+  - uid: 3575
     components:
     - type: Transform
       pos: -38.5,-20.5
       parent: 2
-  - uid: 3274
+  - uid: 3576
     components:
     - type: Transform
       pos: -38.5,-19.5
       parent: 2
-  - uid: 3275
+  - uid: 3577
     components:
     - type: Transform
       pos: -38.5,-21.5
       parent: 2
-  - uid: 3276
+  - uid: 3578
     components:
     - type: Transform
       pos: -38.5,-23.5
       parent: 2
-  - uid: 3277
+  - uid: 3579
     components:
     - type: Transform
       pos: -38.5,-24.5
       parent: 2
-  - uid: 3278
+  - uid: 3580
     components:
     - type: Transform
       pos: -38.5,-25.5
       parent: 2
-  - uid: 3279
+  - uid: 3581
     components:
     - type: Transform
       pos: -38.5,-26.5
       parent: 2
-  - uid: 3280
+  - uid: 3582
     components:
     - type: Transform
       pos: -38.5,-10.5
       parent: 2
-  - uid: 3281
+  - uid: 3583
     components:
     - type: Transform
       pos: -38.5,-28.5
       parent: 2
-  - uid: 3282
+  - uid: 3584
     components:
     - type: Transform
       pos: -38.5,-27.5
       parent: 2
-  - uid: 3283
+  - uid: 3585
     components:
     - type: Transform
       pos: -38.5,-29.5
       parent: 2
-  - uid: 3284
+  - uid: 3586
     components:
     - type: Transform
       pos: -38.5,-31.5
       parent: 2
-  - uid: 3285
+  - uid: 3587
     components:
     - type: Transform
       pos: -38.5,-30.5
       parent: 2
-  - uid: 3286
+  - uid: 3588
     components:
     - type: Transform
       pos: -38.5,-32.5
       parent: 2
-  - uid: 3287
+  - uid: 3589
     components:
     - type: Transform
       pos: -38.5,-33.5
       parent: 2
-  - uid: 3288
+  - uid: 3590
     components:
     - type: Transform
       pos: -38.5,-22.5
       parent: 2
-  - uid: 3289
+  - uid: 3591
     components:
     - type: Transform
       pos: -38.5,-34.5
       parent: 2
-  - uid: 3290
+  - uid: 3592
     components:
     - type: Transform
       pos: -60.5,-4.5
       parent: 2
-  - uid: 3291
+  - uid: 3593
     components:
     - type: Transform
       pos: -60.5,-6.5
       parent: 2
-  - uid: 3292
+  - uid: 3594
     components:
     - type: Transform
       pos: -60.5,-7.5
       parent: 2
-  - uid: 3293
+  - uid: 3595
     components:
     - type: Transform
       pos: -60.5,-8.5
       parent: 2
-  - uid: 3294
+  - uid: 3596
     components:
     - type: Transform
       pos: -60.5,-5.5
       parent: 2
-  - uid: 3295
+  - uid: 3597
     components:
     - type: Transform
       pos: -60.5,-9.5
       parent: 2
-  - uid: 3296
+  - uid: 3598
     components:
     - type: Transform
       pos: -60.5,-10.5
       parent: 2
-  - uid: 3297
+  - uid: 3599
     components:
     - type: Transform
       pos: -60.5,-11.5
       parent: 2
-  - uid: 3298
+  - uid: 3600
     components:
     - type: Transform
       pos: -60.5,-13.5
       parent: 2
-  - uid: 3299
+  - uid: 3601
     components:
     - type: Transform
       pos: -60.5,-12.5
       parent: 2
-  - uid: 3300
+  - uid: 3602
     components:
     - type: Transform
       pos: -60.5,-14.5
       parent: 2
-  - uid: 3301
+  - uid: 3603
     components:
     - type: Transform
       pos: -60.5,-15.5
       parent: 2
-  - uid: 3302
+  - uid: 3604
     components:
     - type: Transform
       pos: -60.5,-16.5
       parent: 2
-  - uid: 3303
+  - uid: 3605
     components:
     - type: Transform
       pos: -60.5,-19.5
       parent: 2
-  - uid: 3304
+  - uid: 3606
     components:
     - type: Transform
       pos: -60.5,-17.5
       parent: 2
-  - uid: 3305
+  - uid: 3607
     components:
     - type: Transform
       pos: -60.5,-18.5
       parent: 2
-  - uid: 3306
+  - uid: 3608
     components:
     - type: Transform
       pos: -60.5,-20.5
       parent: 2
-  - uid: 3307
+  - uid: 3609
     components:
     - type: Transform
       pos: -60.5,-22.5
       parent: 2
-  - uid: 3308
+  - uid: 3610
     components:
     - type: Transform
       pos: -60.5,-23.5
       parent: 2
-  - uid: 3309
+  - uid: 3611
     components:
     - type: Transform
       pos: -60.5,-21.5
       parent: 2
-  - uid: 3310
+  - uid: 3612
     components:
     - type: Transform
       pos: -60.5,-25.5
       parent: 2
-  - uid: 3311
+  - uid: 3613
     components:
     - type: Transform
       pos: -60.5,-26.5
       parent: 2
-  - uid: 3312
+  - uid: 3614
     components:
     - type: Transform
       pos: -60.5,-24.5
       parent: 2
-  - uid: 3313
+  - uid: 3615
     components:
     - type: Transform
       pos: -60.5,-28.5
       parent: 2
-  - uid: 3314
+  - uid: 3616
     components:
     - type: Transform
       pos: -60.5,-27.5
       parent: 2
-  - uid: 3315
+  - uid: 3617
     components:
     - type: Transform
       pos: -59.5,-5.5
       parent: 2
-  - uid: 3316
+  - uid: 3618
     components:
     - type: Transform
       pos: -59.5,-8.5
       parent: 2
-  - uid: 3317
+  - uid: 3619
     components:
     - type: Transform
       pos: -59.5,-4.5
       parent: 2
-  - uid: 3318
+  - uid: 3620
     components:
     - type: Transform
       pos: -59.5,-9.5
       parent: 2
-  - uid: 3319
+  - uid: 3621
     components:
     - type: Transform
       pos: -59.5,-10.5
       parent: 2
-  - uid: 3320
+  - uid: 3622
     components:
     - type: Transform
       pos: -59.5,-11.5
       parent: 2
-  - uid: 3321
+  - uid: 3623
     components:
     - type: Transform
       pos: -59.5,-13.5
       parent: 2
-  - uid: 3322
+  - uid: 3624
     components:
     - type: Transform
       pos: -59.5,-12.5
       parent: 2
-  - uid: 3323
+  - uid: 3625
     components:
     - type: Transform
       pos: -59.5,-14.5
       parent: 2
-  - uid: 3324
+  - uid: 3626
     components:
     - type: Transform
       pos: -59.5,-17.5
       parent: 2
-  - uid: 3325
+  - uid: 3627
     components:
     - type: Transform
       pos: -59.5,-15.5
       parent: 2
-  - uid: 3326
+  - uid: 3628
     components:
     - type: Transform
       pos: -59.5,-7.5
       parent: 2
-  - uid: 3327
+  - uid: 3629
     components:
     - type: Transform
       pos: -59.5,-19.5
       parent: 2
-  - uid: 3328
+  - uid: 3630
     components:
     - type: Transform
       pos: -59.5,-21.5
       parent: 2
-  - uid: 3329
+  - uid: 3631
     components:
     - type: Transform
       pos: -59.5,-22.5
       parent: 2
-  - uid: 3330
+  - uid: 3632
     components:
     - type: Transform
       pos: -59.5,-16.5
       parent: 2
-  - uid: 3331
+  - uid: 3633
     components:
     - type: Transform
       pos: -59.5,-24.5
       parent: 2
-  - uid: 3332
+  - uid: 3634
     components:
     - type: Transform
       pos: -59.5,-23.5
       parent: 2
-  - uid: 3333
+  - uid: 3635
     components:
     - type: Transform
       pos: -59.5,-25.5
       parent: 2
-  - uid: 3334
+  - uid: 3636
     components:
     - type: Transform
       pos: -59.5,-6.5
       parent: 2
-  - uid: 3335
+  - uid: 3637
     components:
     - type: Transform
       pos: -59.5,-26.5
       parent: 2
-  - uid: 3336
+  - uid: 3638
     components:
     - type: Transform
       pos: -59.5,-28.5
       parent: 2
-  - uid: 3337
+  - uid: 3639
     components:
     - type: Transform
       pos: -59.5,-20.5
       parent: 2
-  - uid: 3338
+  - uid: 3640
     components:
     - type: Transform
       pos: -59.5,-27.5
       parent: 2
-  - uid: 3339
+  - uid: 3641
     components:
     - type: Transform
       pos: -59.5,-18.5
       parent: 2
-  - uid: 3340
+  - uid: 3642
     components:
     - type: Transform
       pos: -39.5,19.5
       parent: 2
-  - uid: 3341
+  - uid: 3643
     components:
     - type: Transform
       pos: -39.5,20.5
       parent: 2
-  - uid: 3342
+  - uid: 3644
     components:
     - type: Transform
       pos: -39.5,21.5
       parent: 2
-  - uid: 3343
+  - uid: 3645
     components:
     - type: Transform
       pos: -39.5,22.5
       parent: 2
-  - uid: 3344
+  - uid: 3646
     components:
     - type: Transform
       pos: -39.5,23.5
       parent: 2
-  - uid: 3345
+  - uid: 3647
     components:
     - type: Transform
       pos: -39.5,24.5
       parent: 2
-  - uid: 3346
+  - uid: 3648
     components:
     - type: Transform
       pos: -39.5,25.5
       parent: 2
-  - uid: 3347
+  - uid: 3649
     components:
     - type: Transform
       pos: -39.5,26.5
       parent: 2
-  - uid: 3348
+  - uid: 3650
     components:
     - type: Transform
       pos: -39.5,27.5
       parent: 2
-  - uid: 3349
+  - uid: 3651
     components:
     - type: Transform
       pos: -39.5,28.5
       parent: 2
-  - uid: 3350
+  - uid: 3652
     components:
     - type: Transform
       pos: -39.5,29.5
       parent: 2
-  - uid: 3351
+  - uid: 3653
     components:
     - type: Transform
       pos: -39.5,30.5
       parent: 2
-  - uid: 3352
+  - uid: 3654
     components:
     - type: Transform
       pos: -39.5,32.5
       parent: 2
-  - uid: 3353
+  - uid: 3655
     components:
     - type: Transform
       pos: -39.5,33.5
       parent: 2
-  - uid: 3354
+  - uid: 3656
     components:
     - type: Transform
       pos: -39.5,34.5
       parent: 2
-  - uid: 3355
+  - uid: 3657
     components:
     - type: Transform
       pos: -39.5,35.5
       parent: 2
-  - uid: 3356
+  - uid: 3658
     components:
     - type: Transform
       pos: -39.5,36.5
       parent: 2
-  - uid: 3357
+  - uid: 3659
     components:
     - type: Transform
       pos: -39.5,37.5
       parent: 2
-  - uid: 3358
+  - uid: 3660
     components:
     - type: Transform
       pos: -39.5,38.5
       parent: 2
-  - uid: 3359
+  - uid: 3661
     components:
     - type: Transform
       pos: -39.5,39.5
       parent: 2
-  - uid: 3360
+  - uid: 3662
     components:
     - type: Transform
       pos: -39.5,40.5
       parent: 2
-  - uid: 3361
+  - uid: 3663
     components:
     - type: Transform
       pos: -39.5,41.5
       parent: 2
-  - uid: 3362
+  - uid: 3664
     components:
     - type: Transform
       pos: -39.5,42.5
       parent: 2
-  - uid: 3363
+  - uid: 3665
     components:
     - type: Transform
       pos: -39.5,43.5
       parent: 2
-  - uid: 3364
+  - uid: 3666
     components:
     - type: Transform
       pos: -39.5,44.5
       parent: 2
-  - uid: 3365
+  - uid: 3667
     components:
     - type: Transform
       pos: -39.5,45.5
       parent: 2
-  - uid: 3366
+  - uid: 3668
     components:
     - type: Transform
       pos: -39.5,46.5
       parent: 2
-  - uid: 3367
+  - uid: 3669
     components:
     - type: Transform
       pos: -39.5,47.5
       parent: 2
-  - uid: 3368
+  - uid: 3670
     components:
     - type: Transform
       pos: -38.5,19.5
       parent: 2
-  - uid: 3369
+  - uid: 3671
     components:
     - type: Transform
       pos: -38.5,20.5
       parent: 2
-  - uid: 3370
+  - uid: 3672
     components:
     - type: Transform
       pos: -38.5,21.5
       parent: 2
-  - uid: 3371
+  - uid: 3673
     components:
     - type: Transform
       pos: -38.5,22.5
       parent: 2
-  - uid: 3372
+  - uid: 3674
     components:
     - type: Transform
       pos: -38.5,23.5
       parent: 2
-  - uid: 3373
+  - uid: 3675
     components:
     - type: Transform
       pos: -38.5,24.5
       parent: 2
-  - uid: 3374
+  - uid: 3676
     components:
     - type: Transform
       pos: -38.5,25.5
       parent: 2
-  - uid: 3375
+  - uid: 3677
     components:
     - type: Transform
       pos: -38.5,26.5
       parent: 2
-  - uid: 3376
+  - uid: 3678
     components:
     - type: Transform
       pos: -38.5,27.5
       parent: 2
-  - uid: 3377
+  - uid: 3679
     components:
     - type: Transform
       pos: -38.5,28.5
       parent: 2
-  - uid: 3378
+  - uid: 3680
     components:
     - type: Transform
       pos: -38.5,29.5
       parent: 2
-  - uid: 3379
+  - uid: 3681
     components:
     - type: Transform
       pos: -38.5,31.5
       parent: 2
-  - uid: 3380
+  - uid: 3682
     components:
     - type: Transform
       pos: -39.5,31.5
       parent: 2
-  - uid: 3381
+  - uid: 3683
     components:
     - type: Transform
       pos: -38.5,33.5
       parent: 2
-  - uid: 3382
+  - uid: 3684
     components:
     - type: Transform
       pos: -38.5,32.5
       parent: 2
-  - uid: 3383
+  - uid: 3685
     components:
     - type: Transform
       pos: -38.5,30.5
       parent: 2
-  - uid: 3384
+  - uid: 3686
     components:
     - type: Transform
       pos: -38.5,34.5
       parent: 2
-  - uid: 3385
+  - uid: 3687
     components:
     - type: Transform
       pos: -38.5,35.5
       parent: 2
-  - uid: 3386
+  - uid: 3688
     components:
     - type: Transform
       pos: -38.5,36.5
       parent: 2
-  - uid: 3387
+  - uid: 3689
     components:
     - type: Transform
       pos: -38.5,38.5
       parent: 2
-  - uid: 3388
+  - uid: 3690
     components:
     - type: Transform
       pos: -38.5,37.5
       parent: 2
-  - uid: 3389
+  - uid: 3691
     components:
     - type: Transform
       pos: -38.5,39.5
       parent: 2
-  - uid: 3390
+  - uid: 3692
     components:
     - type: Transform
       pos: -38.5,40.5
       parent: 2
-  - uid: 3391
+  - uid: 3693
     components:
     - type: Transform
       pos: -38.5,42.5
       parent: 2
-  - uid: 3392
+  - uid: 3694
     components:
     - type: Transform
       pos: -38.5,41.5
       parent: 2
-  - uid: 3393
+  - uid: 3695
     components:
     - type: Transform
       pos: -38.5,43.5
       parent: 2
-  - uid: 3394
+  - uid: 3696
     components:
     - type: Transform
       pos: -38.5,44.5
       parent: 2
-  - uid: 3395
+  - uid: 3697
     components:
     - type: Transform
       pos: -38.5,46.5
       parent: 2
-  - uid: 3396
+  - uid: 3698
     components:
     - type: Transform
       pos: -38.5,47.5
       parent: 2
-  - uid: 3397
+  - uid: 3699
     components:
     - type: Transform
       pos: -38.5,45.5
       parent: 2
-  - uid: 3398
+  - uid: 3700
     components:
     - type: Transform
       pos: -40.5,41.5
       parent: 2
-  - uid: 3399
+  - uid: 3701
     components:
     - type: Transform
       pos: -40.5,40.5
       parent: 2
-  - uid: 3400
+  - uid: 3702
     components:
     - type: Transform
       pos: -41.5,41.5
       parent: 2
-  - uid: 3401
+  - uid: 3703
     components:
     - type: Transform
       pos: -41.5,40.5
       parent: 2
-  - uid: 3402
+  - uid: 3704
     components:
     - type: Transform
       pos: -42.5,40.5
       parent: 2
-  - uid: 3403
+  - uid: 3705
     components:
     - type: Transform
       pos: -43.5,41.5
       parent: 2
-  - uid: 3404
+  - uid: 3706
     components:
     - type: Transform
       pos: -43.5,40.5
       parent: 2
-  - uid: 3405
+  - uid: 3707
     components:
     - type: Transform
       pos: -44.5,41.5
       parent: 2
-  - uid: 3406
+  - uid: 3708
     components:
     - type: Transform
       pos: -44.5,40.5
       parent: 2
-  - uid: 3407
+  - uid: 3709
     components:
     - type: Transform
       pos: -45.5,41.5
       parent: 2
-  - uid: 3408
+  - uid: 3710
     components:
     - type: Transform
       pos: -45.5,40.5
       parent: 2
-  - uid: 3409
+  - uid: 3711
     components:
     - type: Transform
       pos: -46.5,41.5
       parent: 2
-  - uid: 3410
+  - uid: 3712
     components:
     - type: Transform
       pos: -46.5,40.5
       parent: 2
-  - uid: 3411
+  - uid: 3713
     components:
     - type: Transform
       pos: -42.5,41.5
       parent: 2
-  - uid: 3412
+  - uid: 3714
     components:
     - type: Transform
       pos: -37.5,34.5
       parent: 2
-  - uid: 3413
+  - uid: 3715
     components:
     - type: Transform
       pos: -37.5,33.5
       parent: 2
-  - uid: 3414
+  - uid: 3716
     components:
     - type: Transform
       pos: -36.5,34.5
       parent: 2
-  - uid: 3415
+  - uid: 3717
     components:
     - type: Transform
       pos: -36.5,33.5
       parent: 2
-  - uid: 3416
+  - uid: 3718
     components:
     - type: Transform
       pos: -35.5,34.5
       parent: 2
-  - uid: 3417
+  - uid: 3719
     components:
     - type: Transform
       pos: -34.5,34.5
       parent: 2
-  - uid: 3418
+  - uid: 3720
     components:
     - type: Transform
       pos: -34.5,33.5
       parent: 2
-  - uid: 3419
+  - uid: 3721
     components:
     - type: Transform
       pos: -33.5,34.5
       parent: 2
-  - uid: 3420
+  - uid: 3722
     components:
     - type: Transform
       pos: -33.5,33.5
       parent: 2
-  - uid: 3421
+  - uid: 3723
     components:
     - type: Transform
       pos: -32.5,34.5
       parent: 2
-  - uid: 3422
+  - uid: 3724
     components:
     - type: Transform
       pos: -32.5,33.5
       parent: 2
-  - uid: 3423
+  - uid: 3725
     components:
     - type: Transform
       pos: -31.5,34.5
       parent: 2
-  - uid: 3424
+  - uid: 3726
     components:
     - type: Transform
       pos: -31.5,33.5
       parent: 2
-  - uid: 3425
+  - uid: 3727
     components:
     - type: Transform
       pos: -30.5,34.5
       parent: 2
-  - uid: 3426
+  - uid: 3728
     components:
     - type: Transform
       pos: -30.5,33.5
       parent: 2
-  - uid: 3427
+  - uid: 3729
     components:
     - type: Transform
       pos: -29.5,34.5
       parent: 2
-  - uid: 3428
+  - uid: 3730
     components:
     - type: Transform
       pos: -35.5,33.5
       parent: 2
-  - uid: 3429
+  - uid: 3731
     components:
     - type: Transform
       pos: -28.5,34.5
       parent: 2
-  - uid: 3430
+  - uid: 3732
     components:
     - type: Transform
       pos: -29.5,33.5
       parent: 2
-  - uid: 3431
+  - uid: 3733
     components:
     - type: Transform
       pos: -28.5,33.5
       parent: 2
-  - uid: 3432
+  - uid: 3734
     components:
     - type: Transform
       pos: -27.5,34.5
       parent: 2
-  - uid: 3433
+  - uid: 3735
     components:
     - type: Transform
       pos: -27.5,33.5
       parent: 2
-  - uid: 3434
+  - uid: 3736
     components:
     - type: Transform
       pos: -37.5,41.5
       parent: 2
-  - uid: 3435
+  - uid: 3737
     components:
     - type: Transform
       pos: -37.5,40.5
       parent: 2
-  - uid: 3436
+  - uid: 3738
     components:
     - type: Transform
       pos: -36.5,41.5
       parent: 2
-  - uid: 3437
+  - uid: 3739
     components:
     - type: Transform
       pos: -36.5,40.5
       parent: 2
-  - uid: 3438
+  - uid: 3740
     components:
     - type: Transform
       pos: -35.5,41.5
       parent: 2
-  - uid: 3439
+  - uid: 3741
     components:
     - type: Transform
       pos: -34.5,41.5
       parent: 2
-  - uid: 3440
+  - uid: 3742
     components:
     - type: Transform
       pos: -34.5,40.5
       parent: 2
-  - uid: 3441
+  - uid: 3743
     components:
     - type: Transform
       pos: -33.5,41.5
       parent: 2
-  - uid: 3442
+  - uid: 3744
     components:
     - type: Transform
       pos: -33.5,40.5
       parent: 2
-  - uid: 3443
+  - uid: 3745
     components:
     - type: Transform
       pos: -32.5,41.5
       parent: 2
-  - uid: 3444
+  - uid: 3746
     components:
     - type: Transform
       pos: -32.5,40.5
       parent: 2
-  - uid: 3445
+  - uid: 3747
     components:
     - type: Transform
       pos: -31.5,41.5
       parent: 2
-  - uid: 3446
+  - uid: 3748
     components:
     - type: Transform
       pos: -31.5,40.5
       parent: 2
-  - uid: 3447
+  - uid: 3749
     components:
     - type: Transform
       pos: -30.5,41.5
       parent: 2
-  - uid: 3448
+  - uid: 3750
     components:
     - type: Transform
       pos: -30.5,40.5
       parent: 2
-  - uid: 3449
+  - uid: 3751
     components:
     - type: Transform
       pos: -35.5,40.5
       parent: 2
-  - uid: 3450
+  - uid: 3752
     components:
     - type: Transform
       pos: -29.5,41.5
       parent: 2
-  - uid: 3451
+  - uid: 3753
     components:
     - type: Transform
       pos: -28.5,40.5
       parent: 2
-  - uid: 3452
+  - uid: 3754
     components:
     - type: Transform
       pos: -28.5,41.5
       parent: 2
-  - uid: 3453
+  - uid: 3755
     components:
     - type: Transform
       pos: -27.5,41.5
       parent: 2
-  - uid: 3454
+  - uid: 3756
     components:
     - type: Transform
       pos: -27.5,40.5
       parent: 2
-  - uid: 3455
+  - uid: 3757
     components:
     - type: Transform
       pos: -26.5,41.5
       parent: 2
-  - uid: 3456
+  - uid: 3758
     components:
     - type: Transform
       pos: -26.5,40.5
       parent: 2
-  - uid: 3457
+  - uid: 3759
     components:
     - type: Transform
       pos: -25.5,41.5
       parent: 2
-  - uid: 3458
+  - uid: 3760
     components:
     - type: Transform
       pos: -25.5,40.5
       parent: 2
-  - uid: 3459
+  - uid: 3761
     components:
     - type: Transform
       pos: -24.5,41.5
       parent: 2
-  - uid: 3460
+  - uid: 3762
     components:
     - type: Transform
       pos: -24.5,40.5
       parent: 2
-  - uid: 3461
+  - uid: 3763
     components:
     - type: Transform
       pos: -23.5,41.5
       parent: 2
-  - uid: 3462
+  - uid: 3764
     components:
     - type: Transform
       pos: -23.5,40.5
       parent: 2
-  - uid: 3463
+  - uid: 3765
     components:
     - type: Transform
       pos: -22.5,41.5
       parent: 2
-  - uid: 3464
+  - uid: 3766
     components:
     - type: Transform
       pos: -22.5,40.5
       parent: 2
-  - uid: 3465
+  - uid: 3767
     components:
     - type: Transform
       pos: -21.5,41.5
       parent: 2
-  - uid: 3466
+  - uid: 3768
     components:
     - type: Transform
       pos: -21.5,40.5
       parent: 2
-  - uid: 3467
+  - uid: 3769
     components:
     - type: Transform
       pos: -29.5,40.5
       parent: 2
-  - uid: 3468
+  - uid: 3770
     components:
     - type: Transform
       pos: -8.5,40.5
       parent: 2
-  - uid: 3469
+  - uid: 3771
     components:
     - type: Transform
       pos: -7.5,41.5
       parent: 2
-  - uid: 3470
+  - uid: 3772
     components:
     - type: Transform
       pos: -7.5,40.5
       parent: 2
-  - uid: 3471
+  - uid: 3773
     components:
     - type: Transform
       pos: -6.5,41.5
       parent: 2
-  - uid: 3472
+  - uid: 3774
     components:
     - type: Transform
       pos: -5.5,41.5
       parent: 2
-  - uid: 3473
+  - uid: 3775
     components:
     - type: Transform
       pos: -5.5,40.5
       parent: 2
-  - uid: 3474
+  - uid: 3776
     components:
     - type: Transform
       pos: -4.5,41.5
       parent: 2
-  - uid: 3475
+  - uid: 3777
     components:
     - type: Transform
       pos: -4.5,40.5
       parent: 2
-  - uid: 3476
+  - uid: 3778
     components:
     - type: Transform
       pos: -3.5,41.5
       parent: 2
-  - uid: 3477
+  - uid: 3779
     components:
     - type: Transform
       pos: -3.5,40.5
       parent: 2
-  - uid: 3478
+  - uid: 3780
     components:
     - type: Transform
       pos: -2.5,41.5
       parent: 2
-  - uid: 3479
+  - uid: 3781
     components:
     - type: Transform
       pos: -2.5,40.5
       parent: 2
-  - uid: 3480
+  - uid: 3782
     components:
     - type: Transform
       pos: -1.5,41.5
       parent: 2
-  - uid: 3481
+  - uid: 3783
     components:
     - type: Transform
       pos: -1.5,40.5
       parent: 2
-  - uid: 3482
+  - uid: 3784
     components:
     - type: Transform
       pos: -0.5,41.5
       parent: 2
-  - uid: 3483
+  - uid: 3785
     components:
     - type: Transform
       pos: -0.5,40.5
       parent: 2
-  - uid: 3484
+  - uid: 3786
     components:
     - type: Transform
       pos: -6.5,40.5
       parent: 2
-  - uid: 3485
+  - uid: 3787
     components:
     - type: Transform
       pos: -0.5,40.5
       parent: 2
-  - uid: 3486
+  - uid: 3788
     components:
     - type: Transform
       pos: -0.5,39.5
       parent: 2
-  - uid: 3487
+  - uid: 3789
     components:
     - type: Transform
       pos: -0.5,38.5
       parent: 2
-  - uid: 3488
+  - uid: 3790
     components:
     - type: Transform
       pos: -0.5,37.5
       parent: 2
-  - uid: 3489
+  - uid: 3791
     components:
     - type: Transform
       pos: -0.5,36.5
       parent: 2
-  - uid: 3490
+  - uid: 3792
     components:
     - type: Transform
       pos: -1.5,39.5
       parent: 2
-  - uid: 3491
+  - uid: 3793
     components:
     - type: Transform
       pos: -1.5,38.5
       parent: 2
-  - uid: 3492
+  - uid: 3794
     components:
     - type: Transform
       pos: -1.5,37.5
       parent: 2
-  - uid: 3493
+  - uid: 3795
     components:
     - type: Transform
       pos: -1.5,36.5
       parent: 2
-  - uid: 3494
+  - uid: 3796
     components:
     - type: Transform
       pos: -1.5,35.5
       parent: 2
-  - uid: 3495
+  - uid: 3797
     components:
     - type: Transform
       pos: -0.5,35.5
       parent: 2
-  - uid: 3496
+  - uid: 3798
     components:
     - type: Transform
       pos: -0.5,42.5
       parent: 2
-  - uid: 3497
+  - uid: 3799
     components:
     - type: Transform
       pos: -0.5,43.5
       parent: 2
-  - uid: 3498
+  - uid: 3800
     components:
     - type: Transform
       pos: -0.5,44.5
       parent: 2
-  - uid: 3499
+  - uid: 3801
     components:
     - type: Transform
       pos: -0.5,45.5
       parent: 2
-  - uid: 3500
+  - uid: 3802
     components:
     - type: Transform
       pos: -0.5,46.5
       parent: 2
-  - uid: 3501
+  - uid: 3803
     components:
     - type: Transform
       pos: -1.5,43.5
       parent: 2
-  - uid: 3502
+  - uid: 3804
     components:
     - type: Transform
       pos: -1.5,42.5
       parent: 2
-  - uid: 3503
+  - uid: 3805
     components:
     - type: Transform
       pos: -1.5,44.5
       parent: 2
-  - uid: 3504
+  - uid: 3806
     components:
     - type: Transform
       pos: -1.5,45.5
       parent: 2
-  - uid: 3505
+  - uid: 3807
     components:
     - type: Transform
       pos: -1.5,46.5
       parent: 2
-  - uid: 3506
+  - uid: 3808
     components:
     - type: Transform
       pos: -1.5,47.5
       parent: 2
-  - uid: 3507
+  - uid: 3809
     components:
     - type: Transform
       pos: -0.5,47.5
       parent: 2
-  - uid: 3508
+  - uid: 3810
     components:
     - type: Transform
       pos: -0.5,20.5
       parent: 2
-  - uid: 3509
+  - uid: 3811
     components:
     - type: Transform
       pos: -0.5,19.5
       parent: 2
-  - uid: 3510
+  - uid: 3812
     components:
     - type: Transform
       pos: -0.5,18.5
       parent: 2
-  - uid: 3511
+  - uid: 3813
     components:
     - type: Transform
       pos: -0.5,17.5
       parent: 2
-  - uid: 3512
+  - uid: 3814
     components:
     - type: Transform
       pos: -0.5,14.5
       parent: 2
-  - uid: 3513
+  - uid: 3815
     components:
     - type: Transform
       pos: -0.5,15.5
       parent: 2
-  - uid: 3514
+  - uid: 3816
     components:
     - type: Transform
       pos: -0.5,13.5
       parent: 2
-  - uid: 3515
+  - uid: 3817
     components:
     - type: Transform
       pos: -0.5,12.5
       parent: 2
-  - uid: 3516
+  - uid: 3818
     components:
     - type: Transform
       pos: -0.5,11.5
       parent: 2
-  - uid: 3517
+  - uid: 3819
     components:
     - type: Transform
       pos: -0.5,10.5
       parent: 2
-  - uid: 3518
+  - uid: 3820
     components:
     - type: Transform
       pos: -0.5,9.5
       parent: 2
-  - uid: 3519
+  - uid: 3821
     components:
     - type: Transform
       pos: -0.5,8.5
       parent: 2
-  - uid: 3520
+  - uid: 3822
     components:
     - type: Transform
       pos: -0.5,7.5
       parent: 2
-  - uid: 3521
+  - uid: 3823
     components:
     - type: Transform
       pos: -0.5,6.5
       parent: 2
-  - uid: 3522
+  - uid: 3824
     components:
     - type: Transform
       pos: -0.5,5.5
       parent: 2
-  - uid: 3523
+  - uid: 3825
     components:
     - type: Transform
       pos: -0.5,16.5
       parent: 2
-  - uid: 3524
+  - uid: 3826
     components:
     - type: Transform
       pos: -0.5,3.5
       parent: 2
-  - uid: 3525
+  - uid: 3827
     components:
     - type: Transform
       pos: -0.5,4.5
       parent: 2
-  - uid: 3526
+  - uid: 3828
     components:
     - type: Transform
       pos: -0.5,1.5
       parent: 2
-  - uid: 3527
+  - uid: 3829
     components:
     - type: Transform
       pos: -0.5,0.5
       parent: 2
-  - uid: 3528
+  - uid: 3830
     components:
     - type: Transform
       pos: -0.5,-0.5
       parent: 2
-  - uid: 3529
+  - uid: 3831
     components:
     - type: Transform
       pos: -0.5,-1.5
       parent: 2
-  - uid: 3530
+  - uid: 3832
     components:
     - type: Transform
       pos: -0.5,-2.5
       parent: 2
-  - uid: 3531
+  - uid: 3833
     components:
     - type: Transform
       pos: -0.5,-3.5
       parent: 2
-  - uid: 3532
+  - uid: 3834
     components:
     - type: Transform
       pos: -1.5,20.5
       parent: 2
-  - uid: 3533
+  - uid: 3835
     components:
     - type: Transform
       pos: -1.5,19.5
       parent: 2
-  - uid: 3534
+  - uid: 3836
     components:
     - type: Transform
       pos: -1.5,18.5
       parent: 2
-  - uid: 3535
+  - uid: 3837
     components:
     - type: Transform
       pos: -1.5,17.5
       parent: 2
-  - uid: 3536
+  - uid: 3838
     components:
     - type: Transform
       pos: -1.5,16.5
       parent: 2
-  - uid: 3537
+  - uid: 3839
     components:
     - type: Transform
       pos: -1.5,15.5
       parent: 2
-  - uid: 3538
+  - uid: 3840
     components:
     - type: Transform
       pos: -1.5,14.5
       parent: 2
-  - uid: 3539
+  - uid: 3841
     components:
     - type: Transform
       pos: -1.5,13.5
       parent: 2
-  - uid: 3540
+  - uid: 3842
     components:
     - type: Transform
       pos: -1.5,12.5
       parent: 2
-  - uid: 3541
+  - uid: 3843
     components:
     - type: Transform
       pos: -1.5,11.5
       parent: 2
-  - uid: 3542
+  - uid: 3844
     components:
     - type: Transform
       pos: -1.5,10.5
       parent: 2
-  - uid: 3543
+  - uid: 3845
     components:
     - type: Transform
       pos: -1.5,9.5
       parent: 2
-  - uid: 3544
+  - uid: 3846
     components:
     - type: Transform
       pos: -1.5,8.5
       parent: 2
-  - uid: 3545
+  - uid: 3847
     components:
     - type: Transform
       pos: -1.5,7.5
       parent: 2
-  - uid: 3546
+  - uid: 3848
     components:
     - type: Transform
       pos: -0.5,2.5
       parent: 2
-  - uid: 3547
+  - uid: 3849
     components:
     - type: Transform
       pos: -1.5,3.5
       parent: 2
-  - uid: 3548
+  - uid: 3850
     components:
     - type: Transform
       pos: -1.5,6.5
       parent: 2
-  - uid: 3549
+  - uid: 3851
     components:
     - type: Transform
       pos: -1.5,2.5
       parent: 2
-  - uid: 3550
+  - uid: 3852
     components:
     - type: Transform
       pos: -1.5,1.5
       parent: 2
-  - uid: 3551
+  - uid: 3853
     components:
     - type: Transform
       pos: -1.5,0.5
       parent: 2
-  - uid: 3552
+  - uid: 3854
     components:
     - type: Transform
       pos: -1.5,-0.5
       parent: 2
-  - uid: 3553
+  - uid: 3855
     components:
     - type: Transform
       pos: -1.5,-1.5
       parent: 2
-  - uid: 3554
+  - uid: 3856
     components:
     - type: Transform
       pos: -1.5,-2.5
       parent: 2
-  - uid: 3555
+  - uid: 3857
     components:
     - type: Transform
       pos: -1.5,-3.5
       parent: 2
-  - uid: 3556
+  - uid: 3858
     components:
     - type: Transform
       pos: -1.5,5.5
       parent: 2
-  - uid: 3557
+  - uid: 3859
     components:
     - type: Transform
       pos: -1.5,4.5
       parent: 2
-  - uid: 3558
+  - uid: 3860
     components:
     - type: Transform
       pos: 0.5,9.5
       parent: 2
-  - uid: 3559
+  - uid: 3861
     components:
     - type: Transform
       pos: 0.5,10.5
       parent: 2
-  - uid: 3560
+  - uid: 3862
     components:
     - type: Transform
       pos: 1.5,9.5
       parent: 2
-  - uid: 3561
+  - uid: 3863
     components:
     - type: Transform
       pos: 1.5,10.5
       parent: 2
-  - uid: 3562
+  - uid: 3864
     components:
     - type: Transform
       pos: 2.5,10.5
       parent: 2
-  - uid: 3563
+  - uid: 3865
     components:
     - type: Transform
       pos: 3.5,9.5
       parent: 2
-  - uid: 3564
+  - uid: 3866
     components:
     - type: Transform
       pos: 3.5,10.5
       parent: 2
-  - uid: 3565
+  - uid: 3867
     components:
     - type: Transform
       pos: 4.5,9.5
       parent: 2
-  - uid: 3566
+  - uid: 3868
     components:
     - type: Transform
       pos: 4.5,10.5
       parent: 2
-  - uid: 3567
+  - uid: 3869
     components:
     - type: Transform
       pos: 5.5,9.5
       parent: 2
-  - uid: 3568
+  - uid: 3870
     components:
     - type: Transform
       pos: 5.5,10.5
       parent: 2
-  - uid: 3569
+  - uid: 3871
     components:
     - type: Transform
       pos: 6.5,9.5
       parent: 2
-  - uid: 3570
+  - uid: 3872
     components:
     - type: Transform
       pos: 6.5,10.5
       parent: 2
-  - uid: 3571
+  - uid: 3873
     components:
     - type: Transform
       pos: 7.5,9.5
       parent: 2
-  - uid: 3572
+  - uid: 3874
     components:
     - type: Transform
       pos: 7.5,10.5
       parent: 2
-  - uid: 3573
+  - uid: 3875
     components:
     - type: Transform
       pos: 8.5,9.5
       parent: 2
-  - uid: 3574
+  - uid: 3876
     components:
     - type: Transform
       pos: 8.5,10.5
       parent: 2
-  - uid: 3575
+  - uid: 3877
     components:
     - type: Transform
       pos: 2.5,9.5
       parent: 2
-  - uid: 3576
+  - uid: 3878
     components:
     - type: Transform
       pos: 9.5,10.5
       parent: 2
-  - uid: 3577
+  - uid: 3879
     components:
     - type: Transform
       pos: 10.5,9.5
       parent: 2
-  - uid: 3578
+  - uid: 3880
     components:
     - type: Transform
       pos: 10.5,10.5
       parent: 2
-  - uid: 3579
+  - uid: 3881
     components:
     - type: Transform
       pos: 9.5,9.5
       parent: 2
-  - uid: 3580
+  - uid: 3882
     components:
     - type: Transform
       pos: 0.5,-2.5
       parent: 2
-  - uid: 3581
+  - uid: 3883
     components:
     - type: Transform
       pos: 0.5,-3.5
       parent: 2
-  - uid: 3582
+  - uid: 3884
     components:
     - type: Transform
       pos: 2.5,-2.5
       parent: 2
-  - uid: 3583
+  - uid: 3885
     components:
     - type: Transform
       pos: 1.5,-3.5
       parent: 2
-  - uid: 3584
+  - uid: 3886
     components:
     - type: Transform
       pos: 2.5,-3.5
       parent: 2
-  - uid: 3585
+  - uid: 3887
     components:
     - type: Transform
       pos: 3.5,-2.5
       parent: 2
-  - uid: 3586
+  - uid: 3888
     components:
     - type: Transform
       pos: 3.5,-3.5
       parent: 2
-  - uid: 3587
+  - uid: 3889
     components:
     - type: Transform
       pos: 4.5,-2.5
       parent: 2
-  - uid: 3588
+  - uid: 3890
     components:
     - type: Transform
       pos: 4.5,-3.5
       parent: 2
-  - uid: 3589
+  - uid: 3891
     components:
     - type: Transform
       pos: 5.5,-2.5
       parent: 2
-  - uid: 3590
+  - uid: 3892
     components:
     - type: Transform
       pos: 5.5,-3.5
       parent: 2
-  - uid: 3591
+  - uid: 3893
     components:
     - type: Transform
       pos: 1.5,-2.5
       parent: 2
-  - uid: 3592
+  - uid: 3894
     components:
     - type: Transform
       pos: 6.5,-3.5
       parent: 2
-  - uid: 3593
+  - uid: 3895
     components:
     - type: Transform
       pos: 7.5,-2.5
       parent: 2
-  - uid: 3594
+  - uid: 3896
     components:
     - type: Transform
       pos: 7.5,-3.5
       parent: 2
-  - uid: 3595
+  - uid: 3897
     components:
     - type: Transform
       pos: 8.5,-2.5
       parent: 2
-  - uid: 3596
+  - uid: 3898
     components:
     - type: Transform
       pos: 9.5,-2.5
       parent: 2
-  - uid: 3597
+  - uid: 3899
     components:
     - type: Transform
       pos: 9.5,-3.5
       parent: 2
-  - uid: 3598
+  - uid: 3900
     components:
     - type: Transform
       pos: 8.5,-3.5
       parent: 2
-  - uid: 3599
+  - uid: 3901
     components:
     - type: Transform
       pos: 6.5,-2.5
       parent: 2
-  - uid: 3600
+  - uid: 3902
     components:
     - type: Transform
       pos: 10.5,-2.5
       parent: 2
-  - uid: 3601
+  - uid: 3903
     components:
     - type: Transform
       pos: 10.5,-3.5
       parent: 2
-  - uid: 3602
+  - uid: 3904
     components:
     - type: Transform
       pos: 11.5,-2.5
       parent: 2
-  - uid: 3603
+  - uid: 3905
     components:
     - type: Transform
       pos: 12.5,-2.5
       parent: 2
-  - uid: 3604
+  - uid: 3906
     components:
     - type: Transform
       pos: 12.5,-3.5
       parent: 2
-  - uid: 3605
+  - uid: 3907
     components:
     - type: Transform
       pos: 11.5,-3.5
       parent: 2
-  - uid: 3606
+  - uid: 3908
     components:
     - type: Transform
       pos: -2.5,-2.5
       parent: 2
-  - uid: 3607
+  - uid: 3909
     components:
     - type: Transform
       pos: -2.5,-3.5
       parent: 2
-  - uid: 3608
+  - uid: 3910
     components:
     - type: Transform
       pos: -3.5,-2.5
       parent: 2
-  - uid: 3609
+  - uid: 3911
     components:
     - type: Transform
       pos: -3.5,-3.5
       parent: 2
-  - uid: 3610
+  - uid: 3912
     components:
     - type: Transform
       pos: -4.5,-2.5
       parent: 2
-  - uid: 3611
+  - uid: 3913
     components:
     - type: Transform
       pos: -5.5,-2.5
       parent: 2
-  - uid: 3612
+  - uid: 3914
     components:
     - type: Transform
       pos: -5.5,-3.5
       parent: 2
-  - uid: 3613
+  - uid: 3915
     components:
     - type: Transform
       pos: -6.5,-2.5
       parent: 2
-  - uid: 3614
+  - uid: 3916
     components:
     - type: Transform
       pos: -6.5,-3.5
       parent: 2
-  - uid: 3615
+  - uid: 3917
     components:
     - type: Transform
       pos: -7.5,-2.5
       parent: 2
-  - uid: 3616
+  - uid: 3918
     components:
     - type: Transform
       pos: -7.5,-3.5
       parent: 2
-  - uid: 3617
+  - uid: 3919
     components:
     - type: Transform
       pos: -8.5,-2.5
       parent: 2
-  - uid: 3618
+  - uid: 3920
     components:
     - type: Transform
       pos: -8.5,-3.5
       parent: 2
-  - uid: 3619
+  - uid: 3921
     components:
     - type: Transform
       pos: -9.5,-2.5
       parent: 2
-  - uid: 3620
+  - uid: 3922
     components:
     - type: Transform
       pos: -9.5,-3.5
       parent: 2
-  - uid: 3621
+  - uid: 3923
     components:
     - type: Transform
       pos: -10.5,-2.5
       parent: 2
-  - uid: 3622
+  - uid: 3924
     components:
     - type: Transform
       pos: -4.5,-3.5
       parent: 2
-  - uid: 3623
+  - uid: 3925
     components:
     - type: Transform
       pos: -10.5,-3.5
       parent: 2
-  - uid: 3624
+  - uid: 3926
     components:
     - type: Transform
       pos: -12.5,-2.5
       parent: 2
-  - uid: 3625
+  - uid: 3927
     components:
     - type: Transform
       pos: -11.5,-2.5
       parent: 2
-  - uid: 3626
+  - uid: 3928
     components:
     - type: Transform
       pos: -12.5,-3.5
       parent: 2
-  - uid: 3627
+  - uid: 3929
     components:
     - type: Transform
       pos: -13.5,-2.5
       parent: 2
-  - uid: 3628
+  - uid: 3930
     components:
     - type: Transform
       pos: -14.5,-2.5
       parent: 2
-  - uid: 3629
+  - uid: 3931
     components:
     - type: Transform
       pos: -13.5,-3.5
       parent: 2
-  - uid: 3630
+  - uid: 3932
     components:
     - type: Transform
       pos: -14.5,-3.5
       parent: 2
-  - uid: 3631
+  - uid: 3933
     components:
     - type: Transform
       pos: -15.5,-2.5
       parent: 2
-  - uid: 3632
+  - uid: 3934
     components:
     - type: Transform
       pos: -15.5,-3.5
       parent: 2
-  - uid: 3633
+  - uid: 3935
     components:
     - type: Transform
       pos: -11.5,-3.5
       parent: 2
 - proto: AtmosFixNitrogenMarker
   entities:
-  - uid: 3634
+  - uid: 3936
     components:
     - type: Transform
       pos: -81.5,-14.5
       parent: 2
-  - uid: 3635
+  - uid: 3937
     components:
     - type: Transform
       pos: -81.5,-15.5
       parent: 2
 - proto: AtmosFixOxygenMarker
   entities:
-  - uid: 3636
+  - uid: 3938
     components:
     - type: Transform
       pos: -84.5,-14.5
       parent: 2
-  - uid: 3637
+  - uid: 3939
     components:
     - type: Transform
       pos: -84.5,-15.5
       parent: 2
 - proto: BaseWallLockerDeltaV
   entities:
-  - uid: 3638
+  - uid: 3940
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
@@ -20675,7 +20681,7 @@ entities:
       locked: False
     - type: Fixtures
       fixtures: {}
-  - uid: 3639
+  - uid: 3941
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
@@ -20685,7 +20691,7 @@ entities:
       locked: False
     - type: Fixtures
       fixtures: {}
-  - uid: 3640
+  - uid: 3942
     components:
     - type: Transform
       pos: -43.5,-48.5
@@ -20694,7 +20700,7 @@ entities:
       locked: False
     - type: Fixtures
       fixtures: {}
-  - uid: 3641
+  - uid: 3943
     components:
     - type: Transform
       pos: -34.5,-48.5
@@ -20705,126 +20711,126 @@ entities:
       fixtures: {}
 - proto: Bed
   entities:
-  - uid: 3642
+  - uid: 3944
     components:
     - type: Transform
       pos: -46.5,-47.5
       parent: 2
-  - uid: 3643
+  - uid: 3945
     components:
     - type: Transform
       pos: -33.5,-50.5
       parent: 2
-  - uid: 3644
+  - uid: 3946
     components:
     - type: Transform
       pos: -44.5,-50.5
       parent: 2
-  - uid: 3645
+  - uid: 3947
     components:
     - type: Transform
       pos: -43.5,-37.5
       parent: 2
-  - uid: 3646
+  - uid: 3948
     components:
     - type: Transform
       pos: -31.5,-47.5
       parent: 2
-  - uid: 3647
+  - uid: 3949
     components:
     - type: Transform
       pos: -30.5,-37.5
       parent: 2
-  - uid: 3648
+  - uid: 3950
     components:
     - type: Transform
       pos: -34.5,-46.5
       parent: 2
-  - uid: 3649
+  - uid: 3951
     components:
     - type: Transform
       pos: -43.5,-46.5
       parent: 2
 - proto: BedsheetBlue
   entities:
-  - uid: 3650
+  - uid: 3952
     components:
     - type: Transform
       pos: -85.5,2.5
       parent: 2
-  - uid: 3651
+  - uid: 3953
     components:
     - type: Transform
       pos: -80.5,2.5
       parent: 2
-  - uid: 3652
+  - uid: 3954
     components:
     - type: Transform
       pos: -80.5,0.5
       parent: 2
 - proto: BedsheetSpawner
   entities:
-  - uid: 3653
+  - uid: 3955
     components:
     - type: Transform
       pos: -30.5,-37.5
       parent: 2
-  - uid: 3654
+  - uid: 3956
     components:
     - type: Transform
       pos: -43.5,-37.5
       parent: 2
-  - uid: 3655
+  - uid: 3957
     components:
     - type: Transform
       pos: -31.5,-47.5
       parent: 2
-  - uid: 3656
+  - uid: 3958
     components:
     - type: Transform
       pos: -33.5,-50.5
       parent: 2
-  - uid: 3657
+  - uid: 3959
     components:
     - type: Transform
       pos: -34.5,-46.5
       parent: 2
-  - uid: 3658
+  - uid: 3960
     components:
     - type: Transform
       pos: -43.5,-46.5
       parent: 2
-  - uid: 3659
+  - uid: 3961
     components:
     - type: Transform
       pos: -44.5,-50.5
       parent: 2
-  - uid: 3660
+  - uid: 3962
     components:
     - type: Transform
       pos: -46.5,-47.5
       parent: 2
 - proto: BenchParkLeft
   entities:
-  - uid: 3661
+  - uid: 3963
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: -89.5,-4.5
       parent: 2
-  - uid: 3662
+  - uid: 3964
     components:
     - type: Transform
       pos: -87.5,-1.5
       parent: 2
 - proto: BenchParkMiddle
   entities:
-  - uid: 3663
+  - uid: 3965
     components:
     - type: Transform
       pos: -88.5,-1.5
       parent: 2
-  - uid: 3664
+  - uid: 3966
     components:
     - type: Transform
       rot: 3.141592653589793 rad
@@ -20832,12 +20838,12 @@ entities:
       parent: 2
 - proto: BenchParkRight
   entities:
-  - uid: 3665
+  - uid: 3967
     components:
     - type: Transform
       pos: -89.5,-1.5
       parent: 2
-  - uid: 3666
+  - uid: 3968
     components:
     - type: Transform
       rot: 3.141592653589793 rad
@@ -20845,19 +20851,19 @@ entities:
       parent: 2
 - proto: BenchSofaCorner
   entities:
-  - uid: 3667
+  - uid: 3969
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: -30.5,-43.5
       parent: 2
-  - uid: 3668
+  - uid: 3970
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: -47.5,-43.5
       parent: 2
-  - uid: 3669
+  - uid: 3971
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
@@ -20865,38 +20871,38 @@ entities:
       parent: 2
 - proto: BenchSofaLeft
   entities:
-  - uid: 3670
+  - uid: 3972
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: -31.5,-43.5
       parent: 2
-  - uid: 3671
+  - uid: 3973
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: -47.5,-42.5
       parent: 2
-  - uid: 3672
+  - uid: 3974
     components:
     - type: Transform
       pos: -95.5,-6.5
       parent: 2
 - proto: BenchSofaRight
   entities:
-  - uid: 3673
+  - uid: 3975
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: -30.5,-42.5
       parent: 2
-  - uid: 3674
+  - uid: 3976
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: -46.5,-43.5
       parent: 2
-  - uid: 3675
+  - uid: 3977
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
@@ -20904,13 +20910,13 @@ entities:
       parent: 2
 - proto: BlastDoor
   entities:
-  - uid: 3676
+  - uid: 3978
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: -96.5,7.5
       parent: 2
-  - uid: 3677
+  - uid: 3979
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
@@ -20918,12 +20924,12 @@ entities:
       parent: 2
 - proto: BoxFolderBase
   entities:
-  - uid: 3678
+  - uid: 3980
     components:
     - type: Transform
       pos: -96.543175,3.5715427
       parent: 2
-  - uid: 3679
+  - uid: 3981
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
@@ -20931,27 +20937,27 @@ entities:
       parent: 2
 - proto: BoxFolderClipboard
   entities:
-  - uid: 3680
+  - uid: 3982
     components:
     - type: Transform
       pos: -31.586655,-45.339874
       parent: 2
-  - uid: 3681
+  - uid: 3983
     components:
     - type: Transform
       pos: -46.49987,-45.339874
       parent: 2
-  - uid: 3682
+  - uid: 3984
     components:
     - type: Transform
       pos: -33.632225,-36.30937
       parent: 2
-  - uid: 3683
+  - uid: 3985
     components:
     - type: Transform
       pos: -45.475975,-36.293743
       parent: 2
-  - uid: 3684
+  - uid: 3986
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
@@ -20959,25 +20965,25 @@ entities:
       parent: 2
 - proto: BoxSoapsAssorted
   entities:
-  - uid: 3686
+  - uid: 3988
     components:
     - type: Transform
-      parent: 3685
+      parent: 3987
     - type: Physics
       canCollide: False
     - type: InsideEntityStorage
 - proto: BoxSoapsAssortedOmega
   entities:
-  - uid: 3692
+  - uid: 3994
     components:
     - type: Transform
-      parent: 3691
+      parent: 3993
     - type: Physics
       canCollide: False
     - type: InsideEntityStorage
 - proto: ButtonFrameCaution
   entities:
-  - uid: 3697
+  - uid: 3999
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
@@ -20985,2733 +20991,2733 @@ entities:
       parent: 2
 - proto: CableApcExtension
   entities:
-  - uid: 3698
+  - uid: 4000
     components:
     - type: Transform
       pos: -44.5,-2.5
       parent: 2
-  - uid: 3699
+  - uid: 4001
     components:
     - type: Transform
       pos: -58.5,-20.5
       parent: 2
-  - uid: 3700
+  - uid: 4002
     components:
     - type: Transform
       pos: -59.5,-35.5
       parent: 2
-  - uid: 3701
+  - uid: 4003
     components:
     - type: Transform
       pos: -59.5,-14.5
       parent: 2
-  - uid: 3702
+  - uid: 4004
     components:
     - type: Transform
       pos: -59.5,-11.5
       parent: 2
-  - uid: 3703
+  - uid: 4005
     components:
     - type: Transform
       pos: -30.5,-2.5
       parent: 2
-  - uid: 3704
+  - uid: 4006
     components:
     - type: Transform
       pos: -11.5,41.5
       parent: 2
-  - uid: 3705
+  - uid: 4007
     components:
     - type: Transform
       pos: -59.5,-21.5
       parent: 2
-  - uid: 3706
+  - uid: 4008
     components:
     - type: Transform
       pos: -0.5,10.5
       parent: 2
-  - uid: 3707
+  - uid: 4009
     components:
     - type: Transform
       pos: -57.5,-2.5
       parent: 2
-  - uid: 3708
+  - uid: 4010
     components:
     - type: Transform
       pos: -24.5,-2.5
       parent: 2
-  - uid: 3709
+  - uid: 4011
     components:
     - type: Transform
       pos: -32.5,-2.5
       parent: 2
-  - uid: 3710
+  - uid: 4012
     components:
     - type: Transform
       pos: -46.5,-2.5
       parent: 2
-  - uid: 3711
+  - uid: 4013
     components:
     - type: Transform
       pos: -0.5,20.5
       parent: 2
-  - uid: 3712
+  - uid: 4014
     components:
     - type: Transform
       pos: -0.5,39.5
       parent: 2
-  - uid: 3713
+  - uid: 4015
     components:
     - type: Transform
       pos: -0.5,19.5
       parent: 2
-  - uid: 3714
+  - uid: 4016
     components:
     - type: Transform
       pos: -7.5,-2.5
       parent: 2
-  - uid: 3715
+  - uid: 4017
     components:
     - type: Transform
       pos: -59.5,-50.5
       parent: 2
-  - uid: 3716
+  - uid: 4018
     components:
     - type: Transform
       pos: -0.5,17.5
       parent: 2
-  - uid: 3717
+  - uid: 4019
     components:
     - type: Transform
       pos: -45.5,-2.5
       parent: 2
-  - uid: 3718
+  - uid: 4020
     components:
     - type: Transform
       pos: -13.5,41.5
       parent: 2
-  - uid: 3719
+  - uid: 4021
     components:
     - type: Transform
       pos: -0.5,28.5
       parent: 2
-  - uid: 3720
+  - uid: 4022
     components:
     - type: Transform
       pos: -0.5,25.5
       parent: 2
-  - uid: 3721
+  - uid: 4023
     components:
     - type: Transform
       pos: -59.5,-5.5
       parent: 2
-  - uid: 3722
+  - uid: 4024
     components:
     - type: Transform
       pos: -0.5,12.5
       parent: 2
-  - uid: 3723
+  - uid: 4025
     components:
     - type: Transform
       pos: -59.5,-22.5
       parent: 2
-  - uid: 3724
+  - uid: 4026
     components:
     - type: Transform
       pos: -22.5,-2.5
       parent: 2
-  - uid: 3725
+  - uid: 4027
     components:
     - type: Transform
       pos: -0.5,34.5
       parent: 2
-  - uid: 3726
+  - uid: 4028
     components:
     - type: Transform
       pos: -0.5,16.5
       parent: 2
-  - uid: 3727
+  - uid: 4029
     components:
     - type: Transform
       pos: -59.5,-10.5
       parent: 2
-  - uid: 3728
+  - uid: 4030
     components:
     - type: Transform
       pos: -21.5,-2.5
       parent: 2
-  - uid: 3729
+  - uid: 4031
     components:
     - type: Transform
       pos: -59.5,-25.5
       parent: 2
-  - uid: 3730
+  - uid: 4032
     components:
     - type: Transform
       pos: -17.5,-2.5
       parent: 2
-  - uid: 3731
+  - uid: 4033
     components:
     - type: Transform
       pos: -59.5,-32.5
       parent: 2
-  - uid: 3732
+  - uid: 4034
     components:
     - type: Transform
       pos: -0.5,21.5
       parent: 2
-  - uid: 3733
+  - uid: 4035
     components:
     - type: Transform
       pos: -0.5,32.5
       parent: 2
-  - uid: 3734
+  - uid: 4036
     components:
     - type: Transform
       pos: -59.5,-31.5
       parent: 2
-  - uid: 3735
+  - uid: 4037
     components:
     - type: Transform
       pos: -0.5,30.5
       parent: 2
-  - uid: 3736
+  - uid: 4038
     components:
     - type: Transform
       pos: -54.5,-2.5
       parent: 2
-  - uid: 3737
+  - uid: 4039
     components:
     - type: Transform
       pos: -25.5,-2.5
       parent: 2
-  - uid: 3738
+  - uid: 4040
     components:
     - type: Transform
       pos: -53.5,-2.5
       parent: 2
-  - uid: 3739
+  - uid: 4041
     components:
     - type: Transform
       pos: -0.5,2.5
       parent: 2
-  - uid: 3740
+  - uid: 4042
     components:
     - type: Transform
       pos: -9.5,41.5
       parent: 2
-  - uid: 3741
+  - uid: 4043
     components:
     - type: Transform
       pos: -0.5,31.5
       parent: 2
-  - uid: 3742
+  - uid: 4044
     components:
     - type: Transform
       pos: -13.5,-2.5
       parent: 2
-  - uid: 3743
+  - uid: 4045
     components:
     - type: Transform
       pos: -0.5,3.5
       parent: 2
-  - uid: 3744
+  - uid: 4046
     components:
     - type: Transform
       pos: -0.5,14.5
       parent: 2
-  - uid: 3745
+  - uid: 4047
     components:
     - type: Transform
       pos: -0.5,35.5
       parent: 2
-  - uid: 3746
+  - uid: 4048
     components:
     - type: Transform
       pos: -0.5,36.5
       parent: 2
-  - uid: 3747
+  - uid: 4049
     components:
     - type: Transform
       pos: -36.5,-2.5
       parent: 2
-  - uid: 3748
+  - uid: 4050
     components:
     - type: Transform
       pos: -26.5,-2.5
       parent: 2
-  - uid: 3749
+  - uid: 4051
     components:
     - type: Transform
       pos: -10.5,-2.5
       parent: 2
-  - uid: 3750
+  - uid: 4052
     components:
     - type: Transform
       pos: -58.5,-2.5
       parent: 2
-  - uid: 3751
+  - uid: 4053
     components:
     - type: Transform
       pos: -5.5,-2.5
       parent: 2
-  - uid: 3752
+  - uid: 4054
     components:
     - type: Transform
       pos: -0.5,7.5
       parent: 2
-  - uid: 3753
+  - uid: 4055
     components:
     - type: Transform
       pos: -41.5,-2.5
       parent: 2
-  - uid: 3754
+  - uid: 4056
     components:
     - type: Transform
       pos: -58.5,-50.5
       parent: 2
-  - uid: 3755
+  - uid: 4057
     components:
     - type: Transform
       pos: -35.5,-2.5
       parent: 2
-  - uid: 3756
+  - uid: 4058
     components:
     - type: Transform
       pos: -4.5,41.5
       parent: 2
-  - uid: 3757
+  - uid: 4059
     components:
     - type: Transform
       pos: -38.5,-2.5
       parent: 2
-  - uid: 3758
+  - uid: 4060
     components:
     - type: Transform
       pos: -0.5,33.5
       parent: 2
-  - uid: 3759
+  - uid: 4061
     components:
     - type: Transform
       pos: -58.5,-38.5
       parent: 2
-  - uid: 3760
+  - uid: 4062
     components:
     - type: Transform
       pos: -59.5,-33.5
       parent: 2
-  - uid: 3761
+  - uid: 4063
     components:
     - type: Transform
       pos: -0.5,23.5
       parent: 2
-  - uid: 3762
+  - uid: 4064
     components:
     - type: Transform
       pos: -59.5,-16.5
       parent: 2
-  - uid: 3763
+  - uid: 4065
     components:
     - type: Transform
       pos: -7.5,41.5
       parent: 2
-  - uid: 3764
+  - uid: 4066
     components:
     - type: Transform
       pos: -59.5,-37.5
       parent: 2
-  - uid: 3765
+  - uid: 4067
     components:
     - type: Transform
       pos: -52.5,-2.5
       parent: 2
-  - uid: 3766
+  - uid: 4068
     components:
     - type: Transform
       pos: -2.5,41.5
       parent: 2
-  - uid: 3767
+  - uid: 4069
     components:
     - type: Transform
       pos: -59.5,-46.5
       parent: 2
-  - uid: 3768
+  - uid: 4070
     components:
     - type: Transform
       pos: -59.5,-29.5
       parent: 2
-  - uid: 3769
+  - uid: 4071
     components:
     - type: Transform
       pos: -1.5,-2.5
       parent: 2
-  - uid: 3770
+  - uid: 4072
     components:
     - type: Transform
       pos: -59.5,-49.5
       parent: 2
-  - uid: 3771
+  - uid: 4073
     components:
     - type: Transform
       pos: -59.5,-19.5
       parent: 2
-  - uid: 3772
+  - uid: 4074
     components:
     - type: Transform
       pos: -51.5,-2.5
       parent: 2
-  - uid: 3773
+  - uid: 4075
     components:
     - type: Transform
       pos: -0.5,1.5
       parent: 2
-  - uid: 3774
+  - uid: 4076
     components:
     - type: Transform
       pos: -18.5,-2.5
       parent: 2
-  - uid: 3775
+  - uid: 4077
     components:
     - type: Transform
       pos: -0.5,40.5
       parent: 2
-  - uid: 3776
+  - uid: 4078
     components:
     - type: Transform
       pos: -59.5,-6.5
       parent: 2
-  - uid: 3777
+  - uid: 4079
     components:
     - type: Transform
       pos: -39.5,-2.5
       parent: 2
-  - uid: 3778
+  - uid: 4080
     components:
     - type: Transform
       pos: -1.5,41.5
       parent: 2
-  - uid: 3779
+  - uid: 4081
     components:
     - type: Transform
       pos: -40.5,-2.5
       parent: 2
-  - uid: 3780
+  - uid: 4082
     components:
     - type: Transform
       pos: -0.5,38.5
       parent: 2
-  - uid: 3781
+  - uid: 4083
     components:
     - type: Transform
       pos: -0.5,27.5
       parent: 2
-  - uid: 3782
+  - uid: 4084
     components:
     - type: Transform
       pos: -2.5,-2.5
       parent: 2
-  - uid: 3783
+  - uid: 4085
     components:
     - type: Transform
       pos: -0.5,15.5
       parent: 2
-  - uid: 3784
+  - uid: 4086
     components:
     - type: Transform
       pos: -9.5,-2.5
       parent: 2
-  - uid: 3785
+  - uid: 4087
     components:
     - type: Transform
       pos: -34.5,-2.5
       parent: 2
-  - uid: 3786
+  - uid: 4088
     components:
     - type: Transform
       pos: -27.5,-2.5
       parent: 2
-  - uid: 3787
+  - uid: 4089
     components:
     - type: Transform
       pos: -0.5,11.5
       parent: 2
-  - uid: 3788
+  - uid: 4090
     components:
     - type: Transform
       pos: -59.5,-24.5
       parent: 2
-  - uid: 3789
+  - uid: 4091
     components:
     - type: Transform
       pos: -12.5,41.5
       parent: 2
-  - uid: 3790
+  - uid: 4092
     components:
     - type: Transform
       pos: -59.5,-2.5
       parent: 2
-  - uid: 3791
+  - uid: 4093
     components:
     - type: Transform
       pos: -0.5,4.5
       parent: 2
-  - uid: 3792
+  - uid: 4094
     components:
     - type: Transform
       pos: -0.5,22.5
       parent: 2
-  - uid: 3793
+  - uid: 4095
     components:
     - type: Transform
       pos: -59.5,-23.5
       parent: 2
-  - uid: 3794
+  - uid: 4096
     components:
     - type: Transform
       pos: -31.5,-2.5
       parent: 2
-  - uid: 3795
+  - uid: 4097
     components:
     - type: Transform
       pos: -59.5,-8.5
       parent: 2
-  - uid: 3796
+  - uid: 4098
     components:
     - type: Transform
       pos: -59.5,-30.5
       parent: 2
-  - uid: 3797
+  - uid: 4099
     components:
     - type: Transform
       pos: -5.5,41.5
       parent: 2
-  - uid: 3798
+  - uid: 4100
     components:
     - type: Transform
       pos: -48.5,-2.5
       parent: 2
-  - uid: 3799
+  - uid: 4101
     components:
     - type: Transform
       pos: -59.5,-18.5
       parent: 2
-  - uid: 3800
+  - uid: 4102
     components:
     - type: Transform
       pos: -19.5,-2.5
       parent: 2
-  - uid: 3801
+  - uid: 4103
     components:
     - type: Transform
       pos: -3.5,41.5
       parent: 2
-  - uid: 3802
+  - uid: 4104
     components:
     - type: Transform
       pos: -59.5,-12.5
       parent: 2
-  - uid: 3803
+  - uid: 4105
     components:
     - type: Transform
       pos: -0.5,0.5
       parent: 2
-  - uid: 3804
+  - uid: 4106
     components:
     - type: Transform
       pos: -0.5,13.5
       parent: 2
-  - uid: 3805
+  - uid: 4107
     components:
     - type: Transform
       pos: -0.5,9.5
       parent: 2
-  - uid: 3806
+  - uid: 4108
     components:
     - type: Transform
       pos: -0.5,8.5
       parent: 2
-  - uid: 3807
+  - uid: 4109
     components:
     - type: Transform
       pos: -59.5,-3.5
       parent: 2
-  - uid: 3808
+  - uid: 4110
     components:
     - type: Transform
       pos: -0.5,18.5
       parent: 2
-  - uid: 3809
+  - uid: 4111
     components:
     - type: Transform
       pos: -28.5,-2.5
       parent: 2
-  - uid: 3810
+  - uid: 4112
     components:
     - type: Transform
       pos: -59.5,-20.5
       parent: 2
-  - uid: 3811
+  - uid: 4113
     components:
     - type: Transform
       pos: -59.5,-38.5
       parent: 2
-  - uid: 3812
+  - uid: 4114
     components:
     - type: Transform
       pos: -0.5,29.5
       parent: 2
-  - uid: 3813
+  - uid: 4115
     components:
     - type: Transform
       pos: -0.5,5.5
       parent: 2
-  - uid: 3814
+  - uid: 4116
     components:
     - type: Transform
       pos: -47.5,-2.5
       parent: 2
-  - uid: 3815
+  - uid: 4117
     components:
     - type: Transform
       pos: -29.5,-2.5
       parent: 2
-  - uid: 3816
+  - uid: 4118
     components:
     - type: Transform
       pos: -59.5,-7.5
       parent: 2
-  - uid: 3817
+  - uid: 4119
     components:
     - type: Transform
       pos: -59.5,-41.5
       parent: 2
-  - uid: 3818
+  - uid: 4120
     components:
     - type: Transform
       pos: -59.5,-44.5
       parent: 2
-  - uid: 3819
+  - uid: 4121
     components:
     - type: Transform
       pos: -59.5,-26.5
       parent: 2
-  - uid: 3820
+  - uid: 4122
     components:
     - type: Transform
       pos: -0.5,37.5
       parent: 2
-  - uid: 3821
+  - uid: 4123
     components:
     - type: Transform
       pos: -0.5,6.5
       parent: 2
-  - uid: 3822
+  - uid: 4124
     components:
     - type: Transform
       pos: -50.5,-2.5
       parent: 2
-  - uid: 3823
+  - uid: 4125
     components:
     - type: Transform
       pos: -59.5,-17.5
       parent: 2
-  - uid: 3824
+  - uid: 4126
     components:
     - type: Transform
       pos: -59.5,-15.5
       parent: 2
-  - uid: 3825
+  - uid: 4127
     components:
     - type: Transform
       pos: -4.5,-2.5
       parent: 2
-  - uid: 3826
+  - uid: 4128
     components:
     - type: Transform
       pos: -37.5,-2.5
       parent: 2
-  - uid: 3827
+  - uid: 4129
     components:
     - type: Transform
       pos: -57.5,-38.5
       parent: 2
-  - uid: 3828
+  - uid: 4130
     components:
     - type: Transform
       pos: -57.5,-50.5
       parent: 2
-  - uid: 3829
+  - uid: 4131
     components:
     - type: Transform
       pos: -12.5,-2.5
       parent: 2
-  - uid: 3830
+  - uid: 4132
     components:
     - type: Transform
       pos: -49.5,-2.5
       parent: 2
-  - uid: 3831
+  - uid: 4133
     components:
     - type: Transform
       pos: -55.5,-2.5
       parent: 2
-  - uid: 3832
+  - uid: 4134
     components:
     - type: Transform
       pos: -15.5,-2.5
       parent: 2
-  - uid: 3833
+  - uid: 4135
     components:
     - type: Transform
       pos: -59.5,-28.5
       parent: 2
-  - uid: 3834
+  - uid: 4136
     components:
     - type: Transform
       pos: -56.5,-2.5
       parent: 2
-  - uid: 3835
+  - uid: 4137
     components:
     - type: Transform
       pos: -59.5,-4.5
       parent: 2
-  - uid: 3836
+  - uid: 4138
     components:
     - type: Transform
       pos: -6.5,41.5
       parent: 2
-  - uid: 3837
+  - uid: 4139
     components:
     - type: Transform
       pos: -59.5,-9.5
       parent: 2
-  - uid: 3838
+  - uid: 4140
     components:
     - type: Transform
       pos: -0.5,24.5
       parent: 2
-  - uid: 3839
+  - uid: 4141
     components:
     - type: Transform
       pos: -0.5,-1.5
       parent: 2
-  - uid: 3840
+  - uid: 4142
     components:
     - type: Transform
       pos: -16.5,-2.5
       parent: 2
-  - uid: 3841
+  - uid: 4143
     components:
     - type: Transform
       pos: -37.5,21.5
       parent: 2
-  - uid: 3842
+  - uid: 4144
     components:
     - type: Transform
       pos: -59.5,-42.5
       parent: 2
-  - uid: 3843
+  - uid: 4145
     components:
     - type: Transform
       pos: -33.5,-2.5
       parent: 2
-  - uid: 3844
+  - uid: 4146
     components:
     - type: Transform
       pos: -14.5,-2.5
       parent: 2
-  - uid: 3845
+  - uid: 4147
     components:
     - type: Transform
       pos: -61.5,-2.5
       parent: 2
-  - uid: 3846
+  - uid: 4148
     components:
     - type: Transform
       pos: -59.5,-34.5
       parent: 2
-  - uid: 3847
+  - uid: 4149
     components:
     - type: Transform
       pos: -11.5,-2.5
       parent: 2
-  - uid: 3848
+  - uid: 4150
     components:
     - type: Transform
       pos: -59.5,-45.5
       parent: 2
-  - uid: 3849
+  - uid: 4151
     components:
     - type: Transform
       pos: -10.5,41.5
       parent: 2
-  - uid: 3850
+  - uid: 4152
     components:
     - type: Transform
       pos: -0.5,41.5
       parent: 2
-  - uid: 3851
+  - uid: 4153
     components:
     - type: Transform
       pos: -60.5,-50.5
       parent: 2
-  - uid: 3852
+  - uid: 4154
     components:
     - type: Transform
       pos: -23.5,-2.5
       parent: 2
-  - uid: 3853
+  - uid: 4155
     components:
     - type: Transform
       pos: -59.5,-27.5
       parent: 2
-  - uid: 3854
+  - uid: 4156
     components:
     - type: Transform
       pos: -0.5,-0.5
       parent: 2
-  - uid: 3855
+  - uid: 4157
     components:
     - type: Transform
       pos: -0.5,-2.5
       parent: 2
-  - uid: 3856
+  - uid: 4158
     components:
     - type: Transform
       pos: -20.5,-2.5
       parent: 2
-  - uid: 3857
+  - uid: 4159
     components:
     - type: Transform
       pos: -59.5,-39.5
       parent: 2
-  - uid: 3858
+  - uid: 4160
     components:
     - type: Transform
       pos: -43.5,-2.5
       parent: 2
-  - uid: 3859
+  - uid: 4161
     components:
     - type: Transform
       pos: -3.5,-2.5
       parent: 2
-  - uid: 3860
+  - uid: 4162
     components:
     - type: Transform
       pos: -0.5,26.5
       parent: 2
-  - uid: 3861
+  - uid: 4163
     components:
     - type: Transform
       pos: -59.5,-40.5
       parent: 2
-  - uid: 3862
+  - uid: 4164
     components:
     - type: Transform
       pos: -59.5,-36.5
       parent: 2
-  - uid: 3863
+  - uid: 4165
     components:
     - type: Transform
       pos: -6.5,-2.5
       parent: 2
-  - uid: 3864
+  - uid: 4166
     components:
     - type: Transform
       pos: -59.5,-43.5
       parent: 2
-  - uid: 3865
+  - uid: 4167
     components:
     - type: Transform
       pos: -42.5,-2.5
       parent: 2
-  - uid: 3866
+  - uid: 4168
     components:
     - type: Transform
       pos: -59.5,-13.5
       parent: 2
-  - uid: 3867
+  - uid: 4169
     components:
     - type: Transform
       pos: -60.5,-2.5
       parent: 2
-  - uid: 3868
+  - uid: 4170
     components:
     - type: Transform
       pos: -8.5,-2.5
       parent: 2
-  - uid: 3869
+  - uid: 4171
     components:
     - type: Transform
       pos: -14.5,41.5
       parent: 2
-  - uid: 3870
+  - uid: 4172
     components:
     - type: Transform
       pos: -15.5,41.5
       parent: 2
-  - uid: 3871
+  - uid: 4173
     components:
     - type: Transform
       pos: -16.5,41.5
       parent: 2
-  - uid: 3872
+  - uid: 4174
     components:
     - type: Transform
       pos: -17.5,41.5
       parent: 2
-  - uid: 3873
+  - uid: 4175
     components:
     - type: Transform
       pos: -8.5,41.5
       parent: 2
-  - uid: 3874
+  - uid: 4176
     components:
     - type: Transform
       pos: -19.5,41.5
       parent: 2
-  - uid: 3875
+  - uid: 4177
     components:
     - type: Transform
       pos: -20.5,41.5
       parent: 2
-  - uid: 3876
+  - uid: 4178
     components:
     - type: Transform
       pos: -21.5,41.5
       parent: 2
-  - uid: 3877
+  - uid: 4179
     components:
     - type: Transform
       pos: -22.5,41.5
       parent: 2
-  - uid: 3878
+  - uid: 4180
     components:
     - type: Transform
       pos: -18.5,41.5
       parent: 2
-  - uid: 3879
+  - uid: 4181
     components:
     - type: Transform
       pos: -23.5,41.5
       parent: 2
-  - uid: 3880
+  - uid: 4182
     components:
     - type: Transform
       pos: -24.5,41.5
       parent: 2
-  - uid: 3881
+  - uid: 4183
     components:
     - type: Transform
       pos: -25.5,41.5
       parent: 2
-  - uid: 3882
+  - uid: 4184
     components:
     - type: Transform
       pos: -27.5,41.5
       parent: 2
-  - uid: 3883
+  - uid: 4185
     components:
     - type: Transform
       pos: -28.5,41.5
       parent: 2
-  - uid: 3884
+  - uid: 4186
     components:
     - type: Transform
       pos: -29.5,41.5
       parent: 2
-  - uid: 3885
+  - uid: 4187
     components:
     - type: Transform
       pos: -30.5,41.5
       parent: 2
-  - uid: 3886
+  - uid: 4188
     components:
     - type: Transform
       pos: -31.5,41.5
       parent: 2
-  - uid: 3887
+  - uid: 4189
     components:
     - type: Transform
       pos: -32.5,41.5
       parent: 2
-  - uid: 3888
+  - uid: 4190
     components:
     - type: Transform
       pos: -33.5,41.5
       parent: 2
-  - uid: 3889
+  - uid: 4191
     components:
     - type: Transform
       pos: -34.5,41.5
       parent: 2
-  - uid: 3890
+  - uid: 4192
     components:
     - type: Transform
       pos: -35.5,41.5
       parent: 2
-  - uid: 3891
+  - uid: 4193
     components:
     - type: Transform
       pos: -36.5,41.5
       parent: 2
-  - uid: 3892
+  - uid: 4194
     components:
     - type: Transform
       pos: -37.5,41.5
       parent: 2
-  - uid: 3893
+  - uid: 4195
     components:
     - type: Transform
       pos: -38.5,41.5
       parent: 2
-  - uid: 3894
+  - uid: 4196
     components:
     - type: Transform
       pos: -26.5,41.5
       parent: 2
-  - uid: 3895
+  - uid: 4197
     components:
     - type: Transform
       pos: -38.5,40.5
       parent: 2
-  - uid: 3896
+  - uid: 4198
     components:
     - type: Transform
       pos: -38.5,38.5
       parent: 2
-  - uid: 3897
+  - uid: 4199
     components:
     - type: Transform
       pos: -38.5,37.5
       parent: 2
-  - uid: 3898
+  - uid: 4200
     components:
     - type: Transform
       pos: -38.5,36.5
       parent: 2
-  - uid: 3899
+  - uid: 4201
     components:
     - type: Transform
       pos: -38.5,39.5
       parent: 2
-  - uid: 3900
+  - uid: 4202
     components:
     - type: Transform
       pos: -38.5,34.5
       parent: 2
-  - uid: 3901
+  - uid: 4203
     components:
     - type: Transform
       pos: -38.5,32.5
       parent: 2
-  - uid: 3902
+  - uid: 4204
     components:
     - type: Transform
       pos: -38.5,35.5
       parent: 2
-  - uid: 3903
+  - uid: 4205
     components:
     - type: Transform
       pos: -38.5,31.5
       parent: 2
-  - uid: 3904
+  - uid: 4206
     components:
     - type: Transform
       pos: -38.5,30.5
       parent: 2
-  - uid: 3905
+  - uid: 4207
     components:
     - type: Transform
       pos: -38.5,29.5
       parent: 2
-  - uid: 3906
+  - uid: 4208
     components:
     - type: Transform
       pos: -38.5,28.5
       parent: 2
-  - uid: 3907
+  - uid: 4209
     components:
     - type: Transform
       pos: -38.5,27.5
       parent: 2
-  - uid: 3908
+  - uid: 4210
     components:
     - type: Transform
       pos: -38.5,26.5
       parent: 2
-  - uid: 3909
+  - uid: 4211
     components:
     - type: Transform
       pos: -38.5,25.5
       parent: 2
-  - uid: 3910
+  - uid: 4212
     components:
     - type: Transform
       pos: -38.5,24.5
       parent: 2
-  - uid: 3911
+  - uid: 4213
     components:
     - type: Transform
       pos: -38.5,23.5
       parent: 2
-  - uid: 3912
+  - uid: 4214
     components:
     - type: Transform
       pos: -38.5,22.5
       parent: 2
-  - uid: 3913
+  - uid: 4215
     components:
     - type: Transform
       pos: -38.5,21.5
       parent: 2
-  - uid: 3914
+  - uid: 4216
     components:
     - type: Transform
       pos: -38.5,19.5
       parent: 2
-  - uid: 3915
+  - uid: 4217
     components:
     - type: Transform
       pos: -38.5,18.5
       parent: 2
-  - uid: 3916
+  - uid: 4218
     components:
     - type: Transform
       pos: -38.5,20.5
       parent: 2
-  - uid: 3917
+  - uid: 4219
     components:
     - type: Transform
       pos: -38.5,33.5
       parent: 2
-  - uid: 3918
+  - uid: 4220
     components:
     - type: Transform
       pos: -38.5,17.5
       parent: 2
-  - uid: 3919
+  - uid: 4221
     components:
     - type: Transform
       pos: -38.5,16.5
       parent: 2
-  - uid: 3920
+  - uid: 4222
     components:
     - type: Transform
       pos: -38.5,13.5
       parent: 2
-  - uid: 3921
+  - uid: 4223
     components:
     - type: Transform
       pos: -38.5,12.5
       parent: 2
-  - uid: 3922
+  - uid: 4224
     components:
     - type: Transform
       pos: -38.5,15.5
       parent: 2
-  - uid: 3923
+  - uid: 4225
     components:
     - type: Transform
       pos: -38.5,11.5
       parent: 2
-  - uid: 3924
+  - uid: 4226
     components:
     - type: Transform
       pos: -38.5,10.5
       parent: 2
-  - uid: 3925
+  - uid: 4227
     components:
     - type: Transform
       pos: -38.5,9.5
       parent: 2
-  - uid: 3926
+  - uid: 4228
     components:
     - type: Transform
       pos: -38.5,8.5
       parent: 2
-  - uid: 3927
+  - uid: 4229
     components:
     - type: Transform
       pos: -38.5,7.5
       parent: 2
-  - uid: 3928
+  - uid: 4230
     components:
     - type: Transform
       pos: -38.5,6.5
       parent: 2
-  - uid: 3929
+  - uid: 4231
     components:
     - type: Transform
       pos: -38.5,4.5
       parent: 2
-  - uid: 3930
+  - uid: 4232
     components:
     - type: Transform
       pos: -38.5,5.5
       parent: 2
-  - uid: 3931
+  - uid: 4233
     components:
     - type: Transform
       pos: -38.5,3.5
       parent: 2
-  - uid: 3932
+  - uid: 4234
     components:
     - type: Transform
       pos: -38.5,2.5
       parent: 2
-  - uid: 3933
+  - uid: 4235
     components:
     - type: Transform
       pos: -38.5,1.5
       parent: 2
-  - uid: 3934
+  - uid: 4236
     components:
     - type: Transform
       pos: -38.5,0.5
       parent: 2
-  - uid: 3935
+  - uid: 4237
     components:
     - type: Transform
       pos: -38.5,-0.5
       parent: 2
-  - uid: 3936
+  - uid: 4238
     components:
     - type: Transform
       pos: -38.5,14.5
       parent: 2
-  - uid: 3937
+  - uid: 4239
     components:
     - type: Transform
       pos: -38.5,-1.5
       parent: 2
-  - uid: 3938
+  - uid: 4240
     components:
     - type: Transform
       pos: -38.5,-3.5
       parent: 2
-  - uid: 3939
+  - uid: 4241
     components:
     - type: Transform
       pos: -38.5,-4.5
       parent: 2
-  - uid: 3940
+  - uid: 4242
     components:
     - type: Transform
       pos: -38.5,-5.5
       parent: 2
-  - uid: 3941
+  - uid: 4243
     components:
     - type: Transform
       pos: -38.5,-6.5
       parent: 2
-  - uid: 3942
+  - uid: 4244
     components:
     - type: Transform
       pos: -38.5,-7.5
       parent: 2
-  - uid: 3943
+  - uid: 4245
     components:
     - type: Transform
       pos: -38.5,-8.5
       parent: 2
-  - uid: 3944
+  - uid: 4246
     components:
     - type: Transform
       pos: -38.5,-9.5
       parent: 2
-  - uid: 3945
+  - uid: 4247
     components:
     - type: Transform
       pos: -38.5,-11.5
       parent: 2
-  - uid: 3946
+  - uid: 4248
     components:
     - type: Transform
       pos: -38.5,-12.5
       parent: 2
-  - uid: 3947
+  - uid: 4249
     components:
     - type: Transform
       pos: -38.5,-14.5
       parent: 2
-  - uid: 3948
+  - uid: 4250
     components:
     - type: Transform
       pos: -38.5,-10.5
       parent: 2
-  - uid: 3949
+  - uid: 4251
     components:
     - type: Transform
       pos: -38.5,-15.5
       parent: 2
-  - uid: 3950
+  - uid: 4252
     components:
     - type: Transform
       pos: -38.5,-16.5
       parent: 2
-  - uid: 3951
+  - uid: 4253
     components:
     - type: Transform
       pos: -38.5,-17.5
       parent: 2
-  - uid: 3952
+  - uid: 4254
     components:
     - type: Transform
       pos: -38.5,-18.5
       parent: 2
-  - uid: 3953
+  - uid: 4255
     components:
     - type: Transform
       pos: -38.5,-20.5
       parent: 2
-  - uid: 3954
+  - uid: 4256
     components:
     - type: Transform
       pos: -38.5,-22.5
       parent: 2
-  - uid: 3955
+  - uid: 4257
     components:
     - type: Transform
       pos: -38.5,-23.5
       parent: 2
-  - uid: 3956
+  - uid: 4258
     components:
     - type: Transform
       pos: -38.5,-13.5
       parent: 2
-  - uid: 3957
+  - uid: 4259
     components:
     - type: Transform
       pos: -38.5,-25.5
       parent: 2
-  - uid: 3958
+  - uid: 4260
     components:
     - type: Transform
       pos: -38.5,-24.5
       parent: 2
-  - uid: 3959
+  - uid: 4261
     components:
     - type: Transform
       pos: -38.5,-19.5
       parent: 2
-  - uid: 3960
+  - uid: 4262
     components:
     - type: Transform
       pos: -38.5,-27.5
       parent: 2
-  - uid: 3961
+  - uid: 4263
     components:
     - type: Transform
       pos: -38.5,-28.5
       parent: 2
-  - uid: 3962
+  - uid: 4264
     components:
     - type: Transform
       pos: -38.5,-29.5
       parent: 2
-  - uid: 3963
+  - uid: 4265
     components:
     - type: Transform
       pos: -38.5,-21.5
       parent: 2
-  - uid: 3964
+  - uid: 4266
     components:
     - type: Transform
       pos: -38.5,-26.5
       parent: 2
-  - uid: 3965
+  - uid: 4267
     components:
     - type: Transform
       pos: -37.5,-29.5
       parent: 2
-  - uid: 3966
+  - uid: 4268
     components:
     - type: Transform
       pos: -37.5,-19.5
       parent: 2
-  - uid: 3967
+  - uid: 4269
     components:
     - type: Transform
       pos: -37.5,-9.5
       parent: 2
-  - uid: 3968
+  - uid: 4270
     components:
     - type: Transform
       pos: -41.5,-1.5
       parent: 2
-  - uid: 3969
+  - uid: 4271
     components:
     - type: Transform
       pos: -31.5,-1.5
       parent: 2
-  - uid: 3970
+  - uid: 4272
     components:
     - type: Transform
       pos: -51.5,-1.5
       parent: 2
-  - uid: 3971
+  - uid: 4273
     components:
     - type: Transform
       pos: -61.5,-1.5
       parent: 2
-  - uid: 3972
+  - uid: 4274
     components:
     - type: Transform
       pos: -58.5,-10.5
       parent: 2
-  - uid: 3973
+  - uid: 4275
     components:
     - type: Transform
       pos: -37.5,4.5
       parent: 2
-  - uid: 3974
+  - uid: 4276
     components:
     - type: Transform
       pos: -8.5,42.5
       parent: 2
-  - uid: 3975
+  - uid: 4277
     components:
     - type: Transform
       pos: -37.5,31.5
       parent: 2
-  - uid: 3976
+  - uid: 4278
     components:
     - type: Transform
       pos: -37.5,42.5
       parent: 2
-  - uid: 3977
+  - uid: 4279
     components:
     - type: Transform
       pos: -27.5,42.5
       parent: 2
-  - uid: 3978
+  - uid: 4280
     components:
     - type: Transform
       pos: 0.5,39.5
       parent: 2
-  - uid: 3979
+  - uid: 4281
     components:
     - type: Transform
       pos: 0.5,12.5
       parent: 2
-  - uid: 3980
+  - uid: 4282
     components:
     - type: Transform
       pos: 0.5,2.5
       parent: 2
-  - uid: 3981
+  - uid: 4283
     components:
     - type: Transform
       pos: -5.5,-1.5
       parent: 2
-  - uid: 3982
+  - uid: 4284
     components:
     - type: Transform
       pos: -15.5,-1.5
       parent: 2
-  - uid: 3983
+  - uid: 4285
     components:
     - type: Transform
       pos: -36.5,-39.5
       parent: 2
-  - uid: 3984
+  - uid: 4286
     components:
     - type: Transform
       pos: -35.5,-39.5
       parent: 2
-  - uid: 3985
+  - uid: 4287
     components:
     - type: Transform
       pos: -37.5,-39.5
       parent: 2
-  - uid: 3986
+  - uid: 4288
     components:
     - type: Transform
       pos: -38.5,-39.5
       parent: 2
-  - uid: 3987
+  - uid: 4289
     components:
     - type: Transform
       pos: -38.5,-40.5
       parent: 2
-  - uid: 3988
+  - uid: 4290
     components:
     - type: Transform
       pos: -38.5,-41.5
       parent: 2
-  - uid: 3989
+  - uid: 4291
     components:
     - type: Transform
       pos: -38.5,-42.5
       parent: 2
-  - uid: 3990
+  - uid: 4292
     components:
     - type: Transform
       pos: -38.5,-43.5
       parent: 2
-  - uid: 3991
+  - uid: 4293
     components:
     - type: Transform
       pos: -38.5,-45.5
       parent: 2
-  - uid: 3992
+  - uid: 4294
     components:
     - type: Transform
       pos: -38.5,-46.5
       parent: 2
-  - uid: 3993
+  - uid: 4295
     components:
     - type: Transform
       pos: -38.5,-47.5
       parent: 2
-  - uid: 3994
+  - uid: 4296
     components:
     - type: Transform
       pos: -38.5,-48.5
       parent: 2
-  - uid: 3995
+  - uid: 4297
     components:
     - type: Transform
       pos: -38.5,-49.5
       parent: 2
-  - uid: 3996
+  - uid: 4298
     components:
     - type: Transform
       pos: -38.5,-44.5
       parent: 2
-  - uid: 3997
+  - uid: 4299
     components:
     - type: Transform
       pos: -37.5,-41.5
       parent: 2
-  - uid: 3998
+  - uid: 4300
     components:
     - type: Transform
       pos: -36.5,-41.5
       parent: 2
-  - uid: 3999
+  - uid: 4301
     components:
     - type: Transform
       pos: -35.5,-41.5
       parent: 2
-  - uid: 4000
+  - uid: 4302
     components:
     - type: Transform
       pos: -34.5,-41.5
       parent: 2
-  - uid: 4001
+  - uid: 4303
     components:
     - type: Transform
       pos: -33.5,-41.5
       parent: 2
-  - uid: 4002
+  - uid: 4304
     components:
     - type: Transform
       pos: -32.5,-41.5
       parent: 2
-  - uid: 4003
+  - uid: 4305
     components:
     - type: Transform
       pos: -31.5,-41.5
       parent: 2
-  - uid: 4004
+  - uid: 4306
     components:
     - type: Transform
       pos: -29.5,-41.5
       parent: 2
-  - uid: 4005
+  - uid: 4307
     components:
     - type: Transform
       pos: -30.5,-41.5
       parent: 2
-  - uid: 4006
+  - uid: 4308
     components:
     - type: Transform
       pos: -28.5,-41.5
       parent: 2
-  - uid: 4007
+  - uid: 4309
     components:
     - type: Transform
       pos: -32.5,-40.5
       parent: 2
-  - uid: 4008
+  - uid: 4310
     components:
     - type: Transform
       pos: -32.5,-39.5
       parent: 2
-  - uid: 4009
+  - uid: 4311
     components:
     - type: Transform
       pos: -32.5,-38.5
       parent: 2
-  - uid: 4010
+  - uid: 4312
     components:
     - type: Transform
       pos: -32.5,-42.5
       parent: 2
-  - uid: 4011
+  - uid: 4313
     components:
     - type: Transform
       pos: -32.5,-43.5
       parent: 2
-  - uid: 4012
+  - uid: 4314
     components:
     - type: Transform
       pos: -32.5,-44.5
       parent: 2
-  - uid: 4013
+  - uid: 4315
     components:
     - type: Transform
       pos: -32.5,-45.5
       parent: 2
-  - uid: 4014
+  - uid: 4316
     components:
     - type: Transform
       pos: -37.5,-47.5
       parent: 2
-  - uid: 4015
+  - uid: 4317
     components:
     - type: Transform
       pos: -36.5,-47.5
       parent: 2
-  - uid: 4016
+  - uid: 4318
     components:
     - type: Transform
       pos: -35.5,-47.5
       parent: 2
-  - uid: 4017
+  - uid: 4319
     components:
     - type: Transform
       pos: -37.5,-49.5
       parent: 2
-  - uid: 4018
+  - uid: 4320
     components:
     - type: Transform
       pos: -36.5,-49.5
       parent: 2
-  - uid: 4019
+  - uid: 4321
     components:
     - type: Transform
       pos: -35.5,-49.5
       parent: 2
-  - uid: 4020
+  - uid: 4322
     components:
     - type: Transform
       pos: -39.5,-49.5
       parent: 2
-  - uid: 4021
+  - uid: 4323
     components:
     - type: Transform
       pos: -40.5,-49.5
       parent: 2
-  - uid: 4022
+  - uid: 4324
     components:
     - type: Transform
       pos: -41.5,-49.5
       parent: 2
-  - uid: 4023
+  - uid: 4325
     components:
     - type: Transform
       pos: -42.5,-49.5
       parent: 2
-  - uid: 4024
+  - uid: 4326
     components:
     - type: Transform
       pos: -39.5,-47.5
       parent: 2
-  - uid: 4025
+  - uid: 4327
     components:
     - type: Transform
       pos: -40.5,-47.5
       parent: 2
-  - uid: 4026
+  - uid: 4328
     components:
     - type: Transform
       pos: -41.5,-47.5
       parent: 2
-  - uid: 4027
+  - uid: 4329
     components:
     - type: Transform
       pos: -42.5,-47.5
       parent: 2
-  - uid: 4028
+  - uid: 4330
     components:
     - type: Transform
       pos: -39.5,-41.5
       parent: 2
-  - uid: 4029
+  - uid: 4331
     components:
     - type: Transform
       pos: -40.5,-41.5
       parent: 2
-  - uid: 4030
+  - uid: 4332
     components:
     - type: Transform
       pos: -41.5,-41.5
       parent: 2
-  - uid: 4031
+  - uid: 4333
     components:
     - type: Transform
       pos: -42.5,-41.5
       parent: 2
-  - uid: 4032
+  - uid: 4334
     components:
     - type: Transform
       pos: -43.5,-41.5
       parent: 2
-  - uid: 4033
+  - uid: 4335
     components:
     - type: Transform
       pos: -45.5,-41.5
       parent: 2
-  - uid: 4034
+  - uid: 4336
     components:
     - type: Transform
       pos: -44.5,-41.5
       parent: 2
-  - uid: 4035
+  - uid: 4337
     components:
     - type: Transform
       pos: -45.5,-40.5
       parent: 2
-  - uid: 4036
+  - uid: 4338
     components:
     - type: Transform
       pos: -45.5,-39.5
       parent: 2
-  - uid: 4037
+  - uid: 4339
     components:
     - type: Transform
       pos: -45.5,-38.5
       parent: 2
-  - uid: 4038
+  - uid: 4340
     components:
     - type: Transform
       pos: -46.5,-41.5
       parent: 2
-  - uid: 4039
+  - uid: 4341
     components:
     - type: Transform
       pos: -47.5,-41.5
       parent: 2
-  - uid: 4040
+  - uid: 4342
     components:
     - type: Transform
       pos: -48.5,-41.5
       parent: 2
-  - uid: 4041
+  - uid: 4343
     components:
     - type: Transform
       pos: -49.5,-41.5
       parent: 2
-  - uid: 4042
+  - uid: 4344
     components:
     - type: Transform
       pos: -45.5,-42.5
       parent: 2
-  - uid: 4043
+  - uid: 4345
     components:
     - type: Transform
       pos: -45.5,-43.5
       parent: 2
-  - uid: 4044
+  - uid: 4346
     components:
     - type: Transform
       pos: -45.5,-44.5
       parent: 2
-  - uid: 4045
+  - uid: 4347
     components:
     - type: Transform
       pos: -45.5,-45.5
       parent: 2
-  - uid: 4046
+  - uid: 4348
     components:
     - type: Transform
       pos: -39.5,-43.5
       parent: 2
-  - uid: 4047
+  - uid: 4349
     components:
     - type: Transform
       pos: -38.5,-38.5
       parent: 2
-  - uid: 4048
+  - uid: 4350
     components:
     - type: Transform
       pos: -38.5,-37.5
       parent: 2
-  - uid: 4049
+  - uid: 4351
     components:
     - type: Transform
       pos: -86.5,-0.5
       parent: 2
-  - uid: 4050
+  - uid: 4352
     components:
     - type: Transform
       pos: -86.5,-1.5
       parent: 2
-  - uid: 4051
+  - uid: 4353
     components:
     - type: Transform
       pos: -86.5,-2.5
       parent: 2
-  - uid: 4052
+  - uid: 4354
     components:
     - type: Transform
       pos: -85.5,-2.5
       parent: 2
-  - uid: 4053
+  - uid: 4355
     components:
     - type: Transform
       pos: -83.5,-2.5
       parent: 2
-  - uid: 4054
+  - uid: 4356
     components:
     - type: Transform
       pos: -82.5,-2.5
       parent: 2
-  - uid: 4055
+  - uid: 4357
     components:
     - type: Transform
       pos: -81.5,-2.5
       parent: 2
-  - uid: 4056
+  - uid: 4358
     components:
     - type: Transform
       pos: -84.5,-2.5
       parent: 2
-  - uid: 4057
+  - uid: 4359
     components:
     - type: Transform
       pos: -80.5,-2.5
       parent: 2
-  - uid: 4058
+  - uid: 4360
     components:
     - type: Transform
       pos: -79.5,-2.5
       parent: 2
-  - uid: 4059
+  - uid: 4361
     components:
     - type: Transform
       pos: -78.5,-2.5
       parent: 2
-  - uid: 4060
+  - uid: 4362
     components:
     - type: Transform
       pos: -77.5,-2.5
       parent: 2
-  - uid: 4061
+  - uid: 4363
     components:
     - type: Transform
       pos: -74.5,-2.5
       parent: 2
-  - uid: 4062
+  - uid: 4364
     components:
     - type: Transform
       pos: -73.5,-2.5
       parent: 2
-  - uid: 4063
+  - uid: 4365
     components:
     - type: Transform
       pos: -76.5,-2.5
       parent: 2
-  - uid: 4064
+  - uid: 4366
     components:
     - type: Transform
       pos: -75.5,-2.5
       parent: 2
-  - uid: 4065
+  - uid: 4367
     components:
     - type: Transform
       pos: -82.5,-4.5
       parent: 2
-  - uid: 4066
+  - uid: 4368
     components:
     - type: Transform
       pos: -82.5,-3.5
       parent: 2
-  - uid: 4067
+  - uid: 4369
     components:
     - type: Transform
       pos: -82.5,-5.5
       parent: 2
-  - uid: 4068
+  - uid: 4370
     components:
     - type: Transform
       pos: -82.5,-6.5
       parent: 2
-  - uid: 4069
+  - uid: 4371
     components:
     - type: Transform
       pos: -82.5,-7.5
       parent: 2
-  - uid: 4070
+  - uid: 4372
     components:
     - type: Transform
       pos: -82.5,-8.5
       parent: 2
-  - uid: 4071
+  - uid: 4373
     components:
     - type: Transform
       pos: -82.5,-10.5
       parent: 2
-  - uid: 4072
+  - uid: 4374
     components:
     - type: Transform
       pos: -82.5,-9.5
       parent: 2
-  - uid: 4073
+  - uid: 4375
     components:
     - type: Transform
       pos: -83.5,-8.5
       parent: 2
-  - uid: 4074
+  - uid: 4376
     components:
     - type: Transform
       pos: -82.5,-1.5
       parent: 2
-  - uid: 4075
+  - uid: 4377
     components:
     - type: Transform
       pos: -82.5,-0.5
       parent: 2
-  - uid: 4076
+  - uid: 4378
     components:
     - type: Transform
       pos: -82.5,0.5
       parent: 2
-  - uid: 4077
+  - uid: 4379
     components:
     - type: Transform
       pos: -82.5,1.5
       parent: 2
-  - uid: 4078
+  - uid: 4380
     components:
     - type: Transform
       pos: -82.5,2.5
       parent: 2
-  - uid: 4079
+  - uid: 4381
     components:
     - type: Transform
       pos: -82.5,3.5
       parent: 2
-  - uid: 4080
+  - uid: 4382
     components:
     - type: Transform
       pos: -82.5,4.5
       parent: 2
-  - uid: 4081
+  - uid: 4383
     components:
     - type: Transform
       pos: -83.5,4.5
       parent: 2
-  - uid: 4082
+  - uid: 4384
     components:
     - type: Transform
       pos: -83.5,2.5
       parent: 2
-  - uid: 4083
+  - uid: 4385
     components:
     - type: Transform
       pos: -87.5,-2.5
       parent: 2
-  - uid: 4084
+  - uid: 4386
     components:
     - type: Transform
       pos: -88.5,-2.5
       parent: 2
-  - uid: 4085
+  - uid: 4387
     components:
     - type: Transform
       pos: -89.5,-2.5
       parent: 2
-  - uid: 4086
+  - uid: 4388
     components:
     - type: Transform
       pos: -90.5,-2.5
       parent: 2
-  - uid: 4087
+  - uid: 4389
     components:
     - type: Transform
       pos: -91.5,-2.5
       parent: 2
-  - uid: 4088
+  - uid: 4390
     components:
     - type: Transform
       pos: -92.5,-2.5
       parent: 2
-  - uid: 4089
+  - uid: 4391
     components:
     - type: Transform
       pos: -93.5,-2.5
       parent: 2
-  - uid: 4090
+  - uid: 4392
     components:
     - type: Transform
       pos: -94.5,-2.5
       parent: 2
-  - uid: 4091
+  - uid: 4393
     components:
     - type: Transform
       pos: -95.5,-2.5
       parent: 2
-  - uid: 4092
+  - uid: 4394
     components:
     - type: Transform
       pos: -96.5,-2.5
       parent: 2
-  - uid: 4093
+  - uid: 4395
     components:
     - type: Transform
       pos: -97.5,-2.5
       parent: 2
-  - uid: 4094
+  - uid: 4396
     components:
     - type: Transform
       pos: -98.5,-2.5
       parent: 2
-  - uid: 4095
+  - uid: 4397
     components:
     - type: Transform
       pos: -100.5,-2.5
       parent: 2
-  - uid: 4096
+  - uid: 4398
     components:
     - type: Transform
       pos: -99.5,-2.5
       parent: 2
-  - uid: 4097
+  - uid: 4399
     components:
     - type: Transform
       pos: -100.5,-3.5
       parent: 2
-  - uid: 4098
+  - uid: 4400
     components:
     - type: Transform
       pos: -98.5,-3.5
       parent: 2
-  - uid: 4099
+  - uid: 4401
     components:
     - type: Transform
       pos: -93.5,-1.5
       parent: 2
-  - uid: 4100
+  - uid: 4402
     components:
     - type: Transform
       pos: -93.5,-0.5
       parent: 2
-  - uid: 4101
+  - uid: 4403
     components:
     - type: Transform
       pos: -93.5,0.5
       parent: 2
-  - uid: 4102
+  - uid: 4404
     components:
     - type: Transform
       pos: -93.5,1.5
       parent: 2
-  - uid: 4103
+  - uid: 4405
     components:
     - type: Transform
       pos: -93.5,3.5
       parent: 2
-  - uid: 4104
+  - uid: 4406
     components:
     - type: Transform
       pos: -93.5,4.5
       parent: 2
-  - uid: 4105
+  - uid: 4407
     components:
     - type: Transform
       pos: -93.5,2.5
       parent: 2
-  - uid: 4106
+  - uid: 4408
     components:
     - type: Transform
       pos: -94.5,2.5
       parent: 2
-  - uid: 4107
+  - uid: 4409
     components:
     - type: Transform
       pos: -93.5,-3.5
       parent: 2
-  - uid: 4108
+  - uid: 4410
     components:
     - type: Transform
       pos: -93.5,-4.5
       parent: 2
-  - uid: 4109
+  - uid: 4411
     components:
     - type: Transform
       pos: -93.5,-6.5
       parent: 2
-  - uid: 4110
+  - uid: 4412
     components:
     - type: Transform
       pos: -93.5,-8.5
       parent: 2
-  - uid: 4111
+  - uid: 4413
     components:
     - type: Transform
       pos: -93.5,-9.5
       parent: 2
-  - uid: 4112
+  - uid: 4414
     components:
     - type: Transform
       pos: -93.5,-7.5
       parent: 2
-  - uid: 4113
+  - uid: 4415
     components:
     - type: Transform
       pos: -94.5,-8.5
       parent: 2
-  - uid: 4114
+  - uid: 4416
     components:
     - type: Transform
       pos: -93.5,-5.5
       parent: 2
-  - uid: 4115
+  - uid: 4417
     components:
     - type: Transform
       pos: -61.5,-50.5
       parent: 2
-  - uid: 4116
+  - uid: 4418
     components:
     - type: Transform
       pos: -62.5,-50.5
       parent: 2
-  - uid: 4117
+  - uid: 4419
     components:
     - type: Transform
       pos: -59.5,-48.5
       parent: 2
-  - uid: 4118
+  - uid: 4420
     components:
     - type: Transform
       pos: -59.5,-47.5
       parent: 2
-  - uid: 4119
+  - uid: 4421
     components:
     - type: Transform
       pos: -93.5,5.5
       parent: 2
-  - uid: 4120
+  - uid: 4422
     components:
     - type: Transform
       pos: -94.5,5.5
       parent: 2
-  - uid: 4121
+  - uid: 4423
     components:
     - type: Transform
       pos: -93.5,-10.5
       parent: 2
-  - uid: 4122
+  - uid: 4424
     components:
     - type: Transform
       pos: -94.5,-10.5
       parent: 2
-  - uid: 4123
+  - uid: 4425
     components:
     - type: Transform
       pos: -81.5,-12.5
       parent: 2
-  - uid: 4124
+  - uid: 4426
     components:
     - type: Transform
       pos: -81.5,-11.5
       parent: 2
-  - uid: 4125
+  - uid: 4427
     components:
     - type: Transform
       pos: -82.5,-11.5
       parent: 2
-  - uid: 4126
+  - uid: 4428
     components:
     - type: Transform
       pos: -83.5,-11.5
       parent: 2
-  - uid: 4127
+  - uid: 4429
     components:
     - type: Transform
       pos: -84.5,-11.5
       parent: 2
-  - uid: 4128
+  - uid: 4430
     components:
     - type: Transform
       pos: -84.5,-12.5
       parent: 2
 - proto: CableHV
   entities:
-  - uid: 4129
+  - uid: 4431
     components:
     - type: Transform
       pos: -80.5,-10.5
       parent: 2
-  - uid: 4130
+  - uid: 4432
     components:
     - type: Transform
       pos: -80.5,-11.5
       parent: 2
-  - uid: 4131
+  - uid: 4433
     components:
     - type: Transform
       pos: -85.5,-10.5
       parent: 2
-  - uid: 4132
+  - uid: 4434
     components:
     - type: Transform
       pos: -85.5,-11.5
       parent: 2
-  - uid: 4133
+  - uid: 4435
     components:
     - type: Transform
       pos: -84.5,-10.5
       parent: 2
-  - uid: 4134
+  - uid: 4436
     components:
     - type: Transform
       pos: -83.5,-10.5
       parent: 2
-  - uid: 4135
+  - uid: 4437
     components:
     - type: Transform
       pos: -82.5,-11.5
       parent: 2
-  - uid: 4136
+  - uid: 4438
     components:
     - type: Transform
       pos: -82.5,-10.5
       parent: 2
-  - uid: 4137
+  - uid: 4439
     components:
     - type: Transform
       pos: -81.5,-10.5
       parent: 2
-  - uid: 4138
+  - uid: 4440
     components:
     - type: Transform
       pos: -82.5,-12.5
       parent: 2
-  - uid: 4139
+  - uid: 4441
     components:
     - type: Transform
       pos: -85.5,-9.5
       parent: 2
 - proto: CableMV
   entities:
-  - uid: 4140
+  - uid: 4442
     components:
     - type: Transform
       pos: -72.5,-2.5
       parent: 2
-  - uid: 4141
+  - uid: 4443
     components:
     - type: Transform
       pos: -59.5,-2.5
       parent: 2
-  - uid: 4142
+  - uid: 4444
     components:
     - type: Transform
       pos: -60.5,-2.5
       parent: 2
-  - uid: 4143
+  - uid: 4445
     components:
     - type: Transform
       pos: -61.5,-2.5
       parent: 2
-  - uid: 4144
+  - uid: 4446
     components:
     - type: Transform
       pos: -62.5,-2.5
       parent: 2
-  - uid: 4145
+  - uid: 4447
     components:
     - type: Transform
       pos: -63.5,-2.5
       parent: 2
-  - uid: 4146
+  - uid: 4448
     components:
     - type: Transform
       pos: -64.5,-2.5
       parent: 2
-  - uid: 4147
+  - uid: 4449
     components:
     - type: Transform
       pos: -65.5,-2.5
       parent: 2
-  - uid: 4148
+  - uid: 4450
     components:
     - type: Transform
       pos: -67.5,-2.5
       parent: 2
-  - uid: 4149
+  - uid: 4451
     components:
     - type: Transform
       pos: -68.5,-2.5
       parent: 2
-  - uid: 4150
+  - uid: 4452
     components:
     - type: Transform
       pos: -69.5,-2.5
       parent: 2
-  - uid: 4151
+  - uid: 4453
     components:
     - type: Transform
       pos: -70.5,-2.5
       parent: 2
-  - uid: 4152
+  - uid: 4454
     components:
     - type: Transform
       pos: -66.5,-2.5
       parent: 2
-  - uid: 4153
+  - uid: 4455
     components:
     - type: Transform
       pos: -58.5,-2.5
       parent: 2
-  - uid: 4154
+  - uid: 4456
     components:
     - type: Transform
       pos: -57.5,-2.5
       parent: 2
-  - uid: 4155
+  - uid: 4457
     components:
     - type: Transform
       pos: -56.5,-2.5
       parent: 2
-  - uid: 4156
+  - uid: 4458
     components:
     - type: Transform
       pos: -55.5,-2.5
       parent: 2
-  - uid: 4157
+  - uid: 4459
     components:
     - type: Transform
       pos: -54.5,-2.5
       parent: 2
-  - uid: 4158
+  - uid: 4460
     components:
     - type: Transform
       pos: -53.5,-2.5
       parent: 2
-  - uid: 4159
+  - uid: 4461
     components:
     - type: Transform
       pos: -51.5,-2.5
       parent: 2
-  - uid: 4160
+  - uid: 4462
     components:
     - type: Transform
       pos: -50.5,-2.5
       parent: 2
-  - uid: 4161
+  - uid: 4463
     components:
     - type: Transform
       pos: -49.5,-2.5
       parent: 2
-  - uid: 4162
+  - uid: 4464
     components:
     - type: Transform
       pos: -48.5,-2.5
       parent: 2
-  - uid: 4163
+  - uid: 4465
     components:
     - type: Transform
       pos: -47.5,-2.5
       parent: 2
-  - uid: 4164
+  - uid: 4466
     components:
     - type: Transform
       pos: -46.5,-2.5
       parent: 2
-  - uid: 4165
+  - uid: 4467
     components:
     - type: Transform
       pos: -45.5,-2.5
       parent: 2
-  - uid: 4166
+  - uid: 4468
     components:
     - type: Transform
       pos: -44.5,-2.5
       parent: 2
-  - uid: 4167
+  - uid: 4469
     components:
     - type: Transform
       pos: -43.5,-2.5
       parent: 2
-  - uid: 4168
+  - uid: 4470
     components:
     - type: Transform
       pos: -42.5,-2.5
       parent: 2
-  - uid: 4169
+  - uid: 4471
     components:
     - type: Transform
       pos: -41.5,-2.5
       parent: 2
-  - uid: 4170
+  - uid: 4472
     components:
     - type: Transform
       pos: -40.5,-2.5
       parent: 2
-  - uid: 4171
+  - uid: 4473
     components:
     - type: Transform
       pos: -52.5,-2.5
       parent: 2
-  - uid: 4172
+  - uid: 4474
     components:
     - type: Transform
       pos: -39.5,-2.5
       parent: 2
-  - uid: 4173
+  - uid: 4475
     components:
     - type: Transform
       pos: -38.5,-2.5
       parent: 2
-  - uid: 4174
+  - uid: 4476
     components:
     - type: Transform
       pos: -38.5,-3.5
       parent: 2
-  - uid: 4175
+  - uid: 4477
     components:
     - type: Transform
       pos: -38.5,-4.5
       parent: 2
-  - uid: 4176
+  - uid: 4478
     components:
     - type: Transform
       pos: -38.5,-5.5
       parent: 2
-  - uid: 4177
+  - uid: 4479
     components:
     - type: Transform
       pos: -38.5,-6.5
       parent: 2
-  - uid: 4178
+  - uid: 4480
     components:
     - type: Transform
       pos: -38.5,-7.5
       parent: 2
-  - uid: 4179
+  - uid: 4481
     components:
     - type: Transform
       pos: -38.5,-8.5
       parent: 2
-  - uid: 4180
+  - uid: 4482
     components:
     - type: Transform
       pos: -38.5,-9.5
       parent: 2
-  - uid: 4181
+  - uid: 4483
     components:
     - type: Transform
       pos: -38.5,-10.5
       parent: 2
-  - uid: 4182
+  - uid: 4484
     components:
     - type: Transform
       pos: -38.5,-12.5
       parent: 2
-  - uid: 4183
+  - uid: 4485
     components:
     - type: Transform
       pos: -38.5,-13.5
       parent: 2
-  - uid: 4184
+  - uid: 4486
     components:
     - type: Transform
       pos: -38.5,-14.5
       parent: 2
-  - uid: 4185
+  - uid: 4487
     components:
     - type: Transform
       pos: -38.5,-15.5
       parent: 2
-  - uid: 4186
+  - uid: 4488
     components:
     - type: Transform
       pos: -38.5,-16.5
       parent: 2
-  - uid: 4187
+  - uid: 4489
     components:
     - type: Transform
       pos: -38.5,-17.5
       parent: 2
-  - uid: 4188
+  - uid: 4490
     components:
     - type: Transform
       pos: -38.5,-18.5
       parent: 2
-  - uid: 4189
+  - uid: 4491
     components:
     - type: Transform
       pos: -38.5,-19.5
       parent: 2
-  - uid: 4190
+  - uid: 4492
     components:
     - type: Transform
       pos: -38.5,-20.5
       parent: 2
-  - uid: 4191
+  - uid: 4493
     components:
     - type: Transform
       pos: -38.5,-11.5
       parent: 2
-  - uid: 4192
+  - uid: 4494
     components:
     - type: Transform
       pos: -38.5,-23.5
       parent: 2
-  - uid: 4193
+  - uid: 4495
     components:
     - type: Transform
       pos: -38.5,-24.5
       parent: 2
-  - uid: 4194
+  - uid: 4496
     components:
     - type: Transform
       pos: -38.5,-25.5
       parent: 2
-  - uid: 4195
+  - uid: 4497
     components:
     - type: Transform
       pos: -38.5,-21.5
       parent: 2
-  - uid: 4196
+  - uid: 4498
     components:
     - type: Transform
       pos: -38.5,-27.5
       parent: 2
-  - uid: 4197
+  - uid: 4499
     components:
     - type: Transform
       pos: -38.5,-28.5
       parent: 2
-  - uid: 4198
+  - uid: 4500
     components:
     - type: Transform
       pos: -38.5,-22.5
       parent: 2
-  - uid: 4199
+  - uid: 4501
     components:
     - type: Transform
       pos: -38.5,-29.5
       parent: 2
-  - uid: 4200
+  - uid: 4502
     components:
     - type: Transform
       pos: -38.5,-31.5
       parent: 2
-  - uid: 4201
+  - uid: 4503
     components:
     - type: Transform
       pos: -38.5,-32.5
       parent: 2
-  - uid: 4202
+  - uid: 4504
     components:
     - type: Transform
       pos: -38.5,-26.5
       parent: 2
-  - uid: 4203
+  - uid: 4505
     components:
     - type: Transform
       pos: -38.5,-33.5
       parent: 2
-  - uid: 4204
+  - uid: 4506
     components:
     - type: Transform
       pos: -38.5,-34.5
       parent: 2
-  - uid: 4205
+  - uid: 4507
     components:
     - type: Transform
       pos: -38.5,-30.5
       parent: 2
-  - uid: 4206
+  - uid: 4508
     components:
     - type: Transform
       pos: -71.5,-2.5
       parent: 2
-  - uid: 4207
+  - uid: 4509
     components:
     - type: Transform
       pos: -73.5,-2.5
       parent: 2
-  - uid: 4208
+  - uid: 4510
     components:
     - type: Transform
       pos: -74.5,-2.5
       parent: 2
-  - uid: 4209
+  - uid: 4511
     components:
     - type: Transform
       pos: -75.5,-2.5
       parent: 2
-  - uid: 4210
+  - uid: 4512
     components:
     - type: Transform
       pos: -76.5,-2.5
       parent: 2
-  - uid: 4211
+  - uid: 4513
     components:
     - type: Transform
       pos: -77.5,-2.5
       parent: 2
-  - uid: 4212
+  - uid: 4514
     components:
     - type: Transform
       pos: -78.5,-2.5
       parent: 2
-  - uid: 4213
+  - uid: 4515
     components:
     - type: Transform
       pos: -79.5,-2.5
       parent: 2
-  - uid: 4214
+  - uid: 4516
     components:
     - type: Transform
       pos: -80.5,-2.5
       parent: 2
-  - uid: 4215
+  - uid: 4517
     components:
     - type: Transform
       pos: -81.5,-2.5
       parent: 2
-  - uid: 4216
+  - uid: 4518
     components:
     - type: Transform
       pos: -82.5,-2.5
       parent: 2
-  - uid: 4217
+  - uid: 4519
     components:
     - type: Transform
       pos: -82.5,-3.5
       parent: 2
-  - uid: 4218
+  - uid: 4520
     components:
     - type: Transform
       pos: -82.5,-4.5
       parent: 2
-  - uid: 4219
+  - uid: 4521
     components:
     - type: Transform
       pos: -82.5,-5.5
       parent: 2
-  - uid: 4220
+  - uid: 4522
     components:
     - type: Transform
       pos: -82.5,-6.5
       parent: 2
-  - uid: 4221
+  - uid: 4523
     components:
     - type: Transform
       pos: -83.5,-2.5
       parent: 2
-  - uid: 4222
+  - uid: 4524
     components:
     - type: Transform
       pos: -84.5,-2.5
       parent: 2
-  - uid: 4223
+  - uid: 4525
     components:
     - type: Transform
       pos: -86.5,-2.5
       parent: 2
-  - uid: 4224
+  - uid: 4526
     components:
     - type: Transform
       pos: -85.5,-2.5
       parent: 2
-  - uid: 4225
+  - uid: 4527
     components:
     - type: Transform
       pos: -86.5,-1.5
       parent: 2
-  - uid: 4226
+  - uid: 4528
     components:
     - type: Transform
       pos: -86.5,-0.5
       parent: 2
-  - uid: 4227
+  - uid: 4529
     components:
     - type: Transform
       pos: -38.5,-35.5
       parent: 2
-  - uid: 4228
+  - uid: 4530
     components:
     - type: Transform
       pos: -38.5,-36.5
       parent: 2
-  - uid: 4229
+  - uid: 4531
     components:
     - type: Transform
       pos: -38.5,-37.5
       parent: 2
-  - uid: 4230
+  - uid: 4532
     components:
     - type: Transform
       pos: -38.5,-39.5
       parent: 2
-  - uid: 4231
+  - uid: 4533
     components:
     - type: Transform
       pos: -38.5,-38.5
       parent: 2
-  - uid: 4232
+  - uid: 4534
     components:
     - type: Transform
       pos: -37.5,-39.5
       parent: 2
-  - uid: 4233
+  - uid: 4535
     components:
     - type: Transform
       pos: -36.5,-39.5
       parent: 2
-  - uid: 4234
+  - uid: 4536
     components:
     - type: Transform
       pos: -35.5,-39.5
       parent: 2
-  - uid: 4235
+  - uid: 4537
     components:
     - type: Transform
       pos: -61.5,-1.5
       parent: 2
-  - uid: 4236
+  - uid: 4538
     components:
     - type: Transform
       pos: -82.5,-11.5
       parent: 2
-  - uid: 4237
+  - uid: 4539
     components:
     - type: Transform
       pos: -82.5,-12.5
       parent: 2
-  - uid: 4238
+  - uid: 4540
     components:
     - type: Transform
       pos: -82.5,-9.5
       parent: 2
-  - uid: 4239
+  - uid: 4541
     components:
     - type: Transform
       pos: -82.5,-10.5
       parent: 2
-  - uid: 4240
+  - uid: 4542
     components:
     - type: Transform
       pos: -82.5,-7.5
       parent: 2
-  - uid: 4241
+  - uid: 4543
     components:
     - type: Transform
       pos: -82.5,-8.5
       parent: 2
 - proto: CandleRedInfinite
   entities:
-  - uid: 4242
+  - uid: 4544
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
@@ -23719,13 +23725,13 @@ entities:
       parent: 2
 - proto: Carpet
   entities:
-  - uid: 4243
+  - uid: 4545
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: -33.5,-49.5
       parent: 2
-  - uid: 4244
+  - uid: 4546
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
@@ -23733,49 +23739,49 @@ entities:
       parent: 2
 - proto: CarpetBlack
   entities:
-  - uid: 4245
+  - uid: 4547
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: -43.5,-38.5
       parent: 2
-  - uid: 4246
+  - uid: 4548
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: -43.5,-37.5
       parent: 2
-  - uid: 4247
+  - uid: 4549
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: -44.5,-50.5
       parent: 2
-  - uid: 4248
+  - uid: 4550
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: -44.5,-49.5
       parent: 2
-  - uid: 4249
+  - uid: 4551
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: -44.5,-36.5
       parent: 2
-  - uid: 4250
+  - uid: 4552
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: -44.5,-37.5
       parent: 2
-  - uid: 4251
+  - uid: 4553
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: -43.5,-36.5
       parent: 2
-  - uid: 4252
+  - uid: 4554
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
@@ -23783,19 +23789,19 @@ entities:
       parent: 2
 - proto: CarpetGreen
   entities:
-  - uid: 4253
+  - uid: 4555
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: -45.5,-47.5
       parent: 2
-  - uid: 4254
+  - uid: 4556
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: -46.5,-47.5
       parent: 2
-  - uid: 4255
+  - uid: 4557
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
@@ -23803,37 +23809,37 @@ entities:
       parent: 2
 - proto: CarpetOrange
   entities:
-  - uid: 4256
+  - uid: 4558
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: -30.5,-36.5
       parent: 2
-  - uid: 4257
+  - uid: 4559
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: -30.5,-37.5
       parent: 2
-  - uid: 4258
+  - uid: 4560
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: -30.5,-38.5
       parent: 2
-  - uid: 4259
+  - uid: 4561
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: -31.5,-36.5
       parent: 2
-  - uid: 4260
+  - uid: 4562
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: -31.5,-37.5
       parent: 2
-  - uid: 4261
+  - uid: 4563
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
@@ -23841,13 +23847,13 @@ entities:
       parent: 2
 - proto: CarpetPink
   entities:
-  - uid: 4262
+  - uid: 4564
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: -42.5,-46.5
       parent: 2
-  - uid: 4263
+  - uid: 4565
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
@@ -23855,13 +23861,13 @@ entities:
       parent: 2
 - proto: CarpetPurple
   entities:
-  - uid: 4264
+  - uid: 4566
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: -34.5,-46.5
       parent: 2
-  - uid: 4265
+  - uid: 4567
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
@@ -23869,19 +23875,19 @@ entities:
       parent: 2
 - proto: CarpetSBlue
   entities:
-  - uid: 4266
+  - uid: 4568
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: -32.5,-47.5
       parent: 2
-  - uid: 4267
+  - uid: 4569
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: -30.5,-47.5
       parent: 2
-  - uid: 4268
+  - uid: 4570
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
@@ -23889,1120 +23895,1120 @@ entities:
       parent: 2
 - proto: Catwalk
   entities:
-  - uid: 4269
+  - uid: 4571
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: -61.5,-50.5
       parent: 2
-  - uid: 4270
+  - uid: 4572
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: -63.5,-50.5
       parent: 2
-  - uid: 4271
+  - uid: 4573
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: -59.5,-37.5
       parent: 2
-  - uid: 4272
+  - uid: 4574
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: -58.5,-40.5
       parent: 2
-  - uid: 4273
+  - uid: 4575
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: -60.5,-29.5
       parent: 2
-  - uid: 4274
+  - uid: 4576
     components:
     - type: Transform
       pos: -21.5,-3.5
       parent: 2
-  - uid: 4275
+  - uid: 4577
     components:
     - type: Transform
       pos: -38.5,15.5
       parent: 2
-  - uid: 4276
+  - uid: 4578
     components:
     - type: Transform
       pos: -0.5,21.5
       parent: 2
-  - uid: 4277
+  - uid: 4579
     components:
     - type: Transform
       pos: -39.5,18.5
       parent: 2
-  - uid: 4278
+  - uid: 4580
     components:
     - type: Transform
       pos: -20.5,40.5
       parent: 2
-  - uid: 4279
+  - uid: 4581
     components:
     - type: Transform
       pos: -17.5,40.5
       parent: 2
-  - uid: 4280
+  - uid: 4582
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: -60.5,-43.5
       parent: 2
-  - uid: 4281
+  - uid: 4583
     components:
     - type: Transform
       pos: -39.5,11.5
       parent: 2
-  - uid: 4282
+  - uid: 4584
     components:
     - type: Transform
       pos: -0.5,31.5
       parent: 2
-  - uid: 4283
+  - uid: 4585
     components:
     - type: Transform
       pos: -19.5,41.5
       parent: 2
-  - uid: 4284
+  - uid: 4586
     components:
     - type: Transform
       pos: -0.5,26.5
       parent: 2
-  - uid: 4285
+  - uid: 4587
     components:
     - type: Transform
       pos: -38.5,16.5
       parent: 2
-  - uid: 4286
+  - uid: 4588
     components:
     - type: Transform
       pos: -16.5,40.5
       parent: 2
-  - uid: 4287
+  - uid: 4589
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: -61.5,-52.5
       parent: 2
-  - uid: 4288
+  - uid: 4590
     components:
     - type: Transform
       pos: -24.5,-3.5
       parent: 2
-  - uid: 4289
+  - uid: 4591
     components:
     - type: Transform
       pos: -22.5,-3.5
       parent: 2
-  - uid: 4290
+  - uid: 4592
     components:
     - type: Transform
       pos: -38.5,11.5
       parent: 2
-  - uid: 4291
+  - uid: 4593
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: -59.5,-34.5
       parent: 2
-  - uid: 4292
+  - uid: 4594
     components:
     - type: Transform
       pos: -20.5,41.5
       parent: 2
-  - uid: 4293
+  - uid: 4595
     components:
     - type: Transform
       pos: -15.5,41.5
       parent: 2
-  - uid: 4294
+  - uid: 4596
     components:
     - type: Transform
       pos: -20.5,-2.5
       parent: 2
-  - uid: 4295
+  - uid: 4597
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: -59.5,-50.5
       parent: 2
-  - uid: 4296
+  - uid: 4598
     components:
     - type: Transform
       pos: -1.5,23.5
       parent: 2
-  - uid: 4297
+  - uid: 4599
     components:
     - type: Transform
       pos: -38.5,18.5
       parent: 2
-  - uid: 4298
+  - uid: 4600
     components:
     - type: Transform
       pos: -9.5,40.5
       parent: 2
-  - uid: 4299
+  - uid: 4601
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: -64.5,-51.5
       parent: 2
-  - uid: 4300
+  - uid: 4602
     components:
     - type: Transform
       pos: -0.5,33.5
       parent: 2
-  - uid: 4301
+  - uid: 4603
     components:
     - type: Transform
       pos: -13.5,40.5
       parent: 2
-  - uid: 4302
+  - uid: 4604
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: -59.5,-43.5
       parent: 2
-  - uid: 4303
+  - uid: 4605
     components:
     - type: Transform
       pos: -38.5,17.5
       parent: 2
-  - uid: 4304
+  - uid: 4606
     components:
     - type: Transform
       pos: -39.5,15.5
       parent: 2
-  - uid: 4305
+  - uid: 4607
     components:
     - type: Transform
       pos: -1.5,28.5
       parent: 2
-  - uid: 4306
+  - uid: 4608
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: -59.5,-47.5
       parent: 2
-  - uid: 4307
+  - uid: 4609
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: -59.5,-45.5
       parent: 2
-  - uid: 4308
+  - uid: 4610
     components:
     - type: Transform
       pos: -39.5,17.5
       parent: 2
-  - uid: 4309
+  - uid: 4611
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: -60.5,-47.5
       parent: 2
-  - uid: 4310
+  - uid: 4612
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: -62.5,-52.5
       parent: 2
-  - uid: 4311
+  - uid: 4613
     components:
     - type: Transform
       pos: -21.5,-2.5
       parent: 2
-  - uid: 4312
+  - uid: 4614
     components:
     - type: Transform
       pos: -11.5,41.5
       parent: 2
-  - uid: 4313
+  - uid: 4615
     components:
     - type: Transform
       pos: -11.5,40.5
       parent: 2
-  - uid: 4314
+  - uid: 4616
     components:
     - type: Transform
       pos: -23.5,-3.5
       parent: 2
-  - uid: 4315
+  - uid: 4617
     components:
     - type: Transform
       pos: -16.5,41.5
       parent: 2
-  - uid: 4316
+  - uid: 4618
     components:
     - type: Transform
       pos: -1.5,27.5
       parent: 2
-  - uid: 4317
+  - uid: 4619
     components:
     - type: Transform
       pos: -25.5,-2.5
       parent: 2
-  - uid: 4318
+  - uid: 4620
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: -64.5,-49.5
       parent: 2
-  - uid: 4319
+  - uid: 4621
     components:
     - type: Transform
       pos: -18.5,-2.5
       parent: 2
-  - uid: 4320
+  - uid: 4622
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: -64.5,-50.5
       parent: 2
-  - uid: 4321
+  - uid: 4623
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: -63.5,-52.5
       parent: 2
-  - uid: 4322
+  - uid: 4624
     components:
     - type: Transform
       pos: -39.5,12.5
       parent: 2
-  - uid: 4323
+  - uid: 4625
     components:
     - type: Transform
       pos: -38.5,14.5
       parent: 2
-  - uid: 4324
+  - uid: 4626
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: -60.5,-41.5
       parent: 2
-  - uid: 4325
+  - uid: 4627
     components:
     - type: Transform
       pos: -17.5,41.5
       parent: 2
-  - uid: 4326
+  - uid: 4628
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: -56.5,-40.5
       parent: 2
-  - uid: 4327
+  - uid: 4629
     components:
     - type: Transform
       pos: -1.5,22.5
       parent: 2
-  - uid: 4328
+  - uid: 4630
     components:
     - type: Transform
       pos: -0.5,30.5
       parent: 2
-  - uid: 4329
+  - uid: 4631
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: -63.5,-51.5
       parent: 2
-  - uid: 4330
+  - uid: 4632
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: -63.5,-49.5
       parent: 2
-  - uid: 4331
+  - uid: 4633
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: -59.5,-49.5
       parent: 2
-  - uid: 4332
+  - uid: 4634
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: -62.5,-49.5
       parent: 2
-  - uid: 4333
+  - uid: 4635
     components:
     - type: Transform
       pos: -23.5,-2.5
       parent: 2
-  - uid: 4334
+  - uid: 4636
     components:
     - type: Transform
       pos: -20.5,-3.5
       parent: 2
-  - uid: 4335
+  - uid: 4637
     components:
     - type: Transform
       pos: -0.5,24.5
       parent: 2
-  - uid: 4336
+  - uid: 4638
     components:
     - type: Transform
       pos: -25.5,-3.5
       parent: 2
-  - uid: 4337
+  - uid: 4639
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: -60.5,-32.5
       parent: 2
-  - uid: 4338
+  - uid: 4640
     components:
     - type: Transform
       pos: -9.5,41.5
       parent: 2
-  - uid: 4339
+  - uid: 4641
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: -60.5,-49.5
       parent: 2
-  - uid: 4340
+  - uid: 4642
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: -56.5,-39.5
       parent: 2
-  - uid: 4341
+  - uid: 4643
     components:
     - type: Transform
       pos: -1.5,29.5
       parent: 2
-  - uid: 4342
+  - uid: 4644
     components:
     - type: Transform
       pos: -1.5,34.5
       parent: 2
-  - uid: 4343
+  - uid: 4645
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: -59.5,-44.5
       parent: 2
-  - uid: 4344
+  - uid: 4646
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: -60.5,-45.5
       parent: 2
-  - uid: 4345
+  - uid: 4647
     components:
     - type: Transform
       pos: -14.5,41.5
       parent: 2
-  - uid: 4346
+  - uid: 4648
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: -61.5,-49.5
       parent: 2
-  - uid: 4347
+  - uid: 4649
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: -60.5,-46.5
       parent: 2
-  - uid: 4348
+  - uid: 4650
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: -59.5,-42.5
       parent: 2
-  - uid: 4349
+  - uid: 4651
     components:
     - type: Transform
       pos: -16.5,-3.5
       parent: 2
-  - uid: 4350
+  - uid: 4652
     components:
     - type: Transform
       pos: -1.5,32.5
       parent: 2
-  - uid: 4351
+  - uid: 4653
     components:
     - type: Transform
       pos: -19.5,40.5
       parent: 2
-  - uid: 4352
+  - uid: 4654
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: -59.5,-48.5
       parent: 2
-  - uid: 4353
+  - uid: 4655
     components:
     - type: Transform
       pos: -39.5,14.5
       parent: 2
-  - uid: 4354
+  - uid: 4656
     components:
     - type: Transform
       pos: -14.5,40.5
       parent: 2
-  - uid: 4355
+  - uid: 4657
     components:
     - type: Transform
       pos: -22.5,-2.5
       parent: 2
-  - uid: 4356
+  - uid: 4658
     components:
     - type: Transform
       pos: -1.5,30.5
       parent: 2
-  - uid: 4357
+  - uid: 4659
     components:
     - type: Transform
       pos: -19.5,-2.5
       parent: 2
-  - uid: 4358
+  - uid: 4660
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: -60.5,-30.5
       parent: 2
-  - uid: 4359
+  - uid: 4661
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: -58.5,-36.5
       parent: 2
-  - uid: 4360
+  - uid: 4662
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: -60.5,-33.5
       parent: 2
-  - uid: 4361
+  - uid: 4663
     components:
     - type: Transform
       pos: -19.5,-3.5
       parent: 2
-  - uid: 4362
+  - uid: 4664
     components:
     - type: Transform
       pos: -18.5,-3.5
       parent: 2
-  - uid: 4363
+  - uid: 4665
     components:
     - type: Transform
       pos: -15.5,40.5
       parent: 2
-  - uid: 4364
+  - uid: 4666
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: -62.5,-51.5
       parent: 2
-  - uid: 4365
+  - uid: 4667
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: -60.5,-42.5
       parent: 2
-  - uid: 4366
+  - uid: 4668
     components:
     - type: Transform
       pos: -10.5,41.5
       parent: 2
-  - uid: 4367
+  - uid: 4669
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: -57.5,-36.5
       parent: 2
-  - uid: 4368
+  - uid: 4670
     components:
     - type: Transform
       pos: -16.5,-2.5
       parent: 2
-  - uid: 4369
+  - uid: 4671
     components:
     - type: Transform
       pos: -17.5,-2.5
       parent: 2
-  - uid: 4370
+  - uid: 4672
     components:
     - type: Transform
       pos: -17.5,-3.5
       parent: 2
-  - uid: 4371
+  - uid: 4673
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: -61.5,-51.5
       parent: 2
-  - uid: 4372
+  - uid: 4674
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: -60.5,-44.5
       parent: 2
-  - uid: 4373
+  - uid: 4675
     components:
     - type: Transform
       pos: -18.5,41.5
       parent: 2
-  - uid: 4374
+  - uid: 4676
     components:
     - type: Transform
       pos: -0.5,27.5
       parent: 2
-  - uid: 4375
+  - uid: 4677
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: -57.5,-39.5
       parent: 2
-  - uid: 4376
+  - uid: 4678
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: -59.5,-40.5
       parent: 2
-  - uid: 4377
+  - uid: 4679
     components:
     - type: Transform
       pos: -0.5,34.5
       parent: 2
-  - uid: 4378
+  - uid: 4680
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: -58.5,-37.5
       parent: 2
-  - uid: 4379
+  - uid: 4681
     components:
     - type: Transform
       pos: -10.5,40.5
       parent: 2
-  - uid: 4380
+  - uid: 4682
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: -62.5,-50.5
       parent: 2
-  - uid: 4381
+  - uid: 4683
     components:
     - type: Transform
       pos: -18.5,40.5
       parent: 2
-  - uid: 4382
+  - uid: 4684
     components:
     - type: Transform
       pos: -0.5,29.5
       parent: 2
-  - uid: 4383
+  - uid: 4685
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: -60.5,-51.5
       parent: 2
-  - uid: 4384
+  - uid: 4686
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: -59.5,-41.5
       parent: 2
-  - uid: 4385
+  - uid: 4687
     components:
     - type: Transform
       pos: -0.5,28.5
       parent: 2
-  - uid: 4386
+  - uid: 4688
     components:
     - type: Transform
       pos: -39.5,16.5
       parent: 2
-  - uid: 4387
+  - uid: 4689
     components:
     - type: Transform
       pos: -0.5,23.5
       parent: 2
-  - uid: 4388
+  - uid: 4690
     components:
     - type: Transform
       pos: -0.5,32.5
       parent: 2
-  - uid: 4389
+  - uid: 4691
     components:
     - type: Transform
       pos: -38.5,12.5
       parent: 2
-  - uid: 4390
+  - uid: 4692
     components:
     - type: Transform
       pos: -1.5,26.5
       parent: 2
-  - uid: 4391
+  - uid: 4693
     components:
     - type: Transform
       pos: -38.5,13.5
       parent: 2
-  - uid: 4392
+  - uid: 4694
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: -59.5,-38.5
       parent: 2
-  - uid: 4393
+  - uid: 4695
     components:
     - type: Transform
       pos: -1.5,21.5
       parent: 2
-  - uid: 4394
+  - uid: 4696
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: -59.5,-30.5
       parent: 2
-  - uid: 4395
+  - uid: 4697
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: -60.5,-38.5
       parent: 2
-  - uid: 4396
+  - uid: 4698
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: -60.5,-34.5
       parent: 2
-  - uid: 4397
+  - uid: 4699
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: -60.5,-37.5
       parent: 2
-  - uid: 4398
+  - uid: 4700
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: -56.5,-36.5
       parent: 2
-  - uid: 4399
+  - uid: 4701
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: -60.5,-40.5
       parent: 2
-  - uid: 4400
+  - uid: 4702
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: -59.5,-29.5
       parent: 2
-  - uid: 4401
+  - uid: 4703
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: -60.5,-39.5
       parent: 2
-  - uid: 4402
+  - uid: 4704
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: -60.5,-35.5
       parent: 2
-  - uid: 4403
+  - uid: 4705
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: -58.5,-39.5
       parent: 2
-  - uid: 4404
+  - uid: 4706
     components:
     - type: Transform
       pos: -0.5,25.5
       parent: 2
-  - uid: 4405
+  - uid: 4707
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: -58.5,-38.5
       parent: 2
-  - uid: 4406
+  - uid: 4708
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: -56.5,-37.5
       parent: 2
-  - uid: 4407
+  - uid: 4709
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: -56.5,-38.5
       parent: 2
-  - uid: 4408
+  - uid: 4710
     components:
     - type: Transform
       pos: -12.5,41.5
       parent: 2
-  - uid: 4409
+  - uid: 4711
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: -60.5,-50.5
       parent: 2
-  - uid: 4410
+  - uid: 4712
     components:
     - type: Transform
       pos: -12.5,40.5
       parent: 2
-  - uid: 4411
+  - uid: 4713
     components:
     - type: Transform
       pos: -1.5,25.5
       parent: 2
-  - uid: 4412
+  - uid: 4714
     components:
     - type: Transform
       pos: -1.5,31.5
       parent: 2
-  - uid: 4413
+  - uid: 4715
     components:
     - type: Transform
       pos: -1.5,24.5
       parent: 2
-  - uid: 4414
+  - uid: 4716
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: -60.5,-36.5
       parent: 2
-  - uid: 4415
+  - uid: 4717
     components:
     - type: Transform
       pos: -24.5,-2.5
       parent: 2
-  - uid: 4416
+  - uid: 4718
     components:
     - type: Transform
       pos: -13.5,41.5
       parent: 2
-  - uid: 4417
+  - uid: 4719
     components:
     - type: Transform
       pos: -39.5,13.5
       parent: 2
-  - uid: 4418
+  - uid: 4720
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: -60.5,-48.5
       parent: 2
-  - uid: 4419
+  - uid: 4721
     components:
     - type: Transform
       pos: -1.5,33.5
       parent: 2
-  - uid: 4420
+  - uid: 4722
     components:
     - type: Transform
       pos: -0.5,22.5
       parent: 2
-  - uid: 4421
+  - uid: 4723
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: -59.5,-31.5
       parent: 2
-  - uid: 4422
+  - uid: 4724
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: -57.5,-40.5
       parent: 2
-  - uid: 4423
+  - uid: 4725
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: -59.5,-32.5
       parent: 2
-  - uid: 4424
+  - uid: 4726
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: -59.5,-35.5
       parent: 2
-  - uid: 4425
+  - uid: 4727
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: -59.5,-39.5
       parent: 2
-  - uid: 4426
+  - uid: 4728
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: -60.5,-31.5
       parent: 2
-  - uid: 4427
+  - uid: 4729
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: -57.5,-38.5
       parent: 2
-  - uid: 4428
+  - uid: 4730
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: -59.5,-36.5
       parent: 2
-  - uid: 4429
+  - uid: 4731
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: -57.5,-37.5
       parent: 2
-  - uid: 4430
+  - uid: 4732
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: -59.5,-33.5
       parent: 2
-  - uid: 4431
+  - uid: 4733
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: -83.5,-6.5
       parent: 2
-  - uid: 4432
+  - uid: 4734
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: -82.5,-6.5
       parent: 2
-  - uid: 4433
+  - uid: 4735
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: -83.5,-7.5
       parent: 2
-  - uid: 4434
+  - uid: 4736
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: -82.5,-7.5
       parent: 2
-  - uid: 4435
+  - uid: 4737
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: -83.5,-8.5
       parent: 2
-  - uid: 4436
+  - uid: 4738
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: -82.5,-8.5
       parent: 2
-  - uid: 4437
+  - uid: 4739
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: -81.5,-11.5
       parent: 2
-  - uid: 4438
+  - uid: 4740
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: -84.5,-11.5
       parent: 2
-  - uid: 4439
+  - uid: 4741
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: -82.5,-10.5
       parent: 2
-  - uid: 4440
+  - uid: 4742
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: -83.5,-11.5
       parent: 2
-  - uid: 4441
+  - uid: 4743
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: -81.5,-10.5
       parent: 2
-  - uid: 4442
+  - uid: 4744
     components:
     - type: Transform
       pos: -81.5,-9.5
       parent: 2
-  - uid: 4443
+  - uid: 4745
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: -84.5,-10.5
       parent: 2
-  - uid: 4444
+  - uid: 4746
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: -82.5,-11.5
       parent: 2
-  - uid: 4445
+  - uid: 4747
     components:
     - type: Transform
       pos: -84.5,-9.5
       parent: 2
-  - uid: 4446
+  - uid: 4748
     components:
     - type: Transform
       pos: -83.5,-9.5
       parent: 2
-  - uid: 4447
+  - uid: 4749
     components:
     - type: Transform
       pos: -82.5,-9.5
       parent: 2
-  - uid: 4448
+  - uid: 4750
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: -83.5,-10.5
       parent: 2
-  - uid: 4449
+  - uid: 4751
     components:
     - type: Transform
       pos: -92.5,5.5
       parent: 2
-  - uid: 4450
+  - uid: 4752
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: -59.5,-46.5
       parent: 2
-  - uid: 4451
+  - uid: 4753
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: -59.5,-51.5
       parent: 2
-  - uid: 4452
+  - uid: 4754
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: -59.5,-52.5
       parent: 2
-  - uid: 4453
+  - uid: 4755
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: -58.5,-49.5
       parent: 2
-  - uid: 4454
+  - uid: 4756
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: -58.5,-50.5
       parent: 2
-  - uid: 4455
+  - uid: 4757
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: -58.5,-51.5
       parent: 2
-  - uid: 4456
+  - uid: 4758
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: -58.5,-52.5
       parent: 2
-  - uid: 4457
+  - uid: 4759
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: -57.5,-49.5
       parent: 2
-  - uid: 4458
+  - uid: 4760
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: -57.5,-51.5
       parent: 2
-  - uid: 4459
+  - uid: 4761
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: -57.5,-50.5
       parent: 2
-  - uid: 4460
+  - uid: 4762
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: -57.5,-52.5
       parent: 2
-  - uid: 4461
+  - uid: 4763
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: -56.5,-49.5
       parent: 2
-  - uid: 4462
+  - uid: 4764
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: -56.5,-51.5
       parent: 2
-  - uid: 4463
+  - uid: 4765
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: -56.5,-52.5
       parent: 2
-  - uid: 4464
+  - uid: 4766
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: -55.5,-49.5
       parent: 2
-  - uid: 4465
+  - uid: 4767
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: -60.5,-52.5
       parent: 2
-  - uid: 4466
+  - uid: 4768
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: -55.5,-50.5
       parent: 2
-  - uid: 4467
+  - uid: 4769
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: -55.5,-52.5
       parent: 2
-  - uid: 4468
+  - uid: 4770
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: -55.5,-51.5
       parent: 2
-  - uid: 4469
+  - uid: 4771
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: -56.5,-50.5
       parent: 2
-  - uid: 4470
+  - uid: 4772
     components:
     - type: Transform
       rot: 3.141592653589793 rad
@@ -25010,73 +25016,73 @@ entities:
       parent: 2
 - proto: ChairOfficeDark
   entities:
-  - uid: 4471
+  - uid: 4773
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: -43.364563,-50.457718
       parent: 2
-  - uid: 4472
+  - uid: 4774
     components:
     - type: Transform
       pos: -34.583313,-50.379593
       parent: 2
-  - uid: 4473
+  - uid: 4775
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: -30.958313,-46.152374
       parent: 2
-  - uid: 4474
+  - uid: 4776
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: -46.956734,-46.1055
       parent: 2
-  - uid: 4475
+  - uid: 4777
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: -45.96279,-37.168743
       parent: 2
-  - uid: 4476
+  - uid: 4778
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: -32.946068,-37.199993
       parent: 2
-  - uid: 4477
+  - uid: 4779
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: -95.55244,2.6753101
       parent: 2
-  - uid: 4478
+  - uid: 4780
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: -92.39619,2.0346851
       parent: 2
-  - uid: 4479
+  - uid: 4781
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: -101.35251,-2.6192665
       parent: 2
-  - uid: 4480
+  - uid: 4782
     components:
     - type: Transform
       pos: -99.54001,-4.2911415
       parent: 2
 - proto: ChairOfficeLight
   entities:
-  - uid: 4481
+  - uid: 4783
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: -81.62826,5.603546
       parent: 2
-  - uid: 4482
+  - uid: 4784
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
@@ -25084,13 +25090,13 @@ entities:
       parent: 2
 - proto: ChairWood
   entities:
-  - uid: 4483
+  - uid: 4785
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: -92.41633,-6.5608425
       parent: 2
-  - uid: 4484
+  - uid: 4786
     components:
     - type: Transform
       rot: 3.141592653589793 rad
@@ -25098,519 +25104,519 @@ entities:
       parent: 2
 - proto: ChemDispenser
   entities:
-  - uid: 4485
+  - uid: 4787
     components:
     - type: Transform
       pos: -80.5,5.5
       parent: 2
 - proto: ChemistryHotplate
   entities:
-  - uid: 4486
+  - uid: 4788
     components:
     - type: Transform
       pos: -81.5,6.5
       parent: 2
     - type: ItemPlacer
       placedEntities:
-      - 5324
+      - 5626
     - type: PlaceableSurface
       isPlaceable: False
 - proto: ChemMaster
   entities:
-  - uid: 4487
+  - uid: 4789
     components:
     - type: Transform
       pos: -80.5,6.5
       parent: 2
 - proto: CircuitImprinter
   entities:
-  - uid: 4488
+  - uid: 4790
     components:
     - type: Transform
       pos: -85.5,-7.5
       parent: 2
 - proto: ClockworkGrille
   entities:
-  - uid: 4489
+  - uid: 4791
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: -76.5,-0.5
       parent: 2
-  - uid: 4490
+  - uid: 4792
     components:
     - type: Transform
       pos: -33.5,-35.5
       parent: 2
-  - uid: 4491
+  - uid: 4793
     components:
     - type: Transform
       pos: -92.5,7.5
       parent: 2
-  - uid: 4492
+  - uid: 4794
     components:
     - type: Transform
       pos: -40.5,-36.5
       parent: 2
-  - uid: 4493
+  - uid: 4795
     components:
     - type: Transform
       pos: -90.5,-10.5
       parent: 2
-  - uid: 4494
+  - uid: 4796
     components:
     - type: Transform
       pos: -29.5,-46.5
       parent: 2
-  - uid: 4495
+  - uid: 4797
     components:
     - type: Transform
       pos: -42.5,-51.5
       parent: 2
-  - uid: 4496
+  - uid: 4798
     components:
     - type: Transform
       pos: -48.5,-36.5
       parent: 2
-  - uid: 4497
+  - uid: 4799
     components:
     - type: Transform
       pos: -44.5,-51.5
       parent: 2
-  - uid: 4498
+  - uid: 4800
     components:
     - type: Transform
       pos: -48.5,-47.5
       parent: 2
-  - uid: 4499
+  - uid: 4801
     components:
     - type: Transform
       pos: -32.5,-35.5
       parent: 2
-  - uid: 4500
+  - uid: 4802
     components:
     - type: Transform
       pos: -82.5,7.5
       parent: 2
-  - uid: 4501
+  - uid: 4803
     components:
     - type: Transform
       pos: -37.5,-36.5
       parent: 2
-  - uid: 4502
+  - uid: 4804
     components:
     - type: Transform
       pos: -94.5,-13.5
       parent: 2
-  - uid: 4503
+  - uid: 4805
     components:
     - type: Transform
       pos: -79.5,5.5
       parent: 2
-  - uid: 4504
+  - uid: 4806
     components:
     - type: Transform
       pos: -48.5,-37.5
       parent: 2
-  - uid: 4505
+  - uid: 4807
     components:
     - type: Transform
       pos: -97.5,-7.5
       parent: 2
-  - uid: 4506
+  - uid: 4808
     components:
     - type: Transform
       pos: -79.5,-8.5
       parent: 2
-  - uid: 4507
+  - uid: 4809
     components:
     - type: Transform
       pos: -88.5,-5.5
       parent: 2
-  - uid: 4508
+  - uid: 4810
     components:
     - type: Transform
       pos: -34.5,-51.5
       parent: 2
-  - uid: 4509
+  - uid: 4811
     components:
     - type: Transform
       pos: -86.5,5.5
       parent: 2
-  - uid: 4510
+  - uid: 4812
     components:
     - type: Transform
       pos: -99.5,0.5
       parent: 2
-  - uid: 4511
+  - uid: 4813
     components:
     - type: Transform
       pos: -86.5,-7.5
       parent: 2
-  - uid: 4512
+  - uid: 4814
     components:
     - type: Transform
       pos: -100.5,0.5
       parent: 2
-  - uid: 4513
+  - uid: 4815
     components:
     - type: Transform
       pos: -45.5,-35.5
       parent: 2
-  - uid: 4514
+  - uid: 4816
     components:
     - type: Transform
       pos: -90.5,4.5
       parent: 2
-  - uid: 4515
+  - uid: 4817
     components:
     - type: Transform
       pos: -103.5,-3.5
       parent: 2
-  - uid: 4516
+  - uid: 4818
     components:
     - type: Transform
       pos: -78.5,-5.5
       parent: 2
-  - uid: 4517
+  - uid: 4819
     components:
     - type: Transform
       pos: -44.5,-35.5
       parent: 2
-  - uid: 4518
+  - uid: 4820
     components:
     - type: Transform
       pos: -90.5,2.5
       parent: 2
-  - uid: 4519
+  - uid: 4821
     components:
     - type: Transform
       pos: -97.5,-8.5
       parent: 2
-  - uid: 4520
+  - uid: 4822
     components:
     - type: Transform
       pos: -88.5,-0.5
       parent: 2
-  - uid: 4521
+  - uid: 4823
     components:
     - type: Transform
       pos: -37.5,-37.5
       parent: 2
-  - uid: 4522
+  - uid: 4824
     components:
     - type: Transform
       pos: -43.5,-51.5
       parent: 2
-  - uid: 4523
+  - uid: 4825
     components:
     - type: Transform
       pos: -89.5,-5.5
       parent: 2
-  - uid: 4524
+  - uid: 4826
     components:
     - type: Transform
       pos: -40.5,-37.5
       parent: 2
-  - uid: 4525
+  - uid: 4827
     components:
     - type: Transform
       pos: -81.5,7.5
       parent: 2
-  - uid: 4526
+  - uid: 4828
     components:
     - type: Transform
       pos: -79.5,-10.5
       parent: 2
-  - uid: 4527
+  - uid: 4829
     components:
     - type: Transform
       pos: -84.5,7.5
       parent: 2
-  - uid: 4528
+  - uid: 4830
     components:
     - type: Transform
       pos: -86.5,4.5
       parent: 2
-  - uid: 4529
+  - uid: 4831
     components:
     - type: Transform
       pos: -79.5,-11.5
       parent: 2
-  - uid: 4530
+  - uid: 4832
     components:
     - type: Transform
       pos: -35.5,-51.5
       parent: 2
-  - uid: 4531
+  - uid: 4833
     components:
     - type: Transform
       pos: -90.5,-8.5
       parent: 2
-  - uid: 4532
+  - uid: 4834
     components:
     - type: Transform
       pos: -87.5,-0.5
       parent: 2
-  - uid: 4533
+  - uid: 4835
     components:
     - type: Transform
       pos: -86.5,2.5
       parent: 2
-  - uid: 4534
+  - uid: 4836
     components:
     - type: Transform
       pos: -95.5,-13.5
       parent: 2
-  - uid: 4535
+  - uid: 4837
     components:
     - type: Transform
       pos: -48.5,-46.5
       parent: 2
-  - uid: 4536
+  - uid: 4838
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: -96.5,4.5
       parent: 2
-  - uid: 4537
+  - uid: 4839
     components:
     - type: Transform
       pos: -83.5,7.5
       parent: 2
-  - uid: 4538
+  - uid: 4840
     components:
     - type: Transform
       pos: -103.5,-2.5
       parent: 2
-  - uid: 4539
+  - uid: 4841
     components:
     - type: Transform
       pos: -90.5,5.5
       parent: 2
-  - uid: 4540
+  - uid: 4842
     components:
     - type: Transform
       pos: -90.5,-11.5
       parent: 2
-  - uid: 4541
+  - uid: 4843
     components:
     - type: Transform
       pos: -97.5,2.5
       parent: 2
-  - uid: 4542
+  - uid: 4844
     components:
     - type: Transform
       pos: -86.5,-11.5
       parent: 2
-  - uid: 4543
+  - uid: 4845
     components:
     - type: Transform
       pos: -86.5,-8.5
       parent: 2
-  - uid: 4544
+  - uid: 4846
     components:
     - type: Transform
       pos: -46.5,-35.5
       parent: 2
-  - uid: 4545
+  - uid: 4847
     components:
     - type: Transform
       pos: -78.5,-0.5
       parent: 2
-  - uid: 4546
+  - uid: 4848
     components:
     - type: Transform
       pos: -29.5,-36.5
       parent: 2
-  - uid: 4547
+  - uid: 4849
     components:
     - type: Transform
       pos: -79.5,2.5
       parent: 2
-  - uid: 4548
+  - uid: 4850
     components:
     - type: Transform
       pos: -33.5,-51.5
       parent: 2
-  - uid: 4549
+  - uid: 4851
     components:
     - type: Transform
       pos: -97.5,1.5
       parent: 2
-  - uid: 4550
+  - uid: 4852
     components:
     - type: Transform
       pos: -89.5,-0.5
       parent: 2
-  - uid: 4551
+  - uid: 4853
     components:
     - type: Transform
       pos: -73.5,-1.5
       parent: 2
-  - uid: 4552
+  - uid: 4854
     components:
     - type: Transform
       pos: -100.5,-6.5
       parent: 2
-  - uid: 4553
+  - uid: 4855
     components:
     - type: Transform
       pos: -29.5,-45.5
       parent: 2
-  - uid: 4554
+  - uid: 4856
     components:
     - type: Transform
       pos: -29.5,-47.5
       parent: 2
-  - uid: 4555
+  - uid: 4857
     components:
     - type: Transform
       pos: -77.5,-0.5
       parent: 2
-  - uid: 4556
+  - uid: 4858
     components:
     - type: Transform
       pos: -48.5,-38.5
       parent: 2
-  - uid: 4557
+  - uid: 4859
     components:
     - type: Transform
       pos: -79.5,1.5
       parent: 2
-  - uid: 4558
+  - uid: 4860
     components:
     - type: Transform
       pos: -39.5,-51.5
       parent: 2
-  - uid: 4559
+  - uid: 4861
     components:
     - type: Transform
       pos: -79.5,4.5
       parent: 2
-  - uid: 4560
+  - uid: 4862
     components:
     - type: Transform
       pos: -99.5,-6.5
       parent: 2
-  - uid: 4561
+  - uid: 4863
     components:
     - type: Transform
       pos: -87.5,-5.5
       parent: 2
-  - uid: 4562
+  - uid: 4864
     components:
     - type: Transform
       pos: -90.5,-7.5
       parent: 2
-  - uid: 4563
+  - uid: 4865
     components:
     - type: Transform
       pos: -93.5,7.5
       parent: 2
-  - uid: 4564
+  - uid: 4866
     components:
     - type: Transform
       pos: -90.5,1.5
       parent: 2
-  - uid: 4565
+  - uid: 4867
     components:
     - type: Transform
       pos: -72.5,-1.5
       parent: 2
-  - uid: 4566
+  - uid: 4868
     components:
     - type: Transform
       pos: -86.5,1.5
       parent: 2
-  - uid: 4567
+  - uid: 4869
     components:
     - type: Transform
       pos: -79.5,-7.5
       parent: 2
-  - uid: 4568
+  - uid: 4870
     components:
     - type: Transform
       pos: -72.5,-4.5
       parent: 2
-  - uid: 4569
+  - uid: 4871
     components:
     - type: Transform
       pos: -29.5,-38.5
       parent: 2
-  - uid: 4570
+  - uid: 4872
     components:
     - type: Transform
       pos: -38.5,-51.5
       parent: 2
-  - uid: 4571
+  - uid: 4873
     components:
     - type: Transform
       pos: -29.5,-37.5
       parent: 2
-  - uid: 4572
+  - uid: 4874
     components:
     - type: Transform
       pos: -48.5,-45.5
       parent: 2
-  - uid: 4573
+  - uid: 4875
     components:
     - type: Transform
       pos: -86.5,-10.5
       parent: 2
-  - uid: 4574
+  - uid: 4876
     components:
     - type: Transform
       pos: -77.5,-5.5
       parent: 2
-  - uid: 4575
+  - uid: 4877
     components:
     - type: Transform
       pos: -73.5,-4.5
       parent: 2
-  - uid: 4576
+  - uid: 4878
     components:
     - type: Transform
       pos: -103.5,-1.5
       parent: 2
-  - uid: 4577
+  - uid: 4879
     components:
     - type: Transform
       pos: -103.5,-4.5
       parent: 2
-  - uid: 4578
+  - uid: 4880
     components:
     - type: Transform
       pos: -98.5,0.5
       parent: 2
-  - uid: 4579
+  - uid: 4881
     components:
     - type: Transform
       pos: -98.5,-6.5
       parent: 2
-  - uid: 4580
+  - uid: 4882
     components:
     - type: Transform
       pos: -101.5,-6.5
       parent: 2
-  - uid: 4581
+  - uid: 4883
     components:
     - type: Transform
       pos: -101.5,0.5
       parent: 2
-  - uid: 4582
+  - uid: 4884
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: -31.5,-35.5
       parent: 2
-  - uid: 4583
+  - uid: 4885
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: -95.5,4.5
       parent: 2
-  - uid: 4584
+  - uid: 4886
     components:
     - type: Transform
       rot: 3.141592653589793 rad
@@ -25618,515 +25624,515 @@ entities:
       parent: 2
 - proto: ClockworkWindow
   entities:
-  - uid: 4585
+  - uid: 4887
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: -40.5,-36.5
       parent: 2
-  - uid: 4586
+  - uid: 4888
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: -29.5,-36.5
       parent: 2
-  - uid: 4587
+  - uid: 4889
     components:
     - type: Transform
       pos: -72.5,-1.5
       parent: 2
-  - uid: 4588
+  - uid: 4890
     components:
     - type: Transform
       pos: -97.5,-7.5
       parent: 2
-  - uid: 4589
+  - uid: 4891
     components:
     - type: Transform
       pos: -97.5,-8.5
       parent: 2
-  - uid: 4590
+  - uid: 4892
     components:
     - type: Transform
       pos: -78.5,-5.5
       parent: 2
-  - uid: 4591
+  - uid: 4893
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: -39.5,-51.5
       parent: 2
-  - uid: 4592
+  - uid: 4894
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: -96.5,4.5
       parent: 2
-  - uid: 4593
+  - uid: 4895
     components:
     - type: Transform
       pos: -79.5,-10.5
       parent: 2
-  - uid: 4594
+  - uid: 4896
     components:
     - type: Transform
       pos: -82.5,7.5
       parent: 2
-  - uid: 4595
+  - uid: 4897
     components:
     - type: Transform
       pos: -86.5,-11.5
       parent: 2
-  - uid: 4596
+  - uid: 4898
     components:
     - type: Transform
       pos: -100.5,0.5
       parent: 2
-  - uid: 4597
+  - uid: 4899
     components:
     - type: Transform
       pos: -93.5,7.5
       parent: 2
-  - uid: 4598
+  - uid: 4900
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: -48.5,-45.5
       parent: 2
-  - uid: 4599
+  - uid: 4901
     components:
     - type: Transform
       pos: -86.5,-8.5
       parent: 2
-  - uid: 4600
+  - uid: 4902
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: -29.5,-47.5
       parent: 2
-  - uid: 4601
+  - uid: 4903
     components:
     - type: Transform
       pos: -78.5,-0.5
       parent: 2
-  - uid: 4602
+  - uid: 4904
     components:
     - type: Transform
       pos: -86.5,-10.5
       parent: 2
-  - uid: 4603
+  - uid: 4905
     components:
     - type: Transform
       pos: -99.5,-6.5
       parent: 2
-  - uid: 4604
+  - uid: 4906
     components:
     - type: Transform
       pos: -77.5,-5.5
       parent: 2
-  - uid: 4605
+  - uid: 4907
     components:
     - type: Transform
       pos: -72.5,-4.5
       parent: 2
-  - uid: 4606
+  - uid: 4908
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: -43.5,-51.5
       parent: 2
-  - uid: 4607
+  - uid: 4909
     components:
     - type: Transform
       pos: -86.5,4.5
       parent: 2
-  - uid: 4608
+  - uid: 4910
     components:
     - type: Transform
       pos: -97.5,2.5
       parent: 2
-  - uid: 4609
+  - uid: 4911
     components:
     - type: Transform
       pos: -86.5,5.5
       parent: 2
-  - uid: 4610
+  - uid: 4912
     components:
     - type: Transform
       pos: -97.5,1.5
       parent: 2
-  - uid: 4611
+  - uid: 4913
     components:
     - type: Transform
       pos: -79.5,4.5
       parent: 2
-  - uid: 4612
+  - uid: 4914
     components:
     - type: Transform
       pos: -90.5,5.5
       parent: 2
-  - uid: 4613
+  - uid: 4915
     components:
     - type: Transform
       pos: -79.5,1.5
       parent: 2
-  - uid: 4614
+  - uid: 4916
     components:
     - type: Transform
       pos: -94.5,-13.5
       parent: 2
-  - uid: 4615
+  - uid: 4917
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: -29.5,-46.5
       parent: 2
-  - uid: 4616
+  - uid: 4918
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: -38.5,-51.5
       parent: 2
-  - uid: 4617
+  - uid: 4919
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: -95.5,4.5
       parent: 2
-  - uid: 4618
+  - uid: 4920
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: -35.5,-51.5
       parent: 2
-  - uid: 4619
+  - uid: 4921
     components:
     - type: Transform
       pos: -79.5,2.5
       parent: 2
-  - uid: 4620
+  - uid: 4922
     components:
     - type: Transform
       pos: -77.5,-0.5
       parent: 2
-  - uid: 4621
+  - uid: 4923
     components:
     - type: Transform
       pos: -100.5,-6.5
       parent: 2
-  - uid: 4622
+  - uid: 4924
     components:
     - type: Transform
       pos: -79.5,-11.5
       parent: 2
-  - uid: 4623
+  - uid: 4925
     components:
     - type: Transform
       pos: -99.5,0.5
       parent: 2
-  - uid: 4624
+  - uid: 4926
     components:
     - type: Transform
       pos: -73.5,-1.5
       parent: 2
-  - uid: 4625
+  - uid: 4927
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: -46.5,-35.5
       parent: 2
-  - uid: 4626
+  - uid: 4928
     components:
     - type: Transform
       pos: -95.5,-13.5
       parent: 2
-  - uid: 4627
+  - uid: 4929
     components:
     - type: Transform
       pos: -88.5,-0.5
       parent: 2
-  - uid: 4628
+  - uid: 4930
     components:
     - type: Transform
       pos: -87.5,-0.5
       parent: 2
-  - uid: 4629
+  - uid: 4931
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: -40.5,-37.5
       parent: 2
-  - uid: 4630
+  - uid: 4932
     components:
     - type: Transform
       pos: -89.5,-5.5
       parent: 2
-  - uid: 4631
+  - uid: 4933
     components:
     - type: Transform
       pos: -92.5,7.5
       parent: 2
-  - uid: 4632
+  - uid: 4934
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: -48.5,-46.5
       parent: 2
-  - uid: 4633
+  - uid: 4935
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: -34.5,-51.5
       parent: 2
-  - uid: 4634
+  - uid: 4936
     components:
     - type: Transform
       pos: -79.5,-7.5
       parent: 2
-  - uid: 4635
+  - uid: 4937
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: -29.5,-37.5
       parent: 2
-  - uid: 4636
+  - uid: 4938
     components:
     - type: Transform
       pos: -86.5,1.5
       parent: 2
-  - uid: 4637
+  - uid: 4939
     components:
     - type: Transform
       pos: -103.5,-2.5
       parent: 2
-  - uid: 4638
+  - uid: 4940
     components:
     - type: Transform
       pos: -73.5,-4.5
       parent: 2
-  - uid: 4639
+  - uid: 4941
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: -44.5,-35.5
       parent: 2
-  - uid: 4640
+  - uid: 4942
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: -33.5,-35.5
       parent: 2
-  - uid: 4641
+  - uid: 4943
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: -42.5,-51.5
       parent: 2
-  - uid: 4642
+  - uid: 4944
     components:
     - type: Transform
       pos: -90.5,-7.5
       parent: 2
-  - uid: 4643
+  - uid: 4945
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: -33.5,-51.5
       parent: 2
-  - uid: 4644
+  - uid: 4946
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: -48.5,-36.5
       parent: 2
-  - uid: 4645
+  - uid: 4947
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: -48.5,-37.5
       parent: 2
-  - uid: 4646
+  - uid: 4948
     components:
     - type: Transform
       pos: -90.5,-10.5
       parent: 2
-  - uid: 4647
+  - uid: 4949
     components:
     - type: Transform
       pos: -90.5,1.5
       parent: 2
-  - uid: 4648
+  - uid: 4950
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: -37.5,-37.5
       parent: 2
-  - uid: 4649
+  - uid: 4951
     components:
     - type: Transform
       pos: -79.5,5.5
       parent: 2
-  - uid: 4650
+  - uid: 4952
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: -32.5,-35.5
       parent: 2
-  - uid: 4651
+  - uid: 4953
     components:
     - type: Transform
       pos: -89.5,-0.5
       parent: 2
-  - uid: 4652
+  - uid: 4954
     components:
     - type: Transform
       pos: -86.5,-7.5
       parent: 2
-  - uid: 4653
+  - uid: 4955
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: -29.5,-38.5
       parent: 2
-  - uid: 4654
+  - uid: 4956
     components:
     - type: Transform
       pos: -87.5,-5.5
       parent: 2
-  - uid: 4655
+  - uid: 4957
     components:
     - type: Transform
       pos: -88.5,-5.5
       parent: 2
-  - uid: 4656
+  - uid: 4958
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: -29.5,-45.5
       parent: 2
-  - uid: 4657
+  - uid: 4959
     components:
     - type: Transform
       pos: -79.5,-8.5
       parent: 2
-  - uid: 4658
+  - uid: 4960
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: -48.5,-38.5
       parent: 2
-  - uid: 4659
+  - uid: 4961
     components:
     - type: Transform
       pos: -81.5,7.5
       parent: 2
-  - uid: 4660
+  - uid: 4962
     components:
     - type: Transform
       pos: -90.5,2.5
       parent: 2
-  - uid: 4661
+  - uid: 4963
     components:
     - type: Transform
       pos: -90.5,-8.5
       parent: 2
-  - uid: 4662
+  - uid: 4964
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: -45.5,-35.5
       parent: 2
-  - uid: 4663
+  - uid: 4965
     components:
     - type: Transform
       pos: -84.5,7.5
       parent: 2
-  - uid: 4664
+  - uid: 4966
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: -44.5,-51.5
       parent: 2
-  - uid: 4665
+  - uid: 4967
     components:
     - type: Transform
       pos: -90.5,-11.5
       parent: 2
-  - uid: 4666
+  - uid: 4968
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: -37.5,-36.5
       parent: 2
-  - uid: 4667
+  - uid: 4969
     components:
     - type: Transform
       pos: -103.5,-3.5
       parent: 2
-  - uid: 4668
+  - uid: 4970
     components:
     - type: Transform
       pos: -90.5,4.5
       parent: 2
-  - uid: 4669
+  - uid: 4971
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: -48.5,-47.5
       parent: 2
-  - uid: 4670
+  - uid: 4972
     components:
     - type: Transform
       pos: -86.5,2.5
       parent: 2
-  - uid: 4671
+  - uid: 4973
     components:
     - type: Transform
       pos: -83.5,7.5
       parent: 2
-  - uid: 4672
+  - uid: 4974
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: -31.5,-35.5
       parent: 2
-  - uid: 4673
+  - uid: 4975
     components:
     - type: Transform
       pos: -98.5,-6.5
       parent: 2
-  - uid: 4674
+  - uid: 4976
     components:
     - type: Transform
       pos: -101.5,-6.5
       parent: 2
-  - uid: 4675
+  - uid: 4977
     components:
     - type: Transform
       pos: -103.5,-4.5
       parent: 2
-  - uid: 4676
+  - uid: 4978
     components:
     - type: Transform
       pos: -103.5,-1.5
       parent: 2
-  - uid: 4677
+  - uid: 4979
     components:
     - type: Transform
       pos: -101.5,0.5
       parent: 2
-  - uid: 4678
+  - uid: 4980
     components:
     - type: Transform
       pos: -98.5,0.5
       parent: 2
-  - uid: 4679
+  - uid: 4981
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: -76.5,-5.5
       parent: 2
-  - uid: 4680
+  - uid: 4982
     components:
     - type: Transform
       rot: 3.141592653589793 rad
@@ -26134,31 +26140,31 @@ entities:
       parent: 2
 - proto: ClosetEmergencyFilledRandom
   entities:
-  - uid: 4681
+  - uid: 4983
     components:
     - type: Transform
       pos: -41.77134,-39.5
       parent: 2
-  - uid: 4682
+  - uid: 4984
     components:
     - type: Transform
       pos: -36.255714,-44.5
       parent: 2
-  - uid: 4683
+  - uid: 4985
     components:
     - type: Transform
       pos: -41.25969,-39.5
       parent: 2
 - proto: ClosetEmergencyN2FilledRandom
   entities:
-  - uid: 4684
+  - uid: 4986
     components:
     - type: Transform
       pos: -36.744064,-44.5
       parent: 2
 - proto: ClosetJanitorFilled
   entities:
-  - uid: 4685
+  - uid: 4987
     components:
     - type: Transform
       pos: -91.74966,-12.5
@@ -26167,7 +26173,7 @@ entities:
       locked: False
 - proto: ClosetWallBlack
   entities:
-  - uid: 3685
+  - uid: 3987
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
@@ -26179,14 +26185,14 @@ entities:
           showEnts: False
           occludes: True
           ents:
-          - 3687
-          - 3690
-          - 3689
-          - 3688
-          - 3686
+          - 3989
+          - 3992
+          - 3991
+          - 3990
+          - 3988
     - type: Fixtures
       fixtures: {}
-  - uid: 3691
+  - uid: 3993
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
@@ -26198,30 +26204,30 @@ entities:
           showEnts: False
           occludes: True
           ents:
-          - 3693
-          - 3694
-          - 3695
-          - 3692
-          - 3696
+          - 3995
+          - 3996
+          - 3997
+          - 3994
+          - 3998
     - type: Fixtures
       fixtures: {}
 - proto: ClosetWallEmergencyFilledRandom
   entities:
-  - uid: 4686
+  - uid: 4988
     components:
     - type: Transform
       pos: -85.5,-0.5
       parent: 2
     - type: Fixtures
       fixtures: {}
-  - uid: 4687
+  - uid: 4989
     components:
     - type: Transform
       pos: -91.5,-0.5
       parent: 2
     - type: Fixtures
       fixtures: {}
-  - uid: 4688
+  - uid: 4990
     components:
     - type: Transform
       rot: 3.141592653589793 rad
@@ -26229,7 +26235,7 @@ entities:
       parent: 2
     - type: Fixtures
       fixtures: {}
-  - uid: 4689
+  - uid: 4991
     components:
     - type: Transform
       rot: 3.141592653589793 rad
@@ -26239,28 +26245,28 @@ entities:
       fixtures: {}
 - proto: ComputerAlert
   entities:
-  - uid: 4690
+  - uid: 4992
     components:
     - type: Transform
       pos: -81.5,-6.5
       parent: 2
 - proto: ComputerAnalysisConsole
   entities:
-  - uid: 4691
+  - uid: 4993
     components:
     - type: Transform
       pos: -95.5,3.5
       parent: 2
     - type: AnalysisConsole
-      analyzerEntity: 5355
+      analyzerEntity: 5657
     - type: DeviceLinkSource
       linkedPorts:
-        5355:
+        5657:
         - - ArtifactAnalyzerSender
           - ArtifactAnalyzerReceiver
 - proto: ComputerCargoOrders
   entities:
-  - uid: 4692
+  - uid: 4994
     components:
     - type: Transform
       rot: 3.141592653589793 rad
@@ -26268,7 +26274,7 @@ entities:
       parent: 2
 - proto: ComputerComms
   entities:
-  - uid: 4693
+  - uid: 4995
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
@@ -26276,7 +26282,7 @@ entities:
       parent: 2
 - proto: ComputerCrewMonitoring
   entities:
-  - uid: 4694
+  - uid: 4996
     components:
     - type: Transform
       rot: 3.141592653589793 rad
@@ -26284,7 +26290,7 @@ entities:
       parent: 2
 - proto: ComputerCriminalRecords
   entities:
-  - uid: 4695
+  - uid: 4997
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
@@ -26292,7 +26298,7 @@ entities:
       parent: 2
 - proto: ComputerId
   entities:
-  - uid: 4696
+  - uid: 4998
     components:
     - type: Transform
       rot: 3.141592653589793 rad
@@ -26300,7 +26306,7 @@ entities:
       parent: 2
 - proto: ComputerMedicalRecords
   entities:
-  - uid: 4697
+  - uid: 4999
     components:
     - type: Transform
       rot: 3.141592653589793 rad
@@ -26308,7 +26314,7 @@ entities:
       parent: 2
 - proto: ComputerPowerMonitoring
   entities:
-  - uid: 4698
+  - uid: 5000
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
@@ -26316,7 +26322,7 @@ entities:
       parent: 2
 - proto: ComputerRadar
   entities:
-  - uid: 4699
+  - uid: 5001
     components:
     - type: Transform
       rot: 3.141592653589793 rad
@@ -26324,7 +26330,7 @@ entities:
       parent: 2
 - proto: ComputerResearchAndDevelopment
   entities:
-  - uid: 4700
+  - uid: 5002
     components:
     - type: Transform
       rot: 3.141592653589793 rad
@@ -26332,7 +26338,7 @@ entities:
       parent: 2
 - proto: ComputerShuttle
   entities:
-  - uid: 4701
+  - uid: 5003
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
@@ -26340,7 +26346,7 @@ entities:
       parent: 2
 - proto: ComputerShuttleCargo
   entities:
-  - uid: 4702
+  - uid: 5004
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
@@ -26348,7 +26354,7 @@ entities:
       parent: 2
 - proto: ComputerStationRecords
   entities:
-  - uid: 4703
+  - uid: 5005
     components:
     - type: Transform
       rot: 3.141592653589793 rad
@@ -26356,14 +26362,14 @@ entities:
       parent: 2
 - proto: CrateFoodProduce
   entities:
-  - uid: 4704
+  - uid: 5006
     components:
     - type: Transform
       pos: -93.5,-8.5
       parent: 2
 - proto: CrateLockBoxSecurity
   entities:
-  - uid: 4705
+  - uid: 5007
     components:
     - type: Transform
       pos: -100.5,-0.5
@@ -26372,63 +26378,63 @@ entities:
       locked: False
 - proto: CrewMonitoringServer
   entities:
-  - uid: 4706
+  - uid: 5008
     components:
     - type: Transform
       pos: -85.5,-12.5
       parent: 2
 - proto: CurtainsBlack
   entities:
-  - uid: 4707
+  - uid: 5009
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: -48.5,-38.5
       parent: 2
-  - uid: 4708
+  - uid: 5010
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: -48.5,-37.5
       parent: 2
-  - uid: 4709
+  - uid: 5011
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: -48.5,-36.5
       parent: 2
-  - uid: 4710
+  - uid: 5012
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: -45.5,-35.5
       parent: 2
-  - uid: 4711
+  - uid: 5013
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: -44.5,-35.5
       parent: 2
-  - uid: 4712
+  - uid: 5014
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: -43.5,-51.5
       parent: 2
-  - uid: 4713
+  - uid: 5015
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: -44.5,-51.5
       parent: 2
-  - uid: 4714
+  - uid: 5016
     components:
     - type: Transform
       pos: -46.5,-35.5
       parent: 2
 - proto: CurtainsBlackOpen
   entities:
-  - uid: 4715
+  - uid: 5017
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
@@ -26436,19 +26442,19 @@ entities:
       parent: 2
 - proto: CurtainsBlueOpen
   entities:
-  - uid: 4716
+  - uid: 5018
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: -29.5,-47.5
       parent: 2
-  - uid: 4717
+  - uid: 5019
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: -29.5,-45.5
       parent: 2
-  - uid: 4718
+  - uid: 5020
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
@@ -26456,19 +26462,19 @@ entities:
       parent: 2
 - proto: CurtainsGreen
   entities:
-  - uid: 4719
+  - uid: 5021
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: -48.5,-47.5
       parent: 2
-  - uid: 4720
+  - uid: 5022
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: -48.5,-46.5
       parent: 2
-  - uid: 4721
+  - uid: 5023
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
@@ -26476,37 +26482,37 @@ entities:
       parent: 2
 - proto: CurtainsOrangeOpen
   entities:
-  - uid: 4722
+  - uid: 5024
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: -33.5,-35.5
       parent: 2
-  - uid: 4723
+  - uid: 5025
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: -32.5,-35.5
       parent: 2
-  - uid: 4724
+  - uid: 5026
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: -31.5,-35.5
       parent: 2
-  - uid: 4725
+  - uid: 5027
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: -29.5,-36.5
       parent: 2
-  - uid: 4726
+  - uid: 5028
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: -29.5,-37.5
       parent: 2
-  - uid: 4727
+  - uid: 5029
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
@@ -26514,7 +26520,7 @@ entities:
       parent: 2
 - proto: CurtainsRed
   entities:
-  - uid: 4728
+  - uid: 5030
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
@@ -26522,13 +26528,13 @@ entities:
       parent: 2
 - proto: CurtainsRedOpen
   entities:
-  - uid: 4729
+  - uid: 5031
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: -34.5,-51.5
       parent: 2
-  - uid: 4730
+  - uid: 5032
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
@@ -26536,7 +26542,7 @@ entities:
       parent: 2
 - proto: DefibrillatorCabinetFilled
   entities:
-  - uid: 4731
+  - uid: 5033
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
@@ -26546,49 +26552,49 @@ entities:
       fixtures: {}
 - proto: Dresser
   entities:
-  - uid: 4732
+  - uid: 5034
     components:
     - type: Transform
       pos: -45.5,-47.5
       parent: 2
-  - uid: 4733
+  - uid: 5035
     components:
     - type: Transform
       pos: -32.5,-47.5
       parent: 2
-  - uid: 4734
+  - uid: 5036
     components:
     - type: Transform
       pos: -44.5,-49.5
       parent: 2
-  - uid: 4735
+  - uid: 5037
     components:
     - type: Transform
       pos: -33.5,-49.5
       parent: 2
-  - uid: 4736
+  - uid: 5038
     components:
     - type: Transform
       pos: -42.5,-46.5
       parent: 2
-  - uid: 4737
+  - uid: 5039
     components:
     - type: Transform
       pos: -35.5,-46.5
       parent: 2
-  - uid: 4738
+  - uid: 5040
     components:
     - type: Transform
       pos: -43.5,-36.5
       parent: 2
-  - uid: 4739
+  - uid: 5041
     components:
     - type: Transform
       pos: -30.5,-36.5
       parent: 2
 - proto: EdgeDetector
   entities:
-  - uid: 4740
+  - uid: 5042
     components:
     - type: Transform
       anchored: True
@@ -26598,7 +26604,7 @@ entities:
       invokeCounter: 1
     - type: DeviceLinkSource
       linkedPorts:
-        5899:
+        6148:
         - - OutputHigh
           - On
         - - OutputLow
@@ -26606,7 +26612,7 @@ entities:
     - type: Physics
       canCollide: False
       bodyType: Static
-  - uid: 4741
+  - uid: 5043
     components:
     - type: Transform
       anchored: True
@@ -26617,7 +26623,7 @@ entities:
       invokeCounter: 1
     - type: DeviceLinkSource
       linkedPorts:
-        5896:
+        6145:
         - - OutputHigh
           - On
         - - OutputLow
@@ -26625,7 +26631,7 @@ entities:
     - type: Physics
       canCollide: False
       bodyType: Static
-  - uid: 4742
+  - uid: 5044
     components:
     - type: Transform
       anchored: True
@@ -26635,7 +26641,7 @@ entities:
       invokeCounter: 1
     - type: DeviceLinkSource
       linkedPorts:
-        5897:
+        6146:
         - - OutputHigh
           - On
         - - OutputLow
@@ -26643,7 +26649,7 @@ entities:
     - type: Physics
       canCollide: False
       bodyType: Static
-  - uid: 4743
+  - uid: 5045
     components:
     - type: Transform
       anchored: True
@@ -26654,7 +26660,7 @@ entities:
       invokeCounter: 1
     - type: DeviceLinkSource
       linkedPorts:
-        5898:
+        6147:
         - - OutputHigh
           - On
         - - OutputLow
@@ -26664,28 +26670,28 @@ entities:
       bodyType: Static
 - proto: EngineeringTechFab
   entities:
-  - uid: 4744
+  - uid: 5046
     components:
     - type: Transform
       pos: -85.5,-8.5
       parent: 2
 - proto: EpistemicsTechFab
   entities:
-  - uid: 4745
+  - uid: 5047
     components:
     - type: Transform
       pos: -92.5,0.5
       parent: 2
 - proto: ExosuitFabricator
   entities:
-  - uid: 4746
+  - uid: 5048
     components:
     - type: Transform
       pos: -91.5,0.5
       parent: 2
 - proto: ExtinguisherCabinetFilled
   entities:
-  - uid: 4747
+  - uid: 5049
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
@@ -26693,7 +26699,7 @@ entities:
       parent: 2
     - type: Fixtures
       fixtures: {}
-  - uid: 4748
+  - uid: 5050
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
@@ -26701,7 +26707,7 @@ entities:
       parent: 2
     - type: Fixtures
       fixtures: {}
-  - uid: 4749
+  - uid: 5051
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
@@ -26709,7 +26715,7 @@ entities:
       parent: 2
     - type: Fixtures
       fixtures: {}
-  - uid: 4750
+  - uid: 5052
     components:
     - type: Transform
       rot: 3.141592653589793 rad
@@ -26717,7 +26723,7 @@ entities:
       parent: 2
     - type: Fixtures
       fixtures: {}
-  - uid: 4751
+  - uid: 5053
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
@@ -26727,7 +26733,7 @@ entities:
       fixtures: {}
 - proto: FaxMachineBase
   entities:
-  - uid: 4752
+  - uid: 5054
     components:
     - type: Transform
       pos: -101.5,-5.5
@@ -26736,14 +26742,14 @@ entities:
       name: asdf
 - proto: filingCabinetDrawerRandom
   entities:
-  - uid: 4753
+  - uid: 5055
     components:
     - type: Transform
       pos: -94.5,3.5
       parent: 2
 - proto: FireAxeCabinetFilled
   entities:
-  - uid: 4754
+  - uid: 5056
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
@@ -26753,97 +26759,97 @@ entities:
       fixtures: {}
 - proto: Firelock
   entities:
-  - uid: 4755
+  - uid: 5057
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: -82.5,-5.5
       parent: 2
-  - uid: 4756
+  - uid: 5058
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: -83.5,-5.5
       parent: 2
-  - uid: 4757
+  - uid: 5059
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: -94.5,-0.5
       parent: 2
-  - uid: 4758
+  - uid: 5060
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: -93.5,-0.5
       parent: 2
-  - uid: 4759
+  - uid: 5061
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: -83.5,-0.5
       parent: 2
-  - uid: 4760
+  - uid: 5062
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: -82.5,-0.5
       parent: 2
-  - uid: 4761
+  - uid: 5063
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: -32.5,-39.5
       parent: 2
-  - uid: 4762
+  - uid: 5064
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: -32.5,-44.5
       parent: 2
-  - uid: 4763
+  - uid: 5065
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: -29.5,-41.5
       parent: 2
-  - uid: 4764
+  - uid: 5066
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: -45.5,-39.5
       parent: 2
-  - uid: 4765
+  - uid: 5067
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: -48.5,-41.5
       parent: 2
-  - uid: 4766
+  - uid: 5068
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: -45.5,-44.5
       parent: 2
-  - uid: 4767
+  - uid: 5069
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: -41.5,-47.5
       parent: 2
-  - uid: 4768
+  - uid: 5070
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: -41.5,-49.5
       parent: 2
-  - uid: 4769
+  - uid: 5071
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: -36.5,-49.5
       parent: 2
-  - uid: 4770
+  - uid: 5072
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
@@ -26851,25 +26857,25 @@ entities:
       parent: 2
 - proto: FirelockEdge
   entities:
-  - uid: 4771
+  - uid: 5073
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: -38.5,-39.5
       parent: 2
-  - uid: 4772
+  - uid: 5074
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: -39.5,-39.5
       parent: 2
-  - uid: 4773
+  - uid: 5075
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: -75.5,-2.5
       parent: 2
-  - uid: 4774
+  - uid: 5076
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
@@ -26877,91 +26883,91 @@ entities:
       parent: 2
 - proto: FirelockGlass
   entities:
-  - uid: 4775
+  - uid: 5077
     components:
     - type: Transform
       pos: -93.5,-5.5
       parent: 2
-  - uid: 4776
+  - uid: 5078
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: -42.5,-41.5
       parent: 2
-  - uid: 4777
+  - uid: 5079
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: -42.5,-42.5
       parent: 2
-  - uid: 4778
+  - uid: 5080
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: -39.5,-45.5
       parent: 2
-  - uid: 4779
+  - uid: 5081
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: -38.5,-45.5
       parent: 2
-  - uid: 4780
+  - uid: 5082
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: -35.5,-42.5
       parent: 2
-  - uid: 4781
+  - uid: 5083
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: -35.5,-41.5
       parent: 2
-  - uid: 4782
+  - uid: 5084
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: -80.5,-3.5
       parent: 2
-  - uid: 4783
+  - uid: 5085
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: -80.5,-2.5
       parent: 2
-  - uid: 4784
+  - uid: 5086
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: -96.5,-3.5
       parent: 2
-  - uid: 4785
+  - uid: 5087
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: -96.5,-2.5
       parent: 2
-  - uid: 4786
+  - uid: 5088
     components:
     - type: Transform
       pos: -94.5,5.5
       parent: 2
-  - uid: 4787
+  - uid: 5089
     components:
     - type: Transform
       pos: -94.5,-5.5
       parent: 2
 - proto: FloorDrain
   entities:
-  - uid: 4788
+  - uid: 5090
     components:
     - type: Transform
       pos: -81.5,5.5
       parent: 2
     - type: Fixtures
       fixtures: {}
-  - uid: 4789
+  - uid: 5091
     components:
     - type: Transform
       pos: -93.5,-10.5
@@ -26970,29 +26976,29 @@ entities:
       fixtures: {}
 - proto: FolderSpawner
   entities:
-  - uid: 4790
+  - uid: 5092
     components:
     - type: Transform
       pos: -46.376472,-45.38675
       parent: 2
-  - uid: 4791
+  - uid: 5093
     components:
     - type: Transform
       pos: -31.53978,-45.371124
       parent: 2
-  - uid: 4792
+  - uid: 5094
     components:
     - type: Transform
       pos: -33.5541,-36.356243
       parent: 2
-  - uid: 4793
+  - uid: 5095
     components:
     - type: Transform
       pos: -45.3666,-36.34062
       parent: 2
 - proto: GasFilter
   entities:
-  - uid: 4794
+  - uid: 5096
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
@@ -27000,8 +27006,7 @@ entities:
       parent: 2
     - type: GasFilter
       filteredGas: Nitrogen
-      enabled: True
-  - uid: 4795
+  - uid: 5097
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
@@ -27009,12 +27014,11 @@ entities:
       parent: 2
     - type: GasFilter
       filteredGas: Oxygen
-      enabled: True
     - type: AtmosPipeColor
       color: '#990000FF'
 - proto: GasMinerNitrogenStationLarge
   entities:
-  - uid: 4796
+  - uid: 5098
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
@@ -27022,7 +27026,7 @@ entities:
       parent: 2
 - proto: GasMinerOxygenStationLarge
   entities:
-  - uid: 4797
+  - uid: 5099
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
@@ -27030,7 +27034,7 @@ entities:
       parent: 2
 - proto: GasMixerFlipped
   entities:
-  - uid: 4798
+  - uid: 5100
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
@@ -27039,18 +27043,17 @@ entities:
     - type: GasMixer
       inletTwoConcentration: 0.25
       inletOneConcentration: 0.75
-      enabled: True
     - type: AtmosPipeColor
       color: '#0055CCFF'
 - proto: GasOutletInjector
   entities:
-  - uid: 4799
+  - uid: 5101
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: -79.5,-14.5
       parent: 2
-  - uid: 4800
+  - uid: 5102
     components:
     - type: Transform
       pos: -95.5,6.5
@@ -27059,19 +27062,19 @@ entities:
       pipeLayer: Secondary
 - proto: GasPassiveVent
   entities:
-  - uid: 4801
+  - uid: 5103
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: -84.5,-14.5
       parent: 2
-  - uid: 4802
+  - uid: 5104
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: -81.5,-14.5
       parent: 2
-  - uid: 4803
+  - uid: 5105
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
@@ -27081,23 +27084,23 @@ entities:
       pipeLayer: Tertiary
 - proto: GasPipeBend
   entities:
-  - uid: 4804
+  - uid: 5106
     components:
     - type: Transform
       pos: -79.5,-12.5
       parent: 2
-  - uid: 4805
+  - uid: 5107
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: -80.5,-12.5
       parent: 2
-  - uid: 4806
+  - uid: 5108
     components:
     - type: Transform
       pos: -81.5,-10.5
       parent: 2
-  - uid: 4807
+  - uid: 5109
     components:
     - type: Transform
       rot: 3.141592653589793 rad
@@ -27105,12 +27108,12 @@ entities:
       parent: 2
     - type: AtmosPipeColor
       color: '#0055CCFF'
-  - uid: 4808
+  - uid: 5110
     components:
     - type: Transform
       pos: -80.5,-8.5
       parent: 2
-  - uid: 4809
+  - uid: 5111
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
@@ -27118,7 +27121,7 @@ entities:
       parent: 2
     - type: AtmosPipeColor
       color: '#990000FF'
-  - uid: 4810
+  - uid: 5112
     components:
     - type: Transform
       rot: 3.141592653589793 rad
@@ -27126,7 +27129,7 @@ entities:
       parent: 2
     - type: AtmosPipeColor
       color: '#990000FF'
-  - uid: 4811
+  - uid: 5113
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
@@ -27134,14 +27137,14 @@ entities:
       parent: 2
 - proto: GasPipeBendAlt1
   entities:
-  - uid: 4812
+  - uid: 5114
     components:
     - type: Transform
       pos: -38.5,-2.5
       parent: 2
     - type: AtmosPipeColor
       color: '#0055CCFF'
-  - uid: 4813
+  - uid: 5115
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
@@ -27149,7 +27152,7 @@ entities:
       parent: 2
     - type: AtmosPipeColor
       color: '#0055CCFF'
-  - uid: 4814
+  - uid: 5116
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
@@ -27157,7 +27160,7 @@ entities:
       parent: 2
     - type: AtmosPipeColor
       color: '#0055CCFF'
-  - uid: 4815
+  - uid: 5117
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
@@ -27165,7 +27168,7 @@ entities:
       parent: 2
     - type: AtmosPipeColor
       color: '#0055CCFF'
-  - uid: 4816
+  - uid: 5118
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
@@ -27173,7 +27176,7 @@ entities:
       parent: 2
     - type: AtmosPipeColor
       color: '#0055CCFF'
-  - uid: 4817
+  - uid: 5119
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
@@ -27181,7 +27184,7 @@ entities:
       parent: 2
     - type: AtmosPipeColor
       color: '#0055CCFF'
-  - uid: 4818
+  - uid: 5120
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
@@ -27189,7 +27192,7 @@ entities:
       parent: 2
     - type: AtmosPipeColor
       color: '#0055CCFF'
-  - uid: 4819
+  - uid: 5121
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
@@ -27197,7 +27200,7 @@ entities:
       parent: 2
     - type: AtmosPipeColor
       color: '#0055CCFF'
-  - uid: 4820
+  - uid: 5122
     components:
     - type: Transform
       rot: 3.141592653589793 rad
@@ -27205,7 +27208,7 @@ entities:
       parent: 2
     - type: AtmosPipeColor
       color: '#0055CCFF'
-  - uid: 4821
+  - uid: 5123
     components:
     - type: Transform
       rot: 3.141592653589793 rad
@@ -27213,7 +27216,7 @@ entities:
       parent: 2
     - type: AtmosPipeColor
       color: '#0055CCFF'
-  - uid: 4822
+  - uid: 5124
     components:
     - type: Transform
       rot: 3.141592653589793 rad
@@ -27221,7 +27224,7 @@ entities:
       parent: 2
     - type: AtmosPipeColor
       color: '#0055CCFF'
-  - uid: 4823
+  - uid: 5125
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
@@ -27229,7 +27232,7 @@ entities:
       parent: 2
     - type: AtmosPipeColor
       color: '#0055CCFF'
-  - uid: 4824
+  - uid: 5126
     components:
     - type: Transform
       rot: 3.141592653589793 rad
@@ -27237,7 +27240,7 @@ entities:
       parent: 2
     - type: AtmosPipeColor
       color: '#0055CCFF'
-  - uid: 4825
+  - uid: 5127
     components:
     - type: Transform
       rot: 3.141592653589793 rad
@@ -27245,7 +27248,7 @@ entities:
       parent: 2
     - type: AtmosPipeColor
       color: '#0055CCFF'
-  - uid: 4826
+  - uid: 5128
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
@@ -27253,7 +27256,7 @@ entities:
       parent: 2
     - type: AtmosPipeColor
       color: '#0055CCFF'
-  - uid: 4827
+  - uid: 5129
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
@@ -27261,7 +27264,7 @@ entities:
       parent: 2
     - type: AtmosPipeColor
       color: '#0055CCFF'
-  - uid: 4828
+  - uid: 5130
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
@@ -27269,7 +27272,7 @@ entities:
       parent: 2
     - type: AtmosPipeColor
       color: '#0055CCFF'
-  - uid: 4829
+  - uid: 5131
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
@@ -27277,7 +27280,7 @@ entities:
       parent: 2
     - type: AtmosPipeColor
       color: '#0055CCFF'
-  - uid: 4830
+  - uid: 5132
     components:
     - type: Transform
       rot: 3.141592653589793 rad
@@ -27285,21 +27288,21 @@ entities:
       parent: 2
 - proto: GasPipeBendAlt2
   entities:
-  - uid: 4831
+  - uid: 5133
     components:
     - type: Transform
       pos: -38.5,-2.5
       parent: 2
     - type: AtmosPipeColor
       color: '#990000FF'
-  - uid: 4832
+  - uid: 5134
     components:
     - type: Transform
       pos: -82.5,0.5
       parent: 2
     - type: AtmosPipeColor
       color: '#990000FF'
-  - uid: 4833
+  - uid: 5135
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
@@ -27307,7 +27310,7 @@ entities:
       parent: 2
     - type: AtmosPipeColor
       color: '#990000FF'
-  - uid: 4834
+  - uid: 5136
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
@@ -27315,7 +27318,7 @@ entities:
       parent: 2
     - type: AtmosPipeColor
       color: '#990000FF'
-  - uid: 4835
+  - uid: 5137
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
@@ -27323,7 +27326,7 @@ entities:
       parent: 2
     - type: AtmosPipeColor
       color: '#990000FF'
-  - uid: 4836
+  - uid: 5138
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
@@ -27331,14 +27334,14 @@ entities:
       parent: 2
     - type: AtmosPipeColor
       color: '#990000FF'
-  - uid: 4837
+  - uid: 5139
     components:
     - type: Transform
       pos: -35.5,-49.5
       parent: 2
     - type: AtmosPipeColor
       color: '#990000FF'
-  - uid: 4838
+  - uid: 5140
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
@@ -27346,7 +27349,7 @@ entities:
       parent: 2
     - type: AtmosPipeColor
       color: '#990000FF'
-  - uid: 4839
+  - uid: 5141
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
@@ -27354,33 +27357,33 @@ entities:
       parent: 2
     - type: AtmosPipeColor
       color: '#990000FF'
-  - uid: 4840
+  - uid: 5142
     components:
     - type: Transform
       pos: -45.5,-38.5
       parent: 2
     - type: AtmosPipeColor
       color: '#990000FF'
-  - uid: 4841
+  - uid: 5143
     components:
     - type: Transform
       pos: -32.5,-38.5
       parent: 2
     - type: AtmosPipeColor
       color: '#990000FF'
-  - uid: 4842
+  - uid: 5144
     components:
     - type: Transform
       pos: -28.5,-41.5
       parent: 2
     - type: AtmosPipeColor
       color: '#990000FF'
-  - uid: 4843
+  - uid: 5145
     components:
     - type: Transform
       pos: -91.5,5.5
       parent: 2
-  - uid: 4844
+  - uid: 5146
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
@@ -27388,7 +27391,7 @@ entities:
       parent: 2
     - type: AtmosPipeColor
       color: '#990000FF'
-  - uid: 4845
+  - uid: 5147
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
@@ -27398,42 +27401,42 @@ entities:
       color: '#990000FF'
 - proto: GasPipeFourwayAlt1
   entities:
-  - uid: 4846
+  - uid: 5148
     components:
     - type: Transform
       pos: -38.5,-47.5
       parent: 2
     - type: AtmosPipeColor
       color: '#0055CCFF'
-  - uid: 4847
+  - uid: 5149
     components:
     - type: Transform
       pos: -45.5,-41.5
       parent: 2
     - type: AtmosPipeColor
       color: '#0055CCFF'
-  - uid: 4848
+  - uid: 5150
     components:
     - type: Transform
       pos: -38.5,-41.5
       parent: 2
     - type: AtmosPipeColor
       color: '#0055CCFF'
-  - uid: 4849
+  - uid: 5151
     components:
     - type: Transform
       pos: -32.5,-41.5
       parent: 2
     - type: AtmosPipeColor
       color: '#0055CCFF'
-  - uid: 4850
+  - uid: 5152
     components:
     - type: Transform
       pos: -93.5,-2.5
       parent: 2
     - type: AtmosPipeColor
       color: '#0055CCFF'
-  - uid: 4851
+  - uid: 5153
     components:
     - type: Transform
       pos: -82.5,-2.5
@@ -27442,42 +27445,42 @@ entities:
       color: '#0055CCFF'
 - proto: GasPipeFourwayAlt2
   entities:
-  - uid: 4852
+  - uid: 5154
     components:
     - type: Transform
       pos: -45.5,-41.5
       parent: 2
     - type: AtmosPipeColor
       color: '#990000FF'
-  - uid: 4853
+  - uid: 5155
     components:
     - type: Transform
       pos: -38.5,-41.5
       parent: 2
     - type: AtmosPipeColor
       color: '#990000FF'
-  - uid: 4854
+  - uid: 5156
     components:
     - type: Transform
       pos: -32.5,-41.5
       parent: 2
     - type: AtmosPipeColor
       color: '#990000FF'
-  - uid: 4855
+  - uid: 5157
     components:
     - type: Transform
       pos: -38.5,-47.5
       parent: 2
     - type: AtmosPipeColor
       color: '#990000FF'
-  - uid: 4856
+  - uid: 5158
     components:
     - type: Transform
       pos: -93.5,-2.5
       parent: 2
     - type: AtmosPipeColor
       color: '#990000FF'
-  - uid: 4857
+  - uid: 5159
     components:
     - type: Transform
       pos: -82.5,-2.5
@@ -27486,7 +27489,7 @@ entities:
       color: '#990000FF'
 - proto: GasPipeManifold
   entities:
-  - uid: 4858
+  - uid: 5160
     components:
     - type: Transform
       rot: 3.141592653589793 rad
@@ -27494,7 +27497,7 @@ entities:
       parent: 2
     - type: AtmosPipeColor
       color: '#0055CCFF'
-  - uid: 4859
+  - uid: 5161
     components:
     - type: Transform
       rot: 3.141592653589793 rad
@@ -27502,7 +27505,7 @@ entities:
       parent: 2
     - type: AtmosPipeColor
       color: '#990000FF'
-  - uid: 4860
+  - uid: 5162
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
@@ -27510,60 +27513,60 @@ entities:
       parent: 2
 - proto: GasPipeStraight
   entities:
-  - uid: 4861
+  - uid: 5163
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: -84.5,-13.5
       parent: 2
-  - uid: 4862
+  - uid: 5164
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: -81.5,-13.5
       parent: 2
-  - uid: 4863
+  - uid: 5165
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: -79.5,-13.5
       parent: 2
-  - uid: 4864
+  - uid: 5166
     components:
     - type: Transform
       pos: -81.5,-11.5
       parent: 2
-  - uid: 4865
+  - uid: 5167
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: -83.5,-10.5
       parent: 2
-  - uid: 4866
+  - uid: 5168
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: -83.5,-10.5
       parent: 2
-  - uid: 4867
+  - uid: 5169
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: -80.5,-10.5
       parent: 2
-  - uid: 4868
+  - uid: 5170
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: -81.5,-9.5
       parent: 2
-  - uid: 4869
+  - uid: 5171
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: -80.5,-11.5
       parent: 2
-  - uid: 4870
+  - uid: 5172
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
@@ -27573,7 +27576,7 @@ entities:
       color: '#990000FF'
 - proto: GasPipeStraightAlt1
   entities:
-  - uid: 4871
+  - uid: 5173
     components:
     - type: Transform
       rot: 3.141592653589793 rad
@@ -27581,7 +27584,7 @@ entities:
       parent: 2
     - type: AtmosPipeColor
       color: '#0055CCFF'
-  - uid: 4872
+  - uid: 5174
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
@@ -27589,7 +27592,7 @@ entities:
       parent: 2
     - type: AtmosPipeColor
       color: '#0055CCFF'
-  - uid: 4873
+  - uid: 5175
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
@@ -27597,7 +27600,7 @@ entities:
       parent: 2
     - type: AtmosPipeColor
       color: '#0055CCFF'
-  - uid: 4874
+  - uid: 5176
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
@@ -27605,7 +27608,7 @@ entities:
       parent: 2
     - type: AtmosPipeColor
       color: '#0055CCFF'
-  - uid: 4875
+  - uid: 5177
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
@@ -27613,7 +27616,7 @@ entities:
       parent: 2
     - type: AtmosPipeColor
       color: '#0055CCFF'
-  - uid: 4876
+  - uid: 5178
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
@@ -27621,7 +27624,7 @@ entities:
       parent: 2
     - type: AtmosPipeColor
       color: '#0055CCFF'
-  - uid: 4877
+  - uid: 5179
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
@@ -27629,7 +27632,7 @@ entities:
       parent: 2
     - type: AtmosPipeColor
       color: '#0055CCFF'
-  - uid: 4878
+  - uid: 5180
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
@@ -27637,7 +27640,7 @@ entities:
       parent: 2
     - type: AtmosPipeColor
       color: '#0055CCFF'
-  - uid: 4879
+  - uid: 5181
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
@@ -27645,7 +27648,7 @@ entities:
       parent: 2
     - type: AtmosPipeColor
       color: '#0055CCFF'
-  - uid: 4880
+  - uid: 5182
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
@@ -27653,7 +27656,7 @@ entities:
       parent: 2
     - type: AtmosPipeColor
       color: '#0055CCFF'
-  - uid: 4881
+  - uid: 5183
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
@@ -27661,7 +27664,7 @@ entities:
       parent: 2
     - type: AtmosPipeColor
       color: '#0055CCFF'
-  - uid: 4882
+  - uid: 5184
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
@@ -27669,7 +27672,7 @@ entities:
       parent: 2
     - type: AtmosPipeColor
       color: '#0055CCFF'
-  - uid: 4883
+  - uid: 5185
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
@@ -27677,7 +27680,7 @@ entities:
       parent: 2
     - type: AtmosPipeColor
       color: '#0055CCFF'
-  - uid: 4884
+  - uid: 5186
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
@@ -27685,7 +27688,7 @@ entities:
       parent: 2
     - type: AtmosPipeColor
       color: '#0055CCFF'
-  - uid: 4885
+  - uid: 5187
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
@@ -27693,7 +27696,7 @@ entities:
       parent: 2
     - type: AtmosPipeColor
       color: '#0055CCFF'
-  - uid: 4886
+  - uid: 5188
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
@@ -27701,7 +27704,7 @@ entities:
       parent: 2
     - type: AtmosPipeColor
       color: '#0055CCFF'
-  - uid: 4887
+  - uid: 5189
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
@@ -27709,7 +27712,7 @@ entities:
       parent: 2
     - type: AtmosPipeColor
       color: '#0055CCFF'
-  - uid: 4888
+  - uid: 5190
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
@@ -27717,7 +27720,7 @@ entities:
       parent: 2
     - type: AtmosPipeColor
       color: '#0055CCFF'
-  - uid: 4889
+  - uid: 5191
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
@@ -27725,7 +27728,7 @@ entities:
       parent: 2
     - type: AtmosPipeColor
       color: '#0055CCFF'
-  - uid: 4890
+  - uid: 5192
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
@@ -27733,7 +27736,7 @@ entities:
       parent: 2
     - type: AtmosPipeColor
       color: '#0055CCFF'
-  - uid: 4891
+  - uid: 5193
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
@@ -27741,7 +27744,7 @@ entities:
       parent: 2
     - type: AtmosPipeColor
       color: '#0055CCFF'
-  - uid: 4892
+  - uid: 5194
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
@@ -27749,7 +27752,7 @@ entities:
       parent: 2
     - type: AtmosPipeColor
       color: '#0055CCFF'
-  - uid: 4893
+  - uid: 5195
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
@@ -27757,7 +27760,7 @@ entities:
       parent: 2
     - type: AtmosPipeColor
       color: '#0055CCFF'
-  - uid: 4894
+  - uid: 5196
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
@@ -27765,7 +27768,7 @@ entities:
       parent: 2
     - type: AtmosPipeColor
       color: '#0055CCFF'
-  - uid: 4895
+  - uid: 5197
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
@@ -27773,7 +27776,7 @@ entities:
       parent: 2
     - type: AtmosPipeColor
       color: '#0055CCFF'
-  - uid: 4896
+  - uid: 5198
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
@@ -27781,7 +27784,7 @@ entities:
       parent: 2
     - type: AtmosPipeColor
       color: '#0055CCFF'
-  - uid: 4897
+  - uid: 5199
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
@@ -27789,7 +27792,7 @@ entities:
       parent: 2
     - type: AtmosPipeColor
       color: '#0055CCFF'
-  - uid: 4898
+  - uid: 5200
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
@@ -27797,7 +27800,7 @@ entities:
       parent: 2
     - type: AtmosPipeColor
       color: '#0055CCFF'
-  - uid: 4899
+  - uid: 5201
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
@@ -27805,7 +27808,7 @@ entities:
       parent: 2
     - type: AtmosPipeColor
       color: '#0055CCFF'
-  - uid: 4900
+  - uid: 5202
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
@@ -27813,7 +27816,7 @@ entities:
       parent: 2
     - type: AtmosPipeColor
       color: '#0055CCFF'
-  - uid: 4901
+  - uid: 5203
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
@@ -27821,7 +27824,7 @@ entities:
       parent: 2
     - type: AtmosPipeColor
       color: '#0055CCFF'
-  - uid: 4902
+  - uid: 5204
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
@@ -27829,7 +27832,7 @@ entities:
       parent: 2
     - type: AtmosPipeColor
       color: '#0055CCFF'
-  - uid: 4903
+  - uid: 5205
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
@@ -27837,7 +27840,7 @@ entities:
       parent: 2
     - type: AtmosPipeColor
       color: '#0055CCFF'
-  - uid: 4904
+  - uid: 5206
     components:
     - type: Transform
       rot: 3.141592653589793 rad
@@ -27845,7 +27848,7 @@ entities:
       parent: 2
     - type: AtmosPipeColor
       color: '#0055CCFF'
-  - uid: 4905
+  - uid: 5207
     components:
     - type: Transform
       rot: 3.141592653589793 rad
@@ -27853,7 +27856,7 @@ entities:
       parent: 2
     - type: AtmosPipeColor
       color: '#0055CCFF'
-  - uid: 4906
+  - uid: 5208
     components:
     - type: Transform
       rot: 3.141592653589793 rad
@@ -27861,7 +27864,7 @@ entities:
       parent: 2
     - type: AtmosPipeColor
       color: '#0055CCFF'
-  - uid: 4907
+  - uid: 5209
     components:
     - type: Transform
       rot: 3.141592653589793 rad
@@ -27869,7 +27872,7 @@ entities:
       parent: 2
     - type: AtmosPipeColor
       color: '#0055CCFF'
-  - uid: 4908
+  - uid: 5210
     components:
     - type: Transform
       rot: 3.141592653589793 rad
@@ -27877,7 +27880,7 @@ entities:
       parent: 2
     - type: AtmosPipeColor
       color: '#0055CCFF'
-  - uid: 4909
+  - uid: 5211
     components:
     - type: Transform
       rot: 3.141592653589793 rad
@@ -27885,7 +27888,7 @@ entities:
       parent: 2
     - type: AtmosPipeColor
       color: '#0055CCFF'
-  - uid: 4910
+  - uid: 5212
     components:
     - type: Transform
       rot: 3.141592653589793 rad
@@ -27893,7 +27896,7 @@ entities:
       parent: 2
     - type: AtmosPipeColor
       color: '#0055CCFF'
-  - uid: 4911
+  - uid: 5213
     components:
     - type: Transform
       rot: 3.141592653589793 rad
@@ -27901,7 +27904,7 @@ entities:
       parent: 2
     - type: AtmosPipeColor
       color: '#0055CCFF'
-  - uid: 4912
+  - uid: 5214
     components:
     - type: Transform
       rot: 3.141592653589793 rad
@@ -27909,7 +27912,7 @@ entities:
       parent: 2
     - type: AtmosPipeColor
       color: '#0055CCFF'
-  - uid: 4913
+  - uid: 5215
     components:
     - type: Transform
       rot: 3.141592653589793 rad
@@ -27917,7 +27920,7 @@ entities:
       parent: 2
     - type: AtmosPipeColor
       color: '#0055CCFF'
-  - uid: 4914
+  - uid: 5216
     components:
     - type: Transform
       rot: 3.141592653589793 rad
@@ -27925,7 +27928,7 @@ entities:
       parent: 2
     - type: AtmosPipeColor
       color: '#0055CCFF'
-  - uid: 4915
+  - uid: 5217
     components:
     - type: Transform
       rot: 3.141592653589793 rad
@@ -27933,7 +27936,7 @@ entities:
       parent: 2
     - type: AtmosPipeColor
       color: '#0055CCFF'
-  - uid: 4916
+  - uid: 5218
     components:
     - type: Transform
       rot: 3.141592653589793 rad
@@ -27941,7 +27944,7 @@ entities:
       parent: 2
     - type: AtmosPipeColor
       color: '#0055CCFF'
-  - uid: 4917
+  - uid: 5219
     components:
     - type: Transform
       rot: 3.141592653589793 rad
@@ -27949,7 +27952,7 @@ entities:
       parent: 2
     - type: AtmosPipeColor
       color: '#0055CCFF'
-  - uid: 4918
+  - uid: 5220
     components:
     - type: Transform
       rot: 3.141592653589793 rad
@@ -27957,7 +27960,7 @@ entities:
       parent: 2
     - type: AtmosPipeColor
       color: '#0055CCFF'
-  - uid: 4919
+  - uid: 5221
     components:
     - type: Transform
       rot: 3.141592653589793 rad
@@ -27965,7 +27968,7 @@ entities:
       parent: 2
     - type: AtmosPipeColor
       color: '#0055CCFF'
-  - uid: 4920
+  - uid: 5222
     components:
     - type: Transform
       rot: 3.141592653589793 rad
@@ -27973,7 +27976,7 @@ entities:
       parent: 2
     - type: AtmosPipeColor
       color: '#0055CCFF'
-  - uid: 4921
+  - uid: 5223
     components:
     - type: Transform
       rot: 3.141592653589793 rad
@@ -27981,7 +27984,7 @@ entities:
       parent: 2
     - type: AtmosPipeColor
       color: '#0055CCFF'
-  - uid: 4922
+  - uid: 5224
     components:
     - type: Transform
       rot: 3.141592653589793 rad
@@ -27989,7 +27992,7 @@ entities:
       parent: 2
     - type: AtmosPipeColor
       color: '#0055CCFF'
-  - uid: 4923
+  - uid: 5225
     components:
     - type: Transform
       rot: 3.141592653589793 rad
@@ -27997,7 +28000,7 @@ entities:
       parent: 2
     - type: AtmosPipeColor
       color: '#0055CCFF'
-  - uid: 4924
+  - uid: 5226
     components:
     - type: Transform
       rot: 3.141592653589793 rad
@@ -28005,7 +28008,7 @@ entities:
       parent: 2
     - type: AtmosPipeColor
       color: '#0055CCFF'
-  - uid: 4925
+  - uid: 5227
     components:
     - type: Transform
       rot: 3.141592653589793 rad
@@ -28013,7 +28016,7 @@ entities:
       parent: 2
     - type: AtmosPipeColor
       color: '#0055CCFF'
-  - uid: 4926
+  - uid: 5228
     components:
     - type: Transform
       rot: 3.141592653589793 rad
@@ -28021,7 +28024,7 @@ entities:
       parent: 2
     - type: AtmosPipeColor
       color: '#0055CCFF'
-  - uid: 4927
+  - uid: 5229
     components:
     - type: Transform
       rot: 3.141592653589793 rad
@@ -28029,7 +28032,7 @@ entities:
       parent: 2
     - type: AtmosPipeColor
       color: '#0055CCFF'
-  - uid: 4928
+  - uid: 5230
     components:
     - type: Transform
       rot: 3.141592653589793 rad
@@ -28037,7 +28040,7 @@ entities:
       parent: 2
     - type: AtmosPipeColor
       color: '#0055CCFF'
-  - uid: 4929
+  - uid: 5231
     components:
     - type: Transform
       rot: 3.141592653589793 rad
@@ -28045,7 +28048,7 @@ entities:
       parent: 2
     - type: AtmosPipeColor
       color: '#0055CCFF'
-  - uid: 4930
+  - uid: 5232
     components:
     - type: Transform
       rot: 3.141592653589793 rad
@@ -28053,7 +28056,7 @@ entities:
       parent: 2
     - type: AtmosPipeColor
       color: '#0055CCFF'
-  - uid: 4931
+  - uid: 5233
     components:
     - type: Transform
       rot: 3.141592653589793 rad
@@ -28061,7 +28064,7 @@ entities:
       parent: 2
     - type: AtmosPipeColor
       color: '#0055CCFF'
-  - uid: 4932
+  - uid: 5234
     components:
     - type: Transform
       rot: 3.141592653589793 rad
@@ -28069,7 +28072,7 @@ entities:
       parent: 2
     - type: AtmosPipeColor
       color: '#0055CCFF'
-  - uid: 4933
+  - uid: 5235
     components:
     - type: Transform
       rot: 3.141592653589793 rad
@@ -28077,7 +28080,7 @@ entities:
       parent: 2
     - type: AtmosPipeColor
       color: '#0055CCFF'
-  - uid: 4934
+  - uid: 5236
     components:
     - type: Transform
       rot: 3.141592653589793 rad
@@ -28085,7 +28088,7 @@ entities:
       parent: 2
     - type: AtmosPipeColor
       color: '#0055CCFF'
-  - uid: 4935
+  - uid: 5237
     components:
     - type: Transform
       rot: 3.141592653589793 rad
@@ -28093,7 +28096,7 @@ entities:
       parent: 2
     - type: AtmosPipeColor
       color: '#0055CCFF'
-  - uid: 4936
+  - uid: 5238
     components:
     - type: Transform
       rot: 3.141592653589793 rad
@@ -28101,7 +28104,7 @@ entities:
       parent: 2
     - type: AtmosPipeColor
       color: '#0055CCFF'
-  - uid: 4937
+  - uid: 5239
     components:
     - type: Transform
       rot: 3.141592653589793 rad
@@ -28109,7 +28112,7 @@ entities:
       parent: 2
     - type: AtmosPipeColor
       color: '#0055CCFF'
-  - uid: 4938
+  - uid: 5240
     components:
     - type: Transform
       rot: 3.141592653589793 rad
@@ -28117,7 +28120,7 @@ entities:
       parent: 2
     - type: AtmosPipeColor
       color: '#0055CCFF'
-  - uid: 4939
+  - uid: 5241
     components:
     - type: Transform
       rot: 3.141592653589793 rad
@@ -28125,7 +28128,7 @@ entities:
       parent: 2
     - type: AtmosPipeColor
       color: '#0055CCFF'
-  - uid: 4940
+  - uid: 5242
     components:
     - type: Transform
       rot: 3.141592653589793 rad
@@ -28133,7 +28136,7 @@ entities:
       parent: 2
     - type: AtmosPipeColor
       color: '#0055CCFF'
-  - uid: 4941
+  - uid: 5243
     components:
     - type: Transform
       rot: 3.141592653589793 rad
@@ -28141,7 +28144,7 @@ entities:
       parent: 2
     - type: AtmosPipeColor
       color: '#0055CCFF'
-  - uid: 4942
+  - uid: 5244
     components:
     - type: Transform
       rot: 3.141592653589793 rad
@@ -28149,7 +28152,7 @@ entities:
       parent: 2
     - type: AtmosPipeColor
       color: '#0055CCFF'
-  - uid: 4943
+  - uid: 5245
     components:
     - type: Transform
       rot: 3.141592653589793 rad
@@ -28157,7 +28160,7 @@ entities:
       parent: 2
     - type: AtmosPipeColor
       color: '#0055CCFF'
-  - uid: 4944
+  - uid: 5246
     components:
     - type: Transform
       rot: 3.141592653589793 rad
@@ -28165,7 +28168,7 @@ entities:
       parent: 2
     - type: AtmosPipeColor
       color: '#0055CCFF'
-  - uid: 4945
+  - uid: 5247
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
@@ -28173,7 +28176,7 @@ entities:
       parent: 2
     - type: AtmosPipeColor
       color: '#0055CCFF'
-  - uid: 4946
+  - uid: 5248
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
@@ -28181,14 +28184,14 @@ entities:
       parent: 2
     - type: AtmosPipeColor
       color: '#0055CCFF'
-  - uid: 4947
+  - uid: 5249
     components:
     - type: Transform
       pos: -38.5,-46.5
       parent: 2
     - type: AtmosPipeColor
       color: '#0055CCFF'
-  - uid: 4948
+  - uid: 5250
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
@@ -28196,7 +28199,7 @@ entities:
       parent: 2
     - type: AtmosPipeColor
       color: '#0055CCFF'
-  - uid: 4949
+  - uid: 5251
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
@@ -28204,7 +28207,7 @@ entities:
       parent: 2
     - type: AtmosPipeColor
       color: '#0055CCFF'
-  - uid: 4950
+  - uid: 5252
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
@@ -28212,7 +28215,7 @@ entities:
       parent: 2
     - type: AtmosPipeColor
       color: '#0055CCFF'
-  - uid: 4951
+  - uid: 5253
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
@@ -28220,7 +28223,7 @@ entities:
       parent: 2
     - type: AtmosPipeColor
       color: '#0055CCFF'
-  - uid: 4952
+  - uid: 5254
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
@@ -28228,7 +28231,7 @@ entities:
       parent: 2
     - type: AtmosPipeColor
       color: '#0055CCFF'
-  - uid: 4953
+  - uid: 5255
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
@@ -28236,7 +28239,7 @@ entities:
       parent: 2
     - type: AtmosPipeColor
       color: '#0055CCFF'
-  - uid: 4954
+  - uid: 5256
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
@@ -28244,7 +28247,7 @@ entities:
       parent: 2
     - type: AtmosPipeColor
       color: '#0055CCFF'
-  - uid: 4955
+  - uid: 5257
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
@@ -28252,7 +28255,7 @@ entities:
       parent: 2
     - type: AtmosPipeColor
       color: '#0055CCFF'
-  - uid: 4956
+  - uid: 5258
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
@@ -28260,7 +28263,7 @@ entities:
       parent: 2
     - type: AtmosPipeColor
       color: '#0055CCFF'
-  - uid: 4957
+  - uid: 5259
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
@@ -28268,7 +28271,7 @@ entities:
       parent: 2
     - type: AtmosPipeColor
       color: '#0055CCFF'
-  - uid: 4958
+  - uid: 5260
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
@@ -28276,7 +28279,7 @@ entities:
       parent: 2
     - type: AtmosPipeColor
       color: '#0055CCFF'
-  - uid: 4959
+  - uid: 5261
     components:
     - type: Transform
       rot: 3.141592653589793 rad
@@ -28284,7 +28287,7 @@ entities:
       parent: 2
     - type: AtmosPipeColor
       color: '#0055CCFF'
-  - uid: 4960
+  - uid: 5262
     components:
     - type: Transform
       rot: 3.141592653589793 rad
@@ -28292,7 +28295,7 @@ entities:
       parent: 2
     - type: AtmosPipeColor
       color: '#0055CCFF'
-  - uid: 4961
+  - uid: 5263
     components:
     - type: Transform
       rot: 3.141592653589793 rad
@@ -28300,7 +28303,7 @@ entities:
       parent: 2
     - type: AtmosPipeColor
       color: '#0055CCFF'
-  - uid: 4962
+  - uid: 5264
     components:
     - type: Transform
       rot: 3.141592653589793 rad
@@ -28308,7 +28311,7 @@ entities:
       parent: 2
     - type: AtmosPipeColor
       color: '#0055CCFF'
-  - uid: 4963
+  - uid: 5265
     components:
     - type: Transform
       rot: 3.141592653589793 rad
@@ -28316,7 +28319,7 @@ entities:
       parent: 2
     - type: AtmosPipeColor
       color: '#0055CCFF'
-  - uid: 4964
+  - uid: 5266
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
@@ -28324,7 +28327,7 @@ entities:
       parent: 2
     - type: AtmosPipeColor
       color: '#0055CCFF'
-  - uid: 4965
+  - uid: 5267
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
@@ -28332,7 +28335,7 @@ entities:
       parent: 2
     - type: AtmosPipeColor
       color: '#0055CCFF'
-  - uid: 4966
+  - uid: 5268
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
@@ -28340,42 +28343,42 @@ entities:
       parent: 2
     - type: AtmosPipeColor
       color: '#0055CCFF'
-  - uid: 4967
+  - uid: 5269
     components:
     - type: Transform
       pos: -32.5,-40.5
       parent: 2
     - type: AtmosPipeColor
       color: '#0055CCFF'
-  - uid: 4968
+  - uid: 5270
     components:
     - type: Transform
       pos: -32.5,-42.5
       parent: 2
     - type: AtmosPipeColor
       color: '#0055CCFF'
-  - uid: 4969
+  - uid: 5271
     components:
     - type: Transform
       pos: -32.5,-39.5
       parent: 2
     - type: AtmosPipeColor
       color: '#0055CCFF'
-  - uid: 4970
+  - uid: 5272
     components:
     - type: Transform
       pos: -32.5,-43.5
       parent: 2
     - type: AtmosPipeColor
       color: '#0055CCFF'
-  - uid: 4971
+  - uid: 5273
     components:
     - type: Transform
       pos: -32.5,-44.5
       parent: 2
     - type: AtmosPipeColor
       color: '#0055CCFF'
-  - uid: 4972
+  - uid: 5274
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
@@ -28383,7 +28386,7 @@ entities:
       parent: 2
     - type: AtmosPipeColor
       color: '#0055CCFF'
-  - uid: 4973
+  - uid: 5275
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
@@ -28391,7 +28394,7 @@ entities:
       parent: 2
     - type: AtmosPipeColor
       color: '#0055CCFF'
-  - uid: 4974
+  - uid: 5276
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
@@ -28399,7 +28402,7 @@ entities:
       parent: 2
     - type: AtmosPipeColor
       color: '#0055CCFF'
-  - uid: 4975
+  - uid: 5277
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
@@ -28407,7 +28410,7 @@ entities:
       parent: 2
     - type: AtmosPipeColor
       color: '#0055CCFF'
-  - uid: 4976
+  - uid: 5278
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
@@ -28415,7 +28418,7 @@ entities:
       parent: 2
     - type: AtmosPipeColor
       color: '#0055CCFF'
-  - uid: 4977
+  - uid: 5279
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
@@ -28423,7 +28426,7 @@ entities:
       parent: 2
     - type: AtmosPipeColor
       color: '#0055CCFF'
-  - uid: 4978
+  - uid: 5280
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
@@ -28431,35 +28434,35 @@ entities:
       parent: 2
     - type: AtmosPipeColor
       color: '#0055CCFF'
-  - uid: 4979
+  - uid: 5281
     components:
     - type: Transform
       pos: -82.5,-0.5
       parent: 2
     - type: AtmosPipeColor
       color: '#0055CCFF'
-  - uid: 4980
+  - uid: 5282
     components:
     - type: Transform
       pos: -82.5,-5.5
       parent: 2
     - type: AtmosPipeColor
       color: '#0055CCFF'
-  - uid: 4981
+  - uid: 5283
     components:
     - type: Transform
       pos: -93.5,-0.5
       parent: 2
     - type: AtmosPipeColor
       color: '#0055CCFF'
-  - uid: 4982
+  - uid: 5284
     components:
     - type: Transform
       pos: -93.5,-5.5
       parent: 2
     - type: AtmosPipeColor
       color: '#0055CCFF'
-  - uid: 4983
+  - uid: 5285
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
@@ -28467,7 +28470,7 @@ entities:
       parent: 2
     - type: AtmosPipeColor
       color: '#0055CCFF'
-  - uid: 4984
+  - uid: 5286
     components:
     - type: Transform
       rot: 3.141592653589793 rad
@@ -28475,7 +28478,7 @@ entities:
       parent: 2
     - type: AtmosPipeColor
       color: '#0055CCFF'
-  - uid: 4985
+  - uid: 5287
     components:
     - type: Transform
       rot: 3.141592653589793 rad
@@ -28483,7 +28486,7 @@ entities:
       parent: 2
     - type: AtmosPipeColor
       color: '#0055CCFF'
-  - uid: 4986
+  - uid: 5288
     components:
     - type: Transform
       rot: 3.141592653589793 rad
@@ -28491,7 +28494,7 @@ entities:
       parent: 2
     - type: AtmosPipeColor
       color: '#0055CCFF'
-  - uid: 4987
+  - uid: 5289
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
@@ -28499,7 +28502,7 @@ entities:
       parent: 2
     - type: AtmosPipeColor
       color: '#0055CCFF'
-  - uid: 4988
+  - uid: 5290
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
@@ -28507,7 +28510,7 @@ entities:
       parent: 2
     - type: AtmosPipeColor
       color: '#0055CCFF'
-  - uid: 4989
+  - uid: 5291
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
@@ -28515,49 +28518,49 @@ entities:
       parent: 2
     - type: AtmosPipeColor
       color: '#0055CCFF'
-  - uid: 4990
+  - uid: 5292
     components:
     - type: Transform
       pos: -93.5,-1.5
       parent: 2
     - type: AtmosPipeColor
       color: '#0055CCFF'
-  - uid: 4991
+  - uid: 5293
     components:
     - type: Transform
       pos: -82.5,-1.5
       parent: 2
     - type: AtmosPipeColor
       color: '#0055CCFF'
-  - uid: 4992
+  - uid: 5294
     components:
     - type: Transform
       pos: -82.5,-3.5
       parent: 2
     - type: AtmosPipeColor
       color: '#0055CCFF'
-  - uid: 4993
+  - uid: 5295
     components:
     - type: Transform
       pos: -82.5,-4.5
       parent: 2
     - type: AtmosPipeColor
       color: '#0055CCFF'
-  - uid: 4994
+  - uid: 5296
     components:
     - type: Transform
       pos: -93.5,-3.5
       parent: 2
     - type: AtmosPipeColor
       color: '#0055CCFF'
-  - uid: 4995
+  - uid: 5297
     components:
     - type: Transform
       pos: -93.5,-4.5
       parent: 2
     - type: AtmosPipeColor
       color: '#0055CCFF'
-  - uid: 4996
+  - uid: 5298
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
@@ -28565,7 +28568,7 @@ entities:
       parent: 2
     - type: AtmosPipeColor
       color: '#0055CCFF'
-  - uid: 4997
+  - uid: 5299
     components:
     - type: Transform
       rot: 3.141592653589793 rad
@@ -28573,7 +28576,7 @@ entities:
       parent: 2
     - type: AtmosPipeColor
       color: '#0055CCFF'
-  - uid: 4998
+  - uid: 5300
     components:
     - type: Transform
       rot: 3.141592653589793 rad
@@ -28581,7 +28584,7 @@ entities:
       parent: 2
     - type: AtmosPipeColor
       color: '#0055CCFF'
-  - uid: 4999
+  - uid: 5301
     components:
     - type: Transform
       rot: 3.141592653589793 rad
@@ -28589,7 +28592,7 @@ entities:
       parent: 2
     - type: AtmosPipeColor
       color: '#0055CCFF'
-  - uid: 5000
+  - uid: 5302
     components:
     - type: Transform
       rot: 3.141592653589793 rad
@@ -28597,7 +28600,7 @@ entities:
       parent: 2
     - type: AtmosPipeColor
       color: '#0055CCFF'
-  - uid: 5001
+  - uid: 5303
     components:
     - type: Transform
       rot: 3.141592653589793 rad
@@ -28605,7 +28608,7 @@ entities:
       parent: 2
     - type: AtmosPipeColor
       color: '#0055CCFF'
-  - uid: 5002
+  - uid: 5304
     components:
     - type: Transform
       rot: 3.141592653589793 rad
@@ -28613,7 +28616,7 @@ entities:
       parent: 2
     - type: AtmosPipeColor
       color: '#0055CCFF'
-  - uid: 5003
+  - uid: 5305
     components:
     - type: Transform
       rot: 3.141592653589793 rad
@@ -28621,7 +28624,7 @@ entities:
       parent: 2
     - type: AtmosPipeColor
       color: '#0055CCFF'
-  - uid: 5004
+  - uid: 5306
     components:
     - type: Transform
       rot: 3.141592653589793 rad
@@ -28629,7 +28632,7 @@ entities:
       parent: 2
     - type: AtmosPipeColor
       color: '#0055CCFF'
-  - uid: 5005
+  - uid: 5307
     components:
     - type: Transform
       rot: 3.141592653589793 rad
@@ -28637,7 +28640,7 @@ entities:
       parent: 2
     - type: AtmosPipeColor
       color: '#0055CCFF'
-  - uid: 5006
+  - uid: 5308
     components:
     - type: Transform
       rot: 3.141592653589793 rad
@@ -28645,7 +28648,7 @@ entities:
       parent: 2
     - type: AtmosPipeColor
       color: '#0055CCFF'
-  - uid: 5007
+  - uid: 5309
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
@@ -28653,7 +28656,7 @@ entities:
       parent: 2
     - type: AtmosPipeColor
       color: '#0055CCFF'
-  - uid: 5008
+  - uid: 5310
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
@@ -28661,7 +28664,7 @@ entities:
       parent: 2
     - type: AtmosPipeColor
       color: '#0055CCFF'
-  - uid: 5009
+  - uid: 5311
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
@@ -28669,7 +28672,7 @@ entities:
       parent: 2
     - type: AtmosPipeColor
       color: '#0055CCFF'
-  - uid: 5010
+  - uid: 5312
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
@@ -28677,7 +28680,7 @@ entities:
       parent: 2
     - type: AtmosPipeColor
       color: '#0055CCFF'
-  - uid: 5011
+  - uid: 5313
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
@@ -28685,7 +28688,7 @@ entities:
       parent: 2
     - type: AtmosPipeColor
       color: '#0055CCFF'
-  - uid: 5012
+  - uid: 5314
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
@@ -28693,7 +28696,7 @@ entities:
       parent: 2
     - type: AtmosPipeColor
       color: '#0055CCFF'
-  - uid: 5013
+  - uid: 5315
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
@@ -28701,7 +28704,7 @@ entities:
       parent: 2
     - type: AtmosPipeColor
       color: '#0055CCFF'
-  - uid: 5014
+  - uid: 5316
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
@@ -28709,7 +28712,7 @@ entities:
       parent: 2
     - type: AtmosPipeColor
       color: '#0055CCFF'
-  - uid: 5015
+  - uid: 5317
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
@@ -28717,7 +28720,7 @@ entities:
       parent: 2
     - type: AtmosPipeColor
       color: '#0055CCFF'
-  - uid: 5016
+  - uid: 5318
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
@@ -28725,7 +28728,7 @@ entities:
       parent: 2
     - type: AtmosPipeColor
       color: '#0055CCFF'
-  - uid: 5017
+  - uid: 5319
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
@@ -28733,7 +28736,7 @@ entities:
       parent: 2
     - type: AtmosPipeColor
       color: '#0055CCFF'
-  - uid: 5018
+  - uid: 5320
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
@@ -28741,7 +28744,7 @@ entities:
       parent: 2
     - type: AtmosPipeColor
       color: '#0055CCFF'
-  - uid: 5019
+  - uid: 5321
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
@@ -28749,7 +28752,7 @@ entities:
       parent: 2
     - type: AtmosPipeColor
       color: '#0055CCFF'
-  - uid: 5020
+  - uid: 5322
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
@@ -28757,7 +28760,7 @@ entities:
       parent: 2
     - type: AtmosPipeColor
       color: '#0055CCFF'
-  - uid: 5021
+  - uid: 5323
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
@@ -28765,7 +28768,7 @@ entities:
       parent: 2
     - type: AtmosPipeColor
       color: '#0055CCFF'
-  - uid: 5022
+  - uid: 5324
     components:
     - type: Transform
       rot: 3.141592653589793 rad
@@ -28773,7 +28776,7 @@ entities:
       parent: 2
     - type: AtmosPipeColor
       color: '#0055CCFF'
-  - uid: 5023
+  - uid: 5325
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
@@ -28781,7 +28784,7 @@ entities:
       parent: 2
     - type: AtmosPipeColor
       color: '#0055CCFF'
-  - uid: 5024
+  - uid: 5326
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
@@ -28789,7 +28792,7 @@ entities:
       parent: 2
     - type: AtmosPipeColor
       color: '#0055CCFF'
-  - uid: 5025
+  - uid: 5327
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
@@ -28797,7 +28800,7 @@ entities:
       parent: 2
     - type: AtmosPipeColor
       color: '#0055CCFF'
-  - uid: 5026
+  - uid: 5328
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
@@ -28805,7 +28808,7 @@ entities:
       parent: 2
     - type: AtmosPipeColor
       color: '#0055CCFF'
-  - uid: 5027
+  - uid: 5329
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
@@ -28813,7 +28816,7 @@ entities:
       parent: 2
     - type: AtmosPipeColor
       color: '#0055CCFF'
-  - uid: 5028
+  - uid: 5330
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
@@ -28821,7 +28824,7 @@ entities:
       parent: 2
     - type: AtmosPipeColor
       color: '#0055CCFF'
-  - uid: 5029
+  - uid: 5331
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
@@ -28829,7 +28832,7 @@ entities:
       parent: 2
     - type: AtmosPipeColor
       color: '#0055CCFF'
-  - uid: 5030
+  - uid: 5332
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
@@ -28837,7 +28840,7 @@ entities:
       parent: 2
     - type: AtmosPipeColor
       color: '#0055CCFF'
-  - uid: 5031
+  - uid: 5333
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
@@ -28845,7 +28848,7 @@ entities:
       parent: 2
     - type: AtmosPipeColor
       color: '#0055CCFF'
-  - uid: 5032
+  - uid: 5334
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
@@ -28853,7 +28856,7 @@ entities:
       parent: 2
     - type: AtmosPipeColor
       color: '#0055CCFF'
-  - uid: 5033
+  - uid: 5335
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
@@ -28861,56 +28864,56 @@ entities:
       parent: 2
     - type: AtmosPipeColor
       color: '#0055CCFF'
-  - uid: 5034
+  - uid: 5336
     components:
     - type: Transform
       pos: -45.5,-37.5
       parent: 2
     - type: AtmosPipeColor
       color: '#0055CCFF'
-  - uid: 5035
+  - uid: 5337
     components:
     - type: Transform
       pos: -32.5,-37.5
       parent: 2
     - type: AtmosPipeColor
       color: '#0055CCFF'
-  - uid: 5036
+  - uid: 5338
     components:
     - type: Transform
       pos: -32.5,-38.5
       parent: 2
     - type: AtmosPipeColor
       color: '#0055CCFF'
-  - uid: 5037
+  - uid: 5339
     components:
     - type: Transform
       pos: -45.5,-38.5
       parent: 2
     - type: AtmosPipeColor
       color: '#0055CCFF'
-  - uid: 5038
+  - uid: 5340
     components:
     - type: Transform
       pos: -36.5,-40.5
       parent: 2
     - type: AtmosPipeColor
       color: '#0055CCFF'
-  - uid: 5039
+  - uid: 5341
     components:
     - type: Transform
       pos: -45.5,-45.5
       parent: 2
     - type: AtmosPipeColor
       color: '#0055CCFF'
-  - uid: 5040
+  - uid: 5342
     components:
     - type: Transform
       pos: -45.5,-46.5
       parent: 2
     - type: AtmosPipeColor
       color: '#0055CCFF'
-  - uid: 5041
+  - uid: 5343
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
@@ -28918,7 +28921,7 @@ entities:
       parent: 2
 - proto: GasPipeStraightAlt2
   entities:
-  - uid: 5042
+  - uid: 5344
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
@@ -28926,7 +28929,7 @@ entities:
       parent: 2
     - type: AtmosPipeColor
       color: '#990000FF'
-  - uid: 5043
+  - uid: 5345
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
@@ -28934,7 +28937,7 @@ entities:
       parent: 2
     - type: AtmosPipeColor
       color: '#990000FF'
-  - uid: 5044
+  - uid: 5346
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
@@ -28942,7 +28945,7 @@ entities:
       parent: 2
     - type: AtmosPipeColor
       color: '#990000FF'
-  - uid: 5045
+  - uid: 5347
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
@@ -28950,7 +28953,7 @@ entities:
       parent: 2
     - type: AtmosPipeColor
       color: '#990000FF'
-  - uid: 5046
+  - uid: 5348
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
@@ -28958,7 +28961,7 @@ entities:
       parent: 2
     - type: AtmosPipeColor
       color: '#990000FF'
-  - uid: 5047
+  - uid: 5349
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
@@ -28966,7 +28969,7 @@ entities:
       parent: 2
     - type: AtmosPipeColor
       color: '#990000FF'
-  - uid: 5048
+  - uid: 5350
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
@@ -28974,7 +28977,7 @@ entities:
       parent: 2
     - type: AtmosPipeColor
       color: '#990000FF'
-  - uid: 5049
+  - uid: 5351
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
@@ -28982,7 +28985,7 @@ entities:
       parent: 2
     - type: AtmosPipeColor
       color: '#990000FF'
-  - uid: 5050
+  - uid: 5352
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
@@ -28990,7 +28993,7 @@ entities:
       parent: 2
     - type: AtmosPipeColor
       color: '#990000FF'
-  - uid: 5051
+  - uid: 5353
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
@@ -28998,7 +29001,7 @@ entities:
       parent: 2
     - type: AtmosPipeColor
       color: '#990000FF'
-  - uid: 5052
+  - uid: 5354
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
@@ -29006,7 +29009,7 @@ entities:
       parent: 2
     - type: AtmosPipeColor
       color: '#990000FF'
-  - uid: 5053
+  - uid: 5355
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
@@ -29014,7 +29017,7 @@ entities:
       parent: 2
     - type: AtmosPipeColor
       color: '#990000FF'
-  - uid: 5054
+  - uid: 5356
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
@@ -29022,7 +29025,7 @@ entities:
       parent: 2
     - type: AtmosPipeColor
       color: '#990000FF'
-  - uid: 5055
+  - uid: 5357
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
@@ -29030,7 +29033,7 @@ entities:
       parent: 2
     - type: AtmosPipeColor
       color: '#990000FF'
-  - uid: 5056
+  - uid: 5358
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
@@ -29038,7 +29041,7 @@ entities:
       parent: 2
     - type: AtmosPipeColor
       color: '#990000FF'
-  - uid: 5057
+  - uid: 5359
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
@@ -29046,7 +29049,7 @@ entities:
       parent: 2
     - type: AtmosPipeColor
       color: '#990000FF'
-  - uid: 5058
+  - uid: 5360
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
@@ -29054,7 +29057,7 @@ entities:
       parent: 2
     - type: AtmosPipeColor
       color: '#990000FF'
-  - uid: 5059
+  - uid: 5361
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
@@ -29062,7 +29065,7 @@ entities:
       parent: 2
     - type: AtmosPipeColor
       color: '#990000FF'
-  - uid: 5060
+  - uid: 5362
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
@@ -29070,7 +29073,7 @@ entities:
       parent: 2
     - type: AtmosPipeColor
       color: '#990000FF'
-  - uid: 5061
+  - uid: 5363
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
@@ -29078,7 +29081,7 @@ entities:
       parent: 2
     - type: AtmosPipeColor
       color: '#990000FF'
-  - uid: 5062
+  - uid: 5364
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
@@ -29086,7 +29089,7 @@ entities:
       parent: 2
     - type: AtmosPipeColor
       color: '#990000FF'
-  - uid: 5063
+  - uid: 5365
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
@@ -29094,7 +29097,7 @@ entities:
       parent: 2
     - type: AtmosPipeColor
       color: '#990000FF'
-  - uid: 5064
+  - uid: 5366
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
@@ -29102,7 +29105,7 @@ entities:
       parent: 2
     - type: AtmosPipeColor
       color: '#990000FF'
-  - uid: 5065
+  - uid: 5367
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
@@ -29110,7 +29113,7 @@ entities:
       parent: 2
     - type: AtmosPipeColor
       color: '#990000FF'
-  - uid: 5066
+  - uid: 5368
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
@@ -29118,7 +29121,7 @@ entities:
       parent: 2
     - type: AtmosPipeColor
       color: '#990000FF'
-  - uid: 5067
+  - uid: 5369
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
@@ -29126,7 +29129,7 @@ entities:
       parent: 2
     - type: AtmosPipeColor
       color: '#990000FF'
-  - uid: 5068
+  - uid: 5370
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
@@ -29134,7 +29137,7 @@ entities:
       parent: 2
     - type: AtmosPipeColor
       color: '#990000FF'
-  - uid: 5069
+  - uid: 5371
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
@@ -29142,7 +29145,7 @@ entities:
       parent: 2
     - type: AtmosPipeColor
       color: '#990000FF'
-  - uid: 5070
+  - uid: 5372
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
@@ -29150,7 +29153,7 @@ entities:
       parent: 2
     - type: AtmosPipeColor
       color: '#990000FF'
-  - uid: 5071
+  - uid: 5373
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
@@ -29158,7 +29161,7 @@ entities:
       parent: 2
     - type: AtmosPipeColor
       color: '#990000FF'
-  - uid: 5072
+  - uid: 5374
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
@@ -29166,7 +29169,7 @@ entities:
       parent: 2
     - type: AtmosPipeColor
       color: '#990000FF'
-  - uid: 5073
+  - uid: 5375
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
@@ -29174,7 +29177,7 @@ entities:
       parent: 2
     - type: AtmosPipeColor
       color: '#990000FF'
-  - uid: 5074
+  - uid: 5376
     components:
     - type: Transform
       rot: 3.141592653589793 rad
@@ -29182,7 +29185,7 @@ entities:
       parent: 2
     - type: AtmosPipeColor
       color: '#990000FF'
-  - uid: 5075
+  - uid: 5377
     components:
     - type: Transform
       rot: 3.141592653589793 rad
@@ -29190,7 +29193,7 @@ entities:
       parent: 2
     - type: AtmosPipeColor
       color: '#990000FF'
-  - uid: 5076
+  - uid: 5378
     components:
     - type: Transform
       rot: 3.141592653589793 rad
@@ -29198,7 +29201,7 @@ entities:
       parent: 2
     - type: AtmosPipeColor
       color: '#990000FF'
-  - uid: 5077
+  - uid: 5379
     components:
     - type: Transform
       rot: 3.141592653589793 rad
@@ -29206,7 +29209,7 @@ entities:
       parent: 2
     - type: AtmosPipeColor
       color: '#990000FF'
-  - uid: 5078
+  - uid: 5380
     components:
     - type: Transform
       rot: 3.141592653589793 rad
@@ -29214,7 +29217,7 @@ entities:
       parent: 2
     - type: AtmosPipeColor
       color: '#990000FF'
-  - uid: 5079
+  - uid: 5381
     components:
     - type: Transform
       rot: 3.141592653589793 rad
@@ -29222,7 +29225,7 @@ entities:
       parent: 2
     - type: AtmosPipeColor
       color: '#990000FF'
-  - uid: 5080
+  - uid: 5382
     components:
     - type: Transform
       rot: 3.141592653589793 rad
@@ -29230,7 +29233,7 @@ entities:
       parent: 2
     - type: AtmosPipeColor
       color: '#990000FF'
-  - uid: 5081
+  - uid: 5383
     components:
     - type: Transform
       rot: 3.141592653589793 rad
@@ -29238,7 +29241,7 @@ entities:
       parent: 2
     - type: AtmosPipeColor
       color: '#990000FF'
-  - uid: 5082
+  - uid: 5384
     components:
     - type: Transform
       rot: 3.141592653589793 rad
@@ -29246,7 +29249,7 @@ entities:
       parent: 2
     - type: AtmosPipeColor
       color: '#990000FF'
-  - uid: 5083
+  - uid: 5385
     components:
     - type: Transform
       rot: 3.141592653589793 rad
@@ -29254,7 +29257,7 @@ entities:
       parent: 2
     - type: AtmosPipeColor
       color: '#990000FF'
-  - uid: 5084
+  - uid: 5386
     components:
     - type: Transform
       rot: 3.141592653589793 rad
@@ -29262,7 +29265,7 @@ entities:
       parent: 2
     - type: AtmosPipeColor
       color: '#990000FF'
-  - uid: 5085
+  - uid: 5387
     components:
     - type: Transform
       rot: 3.141592653589793 rad
@@ -29270,7 +29273,7 @@ entities:
       parent: 2
     - type: AtmosPipeColor
       color: '#990000FF'
-  - uid: 5086
+  - uid: 5388
     components:
     - type: Transform
       rot: 3.141592653589793 rad
@@ -29278,7 +29281,7 @@ entities:
       parent: 2
     - type: AtmosPipeColor
       color: '#990000FF'
-  - uid: 5087
+  - uid: 5389
     components:
     - type: Transform
       rot: 3.141592653589793 rad
@@ -29286,7 +29289,7 @@ entities:
       parent: 2
     - type: AtmosPipeColor
       color: '#990000FF'
-  - uid: 5088
+  - uid: 5390
     components:
     - type: Transform
       rot: 3.141592653589793 rad
@@ -29294,7 +29297,7 @@ entities:
       parent: 2
     - type: AtmosPipeColor
       color: '#990000FF'
-  - uid: 5089
+  - uid: 5391
     components:
     - type: Transform
       rot: 3.141592653589793 rad
@@ -29302,7 +29305,7 @@ entities:
       parent: 2
     - type: AtmosPipeColor
       color: '#990000FF'
-  - uid: 5090
+  - uid: 5392
     components:
     - type: Transform
       rot: 3.141592653589793 rad
@@ -29310,7 +29313,7 @@ entities:
       parent: 2
     - type: AtmosPipeColor
       color: '#990000FF'
-  - uid: 5091
+  - uid: 5393
     components:
     - type: Transform
       rot: 3.141592653589793 rad
@@ -29318,7 +29321,7 @@ entities:
       parent: 2
     - type: AtmosPipeColor
       color: '#990000FF'
-  - uid: 5092
+  - uid: 5394
     components:
     - type: Transform
       rot: 3.141592653589793 rad
@@ -29326,7 +29329,7 @@ entities:
       parent: 2
     - type: AtmosPipeColor
       color: '#990000FF'
-  - uid: 5093
+  - uid: 5395
     components:
     - type: Transform
       rot: 3.141592653589793 rad
@@ -29334,7 +29337,7 @@ entities:
       parent: 2
     - type: AtmosPipeColor
       color: '#990000FF'
-  - uid: 5094
+  - uid: 5396
     components:
     - type: Transform
       rot: 3.141592653589793 rad
@@ -29342,7 +29345,7 @@ entities:
       parent: 2
     - type: AtmosPipeColor
       color: '#990000FF'
-  - uid: 5095
+  - uid: 5397
     components:
     - type: Transform
       rot: 3.141592653589793 rad
@@ -29350,7 +29353,7 @@ entities:
       parent: 2
     - type: AtmosPipeColor
       color: '#990000FF'
-  - uid: 5096
+  - uid: 5398
     components:
     - type: Transform
       rot: 3.141592653589793 rad
@@ -29358,7 +29361,7 @@ entities:
       parent: 2
     - type: AtmosPipeColor
       color: '#990000FF'
-  - uid: 5097
+  - uid: 5399
     components:
     - type: Transform
       rot: 3.141592653589793 rad
@@ -29366,7 +29369,7 @@ entities:
       parent: 2
     - type: AtmosPipeColor
       color: '#990000FF'
-  - uid: 5098
+  - uid: 5400
     components:
     - type: Transform
       rot: 3.141592653589793 rad
@@ -29374,7 +29377,7 @@ entities:
       parent: 2
     - type: AtmosPipeColor
       color: '#990000FF'
-  - uid: 5099
+  - uid: 5401
     components:
     - type: Transform
       rot: 3.141592653589793 rad
@@ -29382,7 +29385,7 @@ entities:
       parent: 2
     - type: AtmosPipeColor
       color: '#990000FF'
-  - uid: 5100
+  - uid: 5402
     components:
     - type: Transform
       rot: 3.141592653589793 rad
@@ -29390,7 +29393,7 @@ entities:
       parent: 2
     - type: AtmosPipeColor
       color: '#990000FF'
-  - uid: 5101
+  - uid: 5403
     components:
     - type: Transform
       rot: 3.141592653589793 rad
@@ -29398,7 +29401,7 @@ entities:
       parent: 2
     - type: AtmosPipeColor
       color: '#990000FF'
-  - uid: 5102
+  - uid: 5404
     components:
     - type: Transform
       rot: 3.141592653589793 rad
@@ -29406,7 +29409,7 @@ entities:
       parent: 2
     - type: AtmosPipeColor
       color: '#990000FF'
-  - uid: 5103
+  - uid: 5405
     components:
     - type: Transform
       rot: 3.141592653589793 rad
@@ -29414,7 +29417,7 @@ entities:
       parent: 2
     - type: AtmosPipeColor
       color: '#990000FF'
-  - uid: 5104
+  - uid: 5406
     components:
     - type: Transform
       rot: 3.141592653589793 rad
@@ -29422,7 +29425,7 @@ entities:
       parent: 2
     - type: AtmosPipeColor
       color: '#990000FF'
-  - uid: 5105
+  - uid: 5407
     components:
     - type: Transform
       rot: 3.141592653589793 rad
@@ -29430,7 +29433,7 @@ entities:
       parent: 2
     - type: AtmosPipeColor
       color: '#990000FF'
-  - uid: 5106
+  - uid: 5408
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
@@ -29438,7 +29441,7 @@ entities:
       parent: 2
     - type: AtmosPipeColor
       color: '#990000FF'
-  - uid: 5107
+  - uid: 5409
     components:
     - type: Transform
       rot: 3.141592653589793 rad
@@ -29446,7 +29449,7 @@ entities:
       parent: 2
     - type: AtmosPipeColor
       color: '#990000FF'
-  - uid: 5108
+  - uid: 5410
     components:
     - type: Transform
       rot: 3.141592653589793 rad
@@ -29454,7 +29457,7 @@ entities:
       parent: 2
     - type: AtmosPipeColor
       color: '#990000FF'
-  - uid: 5109
+  - uid: 5411
     components:
     - type: Transform
       rot: 3.141592653589793 rad
@@ -29462,7 +29465,7 @@ entities:
       parent: 2
     - type: AtmosPipeColor
       color: '#990000FF'
-  - uid: 5110
+  - uid: 5412
     components:
     - type: Transform
       rot: 3.141592653589793 rad
@@ -29470,7 +29473,7 @@ entities:
       parent: 2
     - type: AtmosPipeColor
       color: '#990000FF'
-  - uid: 5111
+  - uid: 5413
     components:
     - type: Transform
       rot: 3.141592653589793 rad
@@ -29478,7 +29481,7 @@ entities:
       parent: 2
     - type: AtmosPipeColor
       color: '#990000FF'
-  - uid: 5112
+  - uid: 5414
     components:
     - type: Transform
       rot: 3.141592653589793 rad
@@ -29486,7 +29489,7 @@ entities:
       parent: 2
     - type: AtmosPipeColor
       color: '#990000FF'
-  - uid: 5113
+  - uid: 5415
     components:
     - type: Transform
       rot: 3.141592653589793 rad
@@ -29494,7 +29497,7 @@ entities:
       parent: 2
     - type: AtmosPipeColor
       color: '#990000FF'
-  - uid: 5114
+  - uid: 5416
     components:
     - type: Transform
       rot: 3.141592653589793 rad
@@ -29502,7 +29505,7 @@ entities:
       parent: 2
     - type: AtmosPipeColor
       color: '#990000FF'
-  - uid: 5115
+  - uid: 5417
     components:
     - type: Transform
       rot: 3.141592653589793 rad
@@ -29510,7 +29513,7 @@ entities:
       parent: 2
     - type: AtmosPipeColor
       color: '#990000FF'
-  - uid: 5116
+  - uid: 5418
     components:
     - type: Transform
       rot: 3.141592653589793 rad
@@ -29518,7 +29521,7 @@ entities:
       parent: 2
     - type: AtmosPipeColor
       color: '#990000FF'
-  - uid: 5117
+  - uid: 5419
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
@@ -29526,7 +29529,7 @@ entities:
       parent: 2
     - type: AtmosPipeColor
       color: '#990000FF'
-  - uid: 5118
+  - uid: 5420
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
@@ -29534,14 +29537,14 @@ entities:
       parent: 2
     - type: AtmosPipeColor
       color: '#990000FF'
-  - uid: 5119
+  - uid: 5421
     components:
     - type: Transform
       pos: -38.5,-46.5
       parent: 2
     - type: AtmosPipeColor
       color: '#990000FF'
-  - uid: 5120
+  - uid: 5422
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
@@ -29549,7 +29552,7 @@ entities:
       parent: 2
     - type: AtmosPipeColor
       color: '#990000FF'
-  - uid: 5121
+  - uid: 5423
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
@@ -29557,7 +29560,7 @@ entities:
       parent: 2
     - type: AtmosPipeColor
       color: '#990000FF'
-  - uid: 5122
+  - uid: 5424
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
@@ -29565,7 +29568,7 @@ entities:
       parent: 2
     - type: AtmosPipeColor
       color: '#990000FF'
-  - uid: 5123
+  - uid: 5425
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
@@ -29573,7 +29576,7 @@ entities:
       parent: 2
     - type: AtmosPipeColor
       color: '#990000FF'
-  - uid: 5124
+  - uid: 5426
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
@@ -29581,7 +29584,7 @@ entities:
       parent: 2
     - type: AtmosPipeColor
       color: '#990000FF'
-  - uid: 5125
+  - uid: 5427
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
@@ -29589,7 +29592,7 @@ entities:
       parent: 2
     - type: AtmosPipeColor
       color: '#990000FF'
-  - uid: 5126
+  - uid: 5428
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
@@ -29597,7 +29600,7 @@ entities:
       parent: 2
     - type: AtmosPipeColor
       color: '#990000FF'
-  - uid: 5127
+  - uid: 5429
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
@@ -29605,7 +29608,7 @@ entities:
       parent: 2
     - type: AtmosPipeColor
       color: '#990000FF'
-  - uid: 5128
+  - uid: 5430
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
@@ -29613,7 +29616,7 @@ entities:
       parent: 2
     - type: AtmosPipeColor
       color: '#990000FF'
-  - uid: 5129
+  - uid: 5431
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
@@ -29621,7 +29624,7 @@ entities:
       parent: 2
     - type: AtmosPipeColor
       color: '#990000FF'
-  - uid: 5130
+  - uid: 5432
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
@@ -29629,7 +29632,7 @@ entities:
       parent: 2
     - type: AtmosPipeColor
       color: '#990000FF'
-  - uid: 5131
+  - uid: 5433
     components:
     - type: Transform
       rot: 3.141592653589793 rad
@@ -29637,7 +29640,7 @@ entities:
       parent: 2
     - type: AtmosPipeColor
       color: '#990000FF'
-  - uid: 5132
+  - uid: 5434
     components:
     - type: Transform
       rot: 3.141592653589793 rad
@@ -29645,7 +29648,7 @@ entities:
       parent: 2
     - type: AtmosPipeColor
       color: '#990000FF'
-  - uid: 5133
+  - uid: 5435
     components:
     - type: Transform
       rot: 3.141592653589793 rad
@@ -29653,7 +29656,7 @@ entities:
       parent: 2
     - type: AtmosPipeColor
       color: '#990000FF'
-  - uid: 5134
+  - uid: 5436
     components:
     - type: Transform
       rot: 3.141592653589793 rad
@@ -29661,7 +29664,7 @@ entities:
       parent: 2
     - type: AtmosPipeColor
       color: '#990000FF'
-  - uid: 5135
+  - uid: 5437
     components:
     - type: Transform
       rot: 3.141592653589793 rad
@@ -29669,7 +29672,7 @@ entities:
       parent: 2
     - type: AtmosPipeColor
       color: '#990000FF'
-  - uid: 5136
+  - uid: 5438
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
@@ -29677,7 +29680,7 @@ entities:
       parent: 2
     - type: AtmosPipeColor
       color: '#990000FF'
-  - uid: 5137
+  - uid: 5439
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
@@ -29685,7 +29688,7 @@ entities:
       parent: 2
     - type: AtmosPipeColor
       color: '#990000FF'
-  - uid: 5138
+  - uid: 5440
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
@@ -29693,42 +29696,42 @@ entities:
       parent: 2
     - type: AtmosPipeColor
       color: '#990000FF'
-  - uid: 5139
+  - uid: 5441
     components:
     - type: Transform
       pos: -32.5,-42.5
       parent: 2
     - type: AtmosPipeColor
       color: '#990000FF'
-  - uid: 5140
+  - uid: 5442
     components:
     - type: Transform
       pos: -32.5,-39.5
       parent: 2
     - type: AtmosPipeColor
       color: '#990000FF'
-  - uid: 5141
+  - uid: 5443
     components:
     - type: Transform
       pos: -32.5,-40.5
       parent: 2
     - type: AtmosPipeColor
       color: '#990000FF'
-  - uid: 5142
+  - uid: 5444
     components:
     - type: Transform
       pos: -32.5,-43.5
       parent: 2
     - type: AtmosPipeColor
       color: '#990000FF'
-  - uid: 5143
+  - uid: 5445
     components:
     - type: Transform
       pos: -32.5,-44.5
       parent: 2
     - type: AtmosPipeColor
       color: '#990000FF'
-  - uid: 5144
+  - uid: 5446
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
@@ -29736,7 +29739,7 @@ entities:
       parent: 2
     - type: AtmosPipeColor
       color: '#990000FF'
-  - uid: 5145
+  - uid: 5447
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
@@ -29744,7 +29747,7 @@ entities:
       parent: 2
     - type: AtmosPipeColor
       color: '#990000FF'
-  - uid: 5146
+  - uid: 5448
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
@@ -29752,7 +29755,7 @@ entities:
       parent: 2
     - type: AtmosPipeColor
       color: '#990000FF'
-  - uid: 5147
+  - uid: 5449
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
@@ -29760,7 +29763,7 @@ entities:
       parent: 2
     - type: AtmosPipeColor
       color: '#990000FF'
-  - uid: 5148
+  - uid: 5450
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
@@ -29768,7 +29771,7 @@ entities:
       parent: 2
     - type: AtmosPipeColor
       color: '#990000FF'
-  - uid: 5149
+  - uid: 5451
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
@@ -29776,35 +29779,35 @@ entities:
       parent: 2
     - type: AtmosPipeColor
       color: '#990000FF'
-  - uid: 5150
+  - uid: 5452
     components:
     - type: Transform
       pos: -82.5,-0.5
       parent: 2
     - type: AtmosPipeColor
       color: '#990000FF'
-  - uid: 5151
+  - uid: 5453
     components:
     - type: Transform
       pos: -82.5,-5.5
       parent: 2
     - type: AtmosPipeColor
       color: '#990000FF'
-  - uid: 5152
+  - uid: 5454
     components:
     - type: Transform
       pos: -93.5,-0.5
       parent: 2
     - type: AtmosPipeColor
       color: '#990000FF'
-  - uid: 5153
+  - uid: 5455
     components:
     - type: Transform
       pos: -93.5,-5.5
       parent: 2
     - type: AtmosPipeColor
       color: '#990000FF'
-  - uid: 5154
+  - uid: 5456
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
@@ -29812,7 +29815,7 @@ entities:
       parent: 2
     - type: AtmosPipeColor
       color: '#990000FF'
-  - uid: 5155
+  - uid: 5457
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
@@ -29820,7 +29823,7 @@ entities:
       parent: 2
     - type: AtmosPipeColor
       color: '#990000FF'
-  - uid: 5156
+  - uid: 5458
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
@@ -29828,7 +29831,7 @@ entities:
       parent: 2
     - type: AtmosPipeColor
       color: '#990000FF'
-  - uid: 5157
+  - uid: 5459
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
@@ -29836,7 +29839,7 @@ entities:
       parent: 2
     - type: AtmosPipeColor
       color: '#990000FF'
-  - uid: 5158
+  - uid: 5460
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
@@ -29844,49 +29847,49 @@ entities:
       parent: 2
     - type: AtmosPipeColor
       color: '#990000FF'
-  - uid: 5159
+  - uid: 5461
     components:
     - type: Transform
       pos: -93.5,-1.5
       parent: 2
     - type: AtmosPipeColor
       color: '#990000FF'
-  - uid: 5160
+  - uid: 5462
     components:
     - type: Transform
       pos: -82.5,-1.5
       parent: 2
     - type: AtmosPipeColor
       color: '#990000FF'
-  - uid: 5161
+  - uid: 5463
     components:
     - type: Transform
       pos: -82.5,-3.5
       parent: 2
     - type: AtmosPipeColor
       color: '#990000FF'
-  - uid: 5162
+  - uid: 5464
     components:
     - type: Transform
       pos: -82.5,-4.5
       parent: 2
     - type: AtmosPipeColor
       color: '#990000FF'
-  - uid: 5163
+  - uid: 5465
     components:
     - type: Transform
       pos: -93.5,-3.5
       parent: 2
     - type: AtmosPipeColor
       color: '#990000FF'
-  - uid: 5164
+  - uid: 5466
     components:
     - type: Transform
       pos: -93.5,-4.5
       parent: 2
     - type: AtmosPipeColor
       color: '#990000FF'
-  - uid: 5165
+  - uid: 5467
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
@@ -29894,7 +29897,7 @@ entities:
       parent: 2
     - type: AtmosPipeColor
       color: '#990000FF'
-  - uid: 5166
+  - uid: 5468
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
@@ -29902,7 +29905,7 @@ entities:
       parent: 2
     - type: AtmosPipeColor
       color: '#990000FF'
-  - uid: 5167
+  - uid: 5469
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
@@ -29910,7 +29913,7 @@ entities:
       parent: 2
     - type: AtmosPipeColor
       color: '#990000FF'
-  - uid: 5168
+  - uid: 5470
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
@@ -29918,7 +29921,7 @@ entities:
       parent: 2
     - type: AtmosPipeColor
       color: '#990000FF'
-  - uid: 5169
+  - uid: 5471
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
@@ -29926,7 +29929,7 @@ entities:
       parent: 2
     - type: AtmosPipeColor
       color: '#990000FF'
-  - uid: 5170
+  - uid: 5472
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
@@ -29934,7 +29937,7 @@ entities:
       parent: 2
     - type: AtmosPipeColor
       color: '#990000FF'
-  - uid: 5171
+  - uid: 5473
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
@@ -29942,7 +29945,7 @@ entities:
       parent: 2
     - type: AtmosPipeColor
       color: '#990000FF'
-  - uid: 5172
+  - uid: 5474
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
@@ -29950,7 +29953,7 @@ entities:
       parent: 2
     - type: AtmosPipeColor
       color: '#990000FF'
-  - uid: 5173
+  - uid: 5475
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
@@ -29958,14 +29961,14 @@ entities:
       parent: 2
     - type: AtmosPipeColor
       color: '#990000FF'
-  - uid: 5174
+  - uid: 5476
     components:
     - type: Transform
       pos: -102.5,-3.5
       parent: 2
     - type: AtmosPipeColor
       color: '#990000FF'
-  - uid: 5175
+  - uid: 5477
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
@@ -29973,7 +29976,7 @@ entities:
       parent: 2
     - type: AtmosPipeColor
       color: '#990000FF'
-  - uid: 5176
+  - uid: 5478
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
@@ -29981,7 +29984,7 @@ entities:
       parent: 2
     - type: AtmosPipeColor
       color: '#990000FF'
-  - uid: 5177
+  - uid: 5479
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
@@ -29989,7 +29992,7 @@ entities:
       parent: 2
     - type: AtmosPipeColor
       color: '#990000FF'
-  - uid: 5178
+  - uid: 5480
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
@@ -29997,7 +30000,7 @@ entities:
       parent: 2
     - type: AtmosPipeColor
       color: '#990000FF'
-  - uid: 5179
+  - uid: 5481
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
@@ -30005,7 +30008,7 @@ entities:
       parent: 2
     - type: AtmosPipeColor
       color: '#990000FF'
-  - uid: 5180
+  - uid: 5482
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
@@ -30013,7 +30016,7 @@ entities:
       parent: 2
     - type: AtmosPipeColor
       color: '#990000FF'
-  - uid: 5181
+  - uid: 5483
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
@@ -30021,7 +30024,7 @@ entities:
       parent: 2
     - type: AtmosPipeColor
       color: '#990000FF'
-  - uid: 5182
+  - uid: 5484
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
@@ -30029,7 +30032,7 @@ entities:
       parent: 2
     - type: AtmosPipeColor
       color: '#990000FF'
-  - uid: 5183
+  - uid: 5485
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
@@ -30037,7 +30040,7 @@ entities:
       parent: 2
     - type: AtmosPipeColor
       color: '#990000FF'
-  - uid: 5184
+  - uid: 5486
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
@@ -30045,7 +30048,7 @@ entities:
       parent: 2
     - type: AtmosPipeColor
       color: '#990000FF'
-  - uid: 5185
+  - uid: 5487
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
@@ -30053,7 +30056,7 @@ entities:
       parent: 2
     - type: AtmosPipeColor
       color: '#990000FF'
-  - uid: 5186
+  - uid: 5488
     components:
     - type: Transform
       rot: 3.141592653589793 rad
@@ -30061,7 +30064,7 @@ entities:
       parent: 2
     - type: AtmosPipeColor
       color: '#990000FF'
-  - uid: 5187
+  - uid: 5489
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
@@ -30069,14 +30072,14 @@ entities:
       parent: 2
     - type: AtmosPipeColor
       color: '#990000FF'
-  - uid: 5188
+  - uid: 5490
     components:
     - type: Transform
       pos: -79.5,-3.5
       parent: 2
     - type: AtmosPipeColor
       color: '#990000FF'
-  - uid: 5189
+  - uid: 5491
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
@@ -30084,7 +30087,7 @@ entities:
       parent: 2
     - type: AtmosPipeColor
       color: '#990000FF'
-  - uid: 5190
+  - uid: 5492
     components:
     - type: Transform
       rot: 3.141592653589793 rad
@@ -30092,7 +30095,7 @@ entities:
       parent: 2
     - type: AtmosPipeColor
       color: '#990000FF'
-  - uid: 5191
+  - uid: 5493
     components:
     - type: Transform
       rot: 3.141592653589793 rad
@@ -30100,7 +30103,7 @@ entities:
       parent: 2
     - type: AtmosPipeColor
       color: '#990000FF'
-  - uid: 5192
+  - uid: 5494
     components:
     - type: Transform
       rot: 3.141592653589793 rad
@@ -30108,7 +30111,7 @@ entities:
       parent: 2
     - type: AtmosPipeColor
       color: '#990000FF'
-  - uid: 5193
+  - uid: 5495
     components:
     - type: Transform
       rot: 3.141592653589793 rad
@@ -30116,7 +30119,7 @@ entities:
       parent: 2
     - type: AtmosPipeColor
       color: '#990000FF'
-  - uid: 5194
+  - uid: 5496
     components:
     - type: Transform
       rot: 3.141592653589793 rad
@@ -30124,7 +30127,7 @@ entities:
       parent: 2
     - type: AtmosPipeColor
       color: '#990000FF'
-  - uid: 5195
+  - uid: 5497
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
@@ -30132,7 +30135,7 @@ entities:
       parent: 2
     - type: AtmosPipeColor
       color: '#990000FF'
-  - uid: 5196
+  - uid: 5498
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
@@ -30140,7 +30143,7 @@ entities:
       parent: 2
     - type: AtmosPipeColor
       color: '#990000FF'
-  - uid: 5197
+  - uid: 5499
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
@@ -30148,7 +30151,7 @@ entities:
       parent: 2
     - type: AtmosPipeColor
       color: '#990000FF'
-  - uid: 5198
+  - uid: 5500
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
@@ -30156,7 +30159,7 @@ entities:
       parent: 2
     - type: AtmosPipeColor
       color: '#990000FF'
-  - uid: 5199
+  - uid: 5501
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
@@ -30164,7 +30167,7 @@ entities:
       parent: 2
     - type: AtmosPipeColor
       color: '#990000FF'
-  - uid: 5200
+  - uid: 5502
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
@@ -30172,14 +30175,14 @@ entities:
       parent: 2
     - type: AtmosPipeColor
       color: '#990000FF'
-  - uid: 5201
+  - uid: 5503
     components:
     - type: Transform
       pos: -32.5,-46.5
       parent: 2
     - type: AtmosPipeColor
       color: '#990000FF'
-  - uid: 5202
+  - uid: 5504
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
@@ -30187,7 +30190,7 @@ entities:
       parent: 2
     - type: AtmosPipeColor
       color: '#990000FF'
-  - uid: 5203
+  - uid: 5505
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
@@ -30195,35 +30198,35 @@ entities:
       parent: 2
     - type: AtmosPipeColor
       color: '#990000FF'
-  - uid: 5204
+  - uid: 5506
     components:
     - type: Transform
       pos: -41.5,-42.5
       parent: 2
     - type: AtmosPipeColor
       color: '#990000FF'
-  - uid: 5205
+  - uid: 5507
     components:
     - type: Transform
       pos: -41.5,-43.5
       parent: 2
     - type: AtmosPipeColor
       color: '#990000FF'
-  - uid: 5206
+  - uid: 5508
     components:
     - type: Transform
       pos: -34.5,-42.5
       parent: 2
     - type: AtmosPipeColor
       color: '#990000FF'
-  - uid: 5207
+  - uid: 5509
     components:
     - type: Transform
       pos: -47.5,-42.5
       parent: 2
     - type: AtmosPipeColor
       color: '#990000FF'
-  - uid: 5208
+  - uid: 5510
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
@@ -30231,7 +30234,7 @@ entities:
       parent: 2
     - type: AtmosPipeColor
       color: '#990000FF'
-  - uid: 5209
+  - uid: 5511
     components:
     - type: Transform
       rot: 3.141592653589793 rad
@@ -30239,7 +30242,7 @@ entities:
       parent: 2
     - type: AtmosPipeColor
       color: '#990000FF'
-  - uid: 5210
+  - uid: 5512
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
@@ -30247,7 +30250,7 @@ entities:
       parent: 2
     - type: AtmosPipeColor
       color: '#990000FF'
-  - uid: 5211
+  - uid: 5513
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
@@ -30255,7 +30258,7 @@ entities:
       parent: 2
     - type: AtmosPipeColor
       color: '#990000FF'
-  - uid: 5212
+  - uid: 5514
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
@@ -30263,19 +30266,19 @@ entities:
       parent: 2
     - type: AtmosPipeColor
       color: '#990000FF'
-  - uid: 5213
+  - uid: 5515
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: -94.5,5.5
       parent: 2
-  - uid: 5214
+  - uid: 5516
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: -95.5,5.5
       parent: 2
-  - uid: 5215
+  - uid: 5517
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
@@ -30283,14 +30286,14 @@ entities:
       parent: 2
     - type: AtmosPipeColor
       color: '#990000FF'
-  - uid: 5216
+  - uid: 5518
     components:
     - type: Transform
       pos: -91.5,2.5
       parent: 2
     - type: AtmosPipeColor
       color: '#990000FF'
-  - uid: 5217
+  - uid: 5519
     components:
     - type: Transform
       pos: -91.5,3.5
@@ -30299,25 +30302,25 @@ entities:
       color: '#990000FF'
 - proto: GasPipeTJunction
   entities:
-  - uid: 5218
+  - uid: 5520
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: -82.5,-10.5
       parent: 2
-  - uid: 5219
+  - uid: 5521
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: -84.5,-11.5
       parent: 2
-  - uid: 5220
+  - uid: 5522
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: -80.5,-9.5
       parent: 2
-  - uid: 5221
+  - uid: 5523
     components:
     - type: Transform
       rot: 3.141592653589793 rad
@@ -30327,7 +30330,7 @@ entities:
       color: '#990000FF'
 - proto: GasPipeTJunctionAlt1
   entities:
-  - uid: 5222
+  - uid: 5524
     components:
     - type: Transform
       rot: 3.141592653589793 rad
@@ -30335,7 +30338,7 @@ entities:
       parent: 2
     - type: AtmosPipeColor
       color: '#0055CCFF'
-  - uid: 5223
+  - uid: 5525
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
@@ -30343,7 +30346,7 @@ entities:
       parent: 2
     - type: AtmosPipeColor
       color: '#0055CCFF'
-  - uid: 5224
+  - uid: 5526
     components:
     - type: Transform
       rot: 3.141592653589793 rad
@@ -30351,7 +30354,7 @@ entities:
       parent: 2
     - type: AtmosPipeColor
       color: '#0055CCFF'
-  - uid: 5225
+  - uid: 5527
     components:
     - type: Transform
       rot: 3.141592653589793 rad
@@ -30359,7 +30362,7 @@ entities:
       parent: 2
     - type: AtmosPipeColor
       color: '#0055CCFF'
-  - uid: 5226
+  - uid: 5528
     components:
     - type: Transform
       rot: 3.141592653589793 rad
@@ -30367,7 +30370,7 @@ entities:
       parent: 2
     - type: AtmosPipeColor
       color: '#0055CCFF'
-  - uid: 5227
+  - uid: 5529
     components:
     - type: Transform
       rot: 3.141592653589793 rad
@@ -30375,7 +30378,7 @@ entities:
       parent: 2
     - type: AtmosPipeColor
       color: '#0055CCFF'
-  - uid: 5228
+  - uid: 5530
     components:
     - type: Transform
       rot: 3.141592653589793 rad
@@ -30383,7 +30386,7 @@ entities:
       parent: 2
     - type: AtmosPipeColor
       color: '#0055CCFF'
-  - uid: 5229
+  - uid: 5531
     components:
     - type: Transform
       rot: 3.141592653589793 rad
@@ -30391,7 +30394,7 @@ entities:
       parent: 2
     - type: AtmosPipeColor
       color: '#0055CCFF'
-  - uid: 5230
+  - uid: 5532
     components:
     - type: Transform
       rot: 3.141592653589793 rad
@@ -30399,7 +30402,7 @@ entities:
       parent: 2
     - type: AtmosPipeColor
       color: '#0055CCFF'
-  - uid: 5231
+  - uid: 5533
     components:
     - type: Transform
       rot: 3.141592653589793 rad
@@ -30409,7 +30412,7 @@ entities:
       color: '#0055CCFF'
 - proto: GasPipeTJunctionAlt2
   entities:
-  - uid: 5232
+  - uid: 5534
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
@@ -30417,7 +30420,7 @@ entities:
       parent: 2
     - type: AtmosPipeColor
       color: '#990000FF'
-  - uid: 5233
+  - uid: 5535
     components:
     - type: Transform
       rot: 3.141592653589793 rad
@@ -30425,7 +30428,7 @@ entities:
       parent: 2
     - type: AtmosPipeColor
       color: '#990000FF'
-  - uid: 5234
+  - uid: 5536
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
@@ -30433,28 +30436,28 @@ entities:
       parent: 2
     - type: AtmosPipeColor
       color: '#990000FF'
-  - uid: 5235
+  - uid: 5537
     components:
     - type: Transform
       pos: -88.5,-2.5
       parent: 2
     - type: AtmosPipeColor
       color: '#990000FF'
-  - uid: 5236
+  - uid: 5538
     components:
     - type: Transform
       pos: -79.5,-2.5
       parent: 2
     - type: AtmosPipeColor
       color: '#990000FF'
-  - uid: 5237
+  - uid: 5539
     components:
     - type: Transform
       pos: -72.5,-2.5
       parent: 2
     - type: AtmosPipeColor
       color: '#990000FF'
-  - uid: 5238
+  - uid: 5540
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
@@ -30462,28 +30465,28 @@ entities:
       parent: 2
     - type: AtmosPipeColor
       color: '#990000FF'
-  - uid: 5239
+  - uid: 5541
     components:
     - type: Transform
       pos: -41.5,-41.5
       parent: 2
     - type: AtmosPipeColor
       color: '#990000FF'
-  - uid: 5240
+  - uid: 5542
     components:
     - type: Transform
       pos: -34.5,-41.5
       parent: 2
     - type: AtmosPipeColor
       color: '#990000FF'
-  - uid: 5241
+  - uid: 5543
     components:
     - type: Transform
       pos: -47.5,-41.5
       parent: 2
     - type: AtmosPipeColor
       color: '#990000FF'
-  - uid: 5242
+  - uid: 5544
     components:
     - type: Transform
       pos: -40.5,-49.5
@@ -30492,7 +30495,7 @@ entities:
       color: '#990000FF'
 - proto: GasPort
   entities:
-  - uid: 5243
+  - uid: 5545
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
@@ -30500,25 +30503,21 @@ entities:
       parent: 2
 - proto: GasPressurePump
   entities:
-  - uid: 5244
+  - uid: 5546
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: -81.5,-12.5
       parent: 2
-    - type: GasPressurePump
-      enabled: True
-  - uid: 5245
+  - uid: 5547
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: -84.5,-12.5
       parent: 2
-    - type: GasPressurePump
-      enabled: True
 - proto: GasPressurePumpAlt1
   entities:
-  - uid: 5246
+  - uid: 5548
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
@@ -30526,13 +30525,13 @@ entities:
       parent: 2
 - proto: GasPressurePumpAlt2
   entities:
-  - uid: 5247
+  - uid: 5549
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: -93.5,5.5
       parent: 2
-  - uid: 5248
+  - uid: 5550
     components:
     - type: Transform
       pos: -91.5,4.5
@@ -30541,7 +30540,7 @@ entities:
       color: '#990000FF'
 - proto: GasPressureRegulator
   entities:
-  - uid: 5249
+  - uid: 5551
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
@@ -30553,7 +30552,7 @@ entities:
       color: '#990000FF'
 - proto: GasThermoMachineFreezerEnabled
   entities:
-  - uid: 5250
+  - uid: 5552
     components:
     - type: Transform
       pos: -85.5,-6.5
@@ -30564,7 +30563,7 @@ entities:
       pipeLayer: Secondary
 - proto: GasThermoMachineHeaterEnabled
   entities:
-  - uid: 5251
+  - uid: 5553
     components:
     - type: Transform
       pos: -84.5,-6.5
@@ -30575,7 +30574,7 @@ entities:
       pipeLayer: Secondary
 - proto: GasVentPumpInlet
   entities:
-  - uid: 5252
+  - uid: 5554
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
@@ -30588,7 +30587,7 @@ entities:
       pipeLayer: Secondary
     - type: AtmosPipeColor
       color: '#0055CCFF'
-  - uid: 5253
+  - uid: 5555
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
@@ -30601,7 +30600,7 @@ entities:
       pipeLayer: Secondary
     - type: AtmosPipeColor
       color: '#0055CCFF'
-  - uid: 5254
+  - uid: 5556
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
@@ -30614,7 +30613,7 @@ entities:
       pipeLayer: Secondary
     - type: AtmosPipeColor
       color: '#0055CCFF'
-  - uid: 5255
+  - uid: 5557
     components:
     - type: Transform
       pos: -30.5,-40.5
@@ -30626,7 +30625,7 @@ entities:
       pipeLayer: Secondary
     - type: AtmosPipeColor
       color: '#0055CCFF'
-  - uid: 5256
+  - uid: 5558
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
@@ -30639,7 +30638,7 @@ entities:
       pipeLayer: Secondary
     - type: AtmosPipeColor
       color: '#0055CCFF'
-  - uid: 5257
+  - uid: 5559
     components:
     - type: Transform
       pos: -35.5,-46.5
@@ -30651,7 +30650,7 @@ entities:
       pipeLayer: Secondary
     - type: AtmosPipeColor
       color: '#0055CCFF'
-  - uid: 5258
+  - uid: 5560
     components:
     - type: Transform
       pos: -42.5,-46.5
@@ -30663,7 +30662,7 @@ entities:
       pipeLayer: Secondary
     - type: AtmosPipeColor
       color: '#0055CCFF'
-  - uid: 5259
+  - uid: 5561
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
@@ -30676,7 +30675,7 @@ entities:
       pipeLayer: Secondary
     - type: AtmosPipeColor
       color: '#0055CCFF'
-  - uid: 5260
+  - uid: 5562
     components:
     - type: Transform
       pos: -37.5,-46.5
@@ -30688,7 +30687,7 @@ entities:
       pipeLayer: Secondary
     - type: AtmosPipeColor
       color: '#0055CCFF'
-  - uid: 5261
+  - uid: 5563
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
@@ -30701,7 +30700,7 @@ entities:
       pipeLayer: Secondary
     - type: AtmosPipeColor
       color: '#0055CCFF'
-  - uid: 5262
+  - uid: 5564
     components:
     - type: Transform
       rot: 3.141592653589793 rad
@@ -30714,7 +30713,7 @@ entities:
       pipeLayer: Secondary
     - type: AtmosPipeColor
       color: '#0055CCFF'
-  - uid: 5263
+  - uid: 5565
     components:
     - type: Transform
       pos: -36.5,-39.5
@@ -30726,7 +30725,7 @@ entities:
       pipeLayer: Secondary
     - type: AtmosPipeColor
       color: '#0055CCFF'
-  - uid: 5264
+  - uid: 5566
     components:
     - type: Transform
       pos: -43.5,-40.5
@@ -30738,7 +30737,7 @@ entities:
       pipeLayer: Secondary
     - type: AtmosPipeColor
       color: '#0055CCFF'
-  - uid: 5265
+  - uid: 5567
     components:
     - type: Transform
       pos: -49.5,-40.5
@@ -30750,7 +30749,7 @@ entities:
       pipeLayer: Secondary
     - type: AtmosPipeColor
       color: '#0055CCFF'
-  - uid: 5266
+  - uid: 5568
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
@@ -30763,7 +30762,7 @@ entities:
       pipeLayer: Secondary
     - type: AtmosPipeColor
       color: '#0055CCFF'
-  - uid: 5267
+  - uid: 5569
     components:
     - type: Transform
       rot: 3.141592653589793 rad
@@ -30776,7 +30775,7 @@ entities:
       pipeLayer: Secondary
     - type: AtmosPipeColor
       color: '#0055CCFF'
-  - uid: 5268
+  - uid: 5570
     components:
     - type: Transform
       pos: -91.5,6.5
@@ -30788,7 +30787,7 @@ entities:
       pipeLayer: Secondary
     - type: AtmosPipeColor
       color: '#0055CCFF'
-  - uid: 5269
+  - uid: 5571
     components:
     - type: Transform
       pos: -80.5,6.5
@@ -30800,7 +30799,7 @@ entities:
       pipeLayer: Secondary
     - type: AtmosPipeColor
       color: '#0055CCFF'
-  - uid: 5270
+  - uid: 5572
     components:
     - type: Transform
       pos: -95.5,-1.5
@@ -30812,7 +30811,7 @@ entities:
       pipeLayer: Secondary
     - type: AtmosPipeColor
       color: '#0055CCFF'
-  - uid: 5271
+  - uid: 5573
     components:
     - type: Transform
       pos: -81.5,-1.5
@@ -30824,7 +30823,7 @@ entities:
       pipeLayer: Secondary
     - type: AtmosPipeColor
       color: '#0055CCFF'
-  - uid: 5272
+  - uid: 5574
     components:
     - type: Transform
       pos: -97.5,-1.5
@@ -30836,7 +30835,7 @@ entities:
       pipeLayer: Secondary
     - type: AtmosPipeColor
       color: '#0055CCFF'
-  - uid: 5273
+  - uid: 5575
     components:
     - type: Transform
       pos: -75.5,-1.5
@@ -30850,7 +30849,7 @@ entities:
       color: '#0055CCFF'
 - proto: GasVentPumpOutlet
   entities:
-  - uid: 5274
+  - uid: 5576
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
@@ -30863,7 +30862,7 @@ entities:
       pipeLayer: Tertiary
     - type: AtmosPipeColor
       color: '#990000FF'
-  - uid: 5275
+  - uid: 5577
     components:
     - type: Transform
       rot: 3.141592653589793 rad
@@ -30876,7 +30875,7 @@ entities:
       pipeLayer: Tertiary
     - type: AtmosPipeColor
       color: '#990000FF'
-  - uid: 5276
+  - uid: 5578
     components:
     - type: Transform
       rot: 3.141592653589793 rad
@@ -30889,7 +30888,7 @@ entities:
       pipeLayer: Tertiary
     - type: AtmosPipeColor
       color: '#990000FF'
-  - uid: 5277
+  - uid: 5579
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
@@ -30902,7 +30901,7 @@ entities:
       pipeLayer: Tertiary
     - type: AtmosPipeColor
       color: '#990000FF'
-  - uid: 5278
+  - uid: 5580
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
@@ -30915,7 +30914,7 @@ entities:
       pipeLayer: Tertiary
     - type: AtmosPipeColor
       color: '#990000FF'
-  - uid: 5279
+  - uid: 5581
     components:
     - type: Transform
       rot: 3.141592653589793 rad
@@ -30928,7 +30927,7 @@ entities:
       pipeLayer: Tertiary
     - type: AtmosPipeColor
       color: '#990000FF'
-  - uid: 5280
+  - uid: 5582
     components:
     - type: Transform
       rot: 3.141592653589793 rad
@@ -30941,7 +30940,7 @@ entities:
       pipeLayer: Tertiary
     - type: AtmosPipeColor
       color: '#990000FF'
-  - uid: 5281
+  - uid: 5583
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
@@ -30954,7 +30953,7 @@ entities:
       pipeLayer: Tertiary
     - type: AtmosPipeColor
       color: '#990000FF'
-  - uid: 5282
+  - uid: 5584
     components:
     - type: Transform
       rot: 3.141592653589793 rad
@@ -30967,7 +30966,7 @@ entities:
       pipeLayer: Tertiary
     - type: AtmosPipeColor
       color: '#990000FF'
-  - uid: 5283
+  - uid: 5585
     components:
     - type: Transform
       rot: 3.141592653589793 rad
@@ -30980,7 +30979,7 @@ entities:
       pipeLayer: Tertiary
     - type: AtmosPipeColor
       color: '#990000FF'
-  - uid: 5284
+  - uid: 5586
     components:
     - type: Transform
       rot: 3.141592653589793 rad
@@ -30993,7 +30992,7 @@ entities:
       pipeLayer: Tertiary
     - type: AtmosPipeColor
       color: '#990000FF'
-  - uid: 5285
+  - uid: 5587
     components:
     - type: Transform
       rot: 3.141592653589793 rad
@@ -31006,7 +31005,7 @@ entities:
       pipeLayer: Tertiary
     - type: AtmosPipeColor
       color: '#990000FF'
-  - uid: 5286
+  - uid: 5588
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
@@ -31019,7 +31018,7 @@ entities:
       pipeLayer: Tertiary
     - type: AtmosPipeColor
       color: '#990000FF'
-  - uid: 5287
+  - uid: 5589
     components:
     - type: Transform
       rot: 3.141592653589793 rad
@@ -31032,7 +31031,7 @@ entities:
       pipeLayer: Tertiary
     - type: AtmosPipeColor
       color: '#990000FF'
-  - uid: 5288
+  - uid: 5590
     components:
     - type: Transform
       rot: 3.141592653589793 rad
@@ -31045,7 +31044,7 @@ entities:
       pipeLayer: Tertiary
     - type: AtmosPipeColor
       color: '#990000FF'
-  - uid: 5289
+  - uid: 5591
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
@@ -31058,7 +31057,7 @@ entities:
       pipeLayer: Tertiary
     - type: AtmosPipeColor
       color: '#990000FF'
-  - uid: 5290
+  - uid: 5592
     components:
     - type: Transform
       rot: 3.141592653589793 rad
@@ -31071,7 +31070,7 @@ entities:
       pipeLayer: Tertiary
     - type: AtmosPipeColor
       color: '#990000FF'
-  - uid: 5291
+  - uid: 5593
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
@@ -31084,7 +31083,7 @@ entities:
       pipeLayer: Tertiary
     - type: AtmosPipeColor
       color: '#990000FF'
-  - uid: 5292
+  - uid: 5594
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
@@ -31097,7 +31096,7 @@ entities:
       pipeLayer: Tertiary
     - type: AtmosPipeColor
       color: '#990000FF'
-  - uid: 5293
+  - uid: 5595
     components:
     - type: Transform
       rot: 3.141592653589793 rad
@@ -31110,7 +31109,7 @@ entities:
       pipeLayer: Tertiary
     - type: AtmosPipeColor
       color: '#990000FF'
-  - uid: 5294
+  - uid: 5596
     components:
     - type: Transform
       rot: 3.141592653589793 rad
@@ -31125,7 +31124,7 @@ entities:
       color: '#990000FF'
 - proto: GasVentScrubber
   entities:
-  - uid: 5295
+  - uid: 5597
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
@@ -31135,7 +31134,7 @@ entities:
       pipeLayer: Tertiary
     - type: AtmosPipeColor
       color: '#990000FF'
-  - uid: 5296
+  - uid: 5598
     components:
     - type: Transform
       rot: 3.141592653589793 rad
@@ -31147,42 +31146,50 @@ entities:
       color: '#990000FF'
 - proto: GeneratorBasic15kW
   entities:
-  - uid: 5297
+  - uid: 5599
     components:
     - type: Transform
       pos: -80.5,-11.5
       parent: 2
-  - uid: 5298
+    - type: PowerSupplier
+      supplyRampPosition: 15000
+  - uid: 5600
     components:
     - type: Transform
       pos: -80.5,-10.5
       parent: 2
-  - uid: 5299
+    - type: PowerSupplier
+      supplyRampPosition: 15000
+  - uid: 5601
     components:
     - type: Transform
       pos: -85.5,-10.5
       parent: 2
-  - uid: 5300
+    - type: PowerSupplier
+      supplyRampPosition: 15000
+  - uid: 5602
     components:
     - type: Transform
       pos: -85.5,-11.5
       parent: 2
+    - type: PowerSupplier
+      supplyRampPosition: 15000
 - proto: GravityGeneratorMini
   entities:
-  - uid: 5301
+  - uid: 5603
     components:
     - type: Transform
       pos: -83.5,-12.5
       parent: 2
 - proto: Grille
   entities:
-  - uid: 5302
+  - uid: 5604
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: -84.5,-13.5
       parent: 2
-  - uid: 5303
+  - uid: 5605
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
@@ -31190,7 +31197,7 @@ entities:
       parent: 2
 - proto: GunSafeBaseSecure
   entities:
-  - uid: 5304
+  - uid: 5606
     components:
     - type: Transform
       pos: -101.5,-0.5
@@ -31199,7 +31206,7 @@ entities:
       locked: False
 - proto: Holopad
   entities:
-  - uid: 5305
+  - uid: 5607
     components:
     - type: MetaData
       name: holopad (Dorms)
@@ -31210,7 +31217,7 @@ entities:
       currentLabel: Dorms
     - type: NameModifier
       baseName: holopad
-  - uid: 5306
+  - uid: 5608
     components:
     - type: MetaData
       name: holopad (Cargo Dock)
@@ -31223,7 +31230,7 @@ entities:
       baseName: holopad
 - proto: HolopadCommandBridge
   entities:
-  - uid: 5307
+  - uid: 5609
     components:
     - type: MetaData
       name: holopad (Bridge)
@@ -31236,49 +31243,49 @@ entities:
       baseName: holopad
 - proto: HospitalCurtainsOpen
   entities:
-  - uid: 5308
+  - uid: 5610
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: -85.5,2.5
       parent: 2
-  - uid: 5309
+  - uid: 5611
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: -85.5,0.5
       parent: 2
-  - uid: 5310
+  - uid: 5612
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: -80.5,2.5
       parent: 2
-  - uid: 5311
+  - uid: 5613
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: -80.5,0.5
       parent: 2
-  - uid: 5312
+  - uid: 5614
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: -28.5,-42.5
       parent: 2
-  - uid: 5313
+  - uid: 5615
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: -27.5,-42.5
       parent: 2
-  - uid: 5314
+  - uid: 5616
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: -49.5,-42.5
       parent: 2
-  - uid: 5315
+  - uid: 5617
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
@@ -31286,57 +31293,57 @@ entities:
       parent: 2
 - proto: KitchenElectricGrill
   entities:
-  - uid: 5316
+  - uid: 5618
     components:
     - type: Transform
       pos: -95.5,-9.5
       parent: 2
 - proto: KitchenMicrowave
   entities:
-  - uid: 5317
+  - uid: 5619
     components:
     - type: Transform
       pos: -96.5,-12.5
       parent: 2
 - proto: KitchenReagentGrinder
   entities:
-  - uid: 5318
+  - uid: 5620
     components:
     - type: Transform
       pos: -82.5,6.5
       parent: 2
-  - uid: 5319
+  - uid: 5621
     components:
     - type: Transform
       pos: -93.5,-12.5
       parent: 2
 - proto: LampGold
   entities:
-  - uid: 5320
+  - uid: 5622
     components:
     - type: Transform
       pos: -47.640495,-44.793
       parent: 2
-  - uid: 5321
+  - uid: 5623
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: -30.299622,-44.793
       parent: 2
-  - uid: 5322
+  - uid: 5624
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: -32.319725,-35.793743
       parent: 2
-  - uid: 5323
+  - uid: 5625
     components:
     - type: Transform
       pos: -46.663475,-35.793743
       parent: 2
 - proto: LargeBeaker
   entities:
-  - uid: 5324
+  - uid: 5626
     components:
     - type: Transform
       pos: -81.5,6.75
@@ -31345,19 +31352,19 @@ entities:
       enabled: False
 - proto: LiquidOxygenCanister
   entities:
-  - uid: 5325
+  - uid: 5627
     components:
     - type: Transform
       pos: -76.5,-1.5
       parent: 2
-  - uid: 5326
+  - uid: 5628
     components:
     - type: Transform
       pos: -37.5,-39.5
       parent: 2
 - proto: LockerAdministrativeAssistantFilled
   entities:
-  - uid: 5327
+  - uid: 5629
     components:
     - type: Transform
       pos: -97.76281,-4.5
@@ -31366,7 +31373,7 @@ entities:
       locked: False
 - proto: LockerCaptainFilledHardsuit
   entities:
-  - uid: 5328
+  - uid: 5630
     components:
     - type: Transform
       pos: -97.26281,-4.5
@@ -31375,7 +31382,7 @@ entities:
       locked: False
 - proto: LockerChiefEngineerFilledHardsuit
   entities:
-  - uid: 5329
+  - uid: 5631
     components:
     - type: Transform
       pos: -80.26234,-6.5
@@ -31384,7 +31391,7 @@ entities:
       locked: False
 - proto: LockerChiefMedicalOfficerFilledHardsuit
   entities:
-  - uid: 5330
+  - uid: 5632
     components:
     - type: Transform
       pos: -84.75326,6.5
@@ -31393,7 +31400,7 @@ entities:
       locked: False
 - proto: LockerEngineerFilledHardsuit
   entities:
-  - uid: 5331
+  - uid: 5633
     components:
     - type: Transform
       pos: -80.76234,-6.5
@@ -31402,7 +31409,7 @@ entities:
       locked: False
 - proto: LockerHeadOfPersonnelFilled
   entities:
-  - uid: 5332
+  - uid: 5634
     components:
     - type: Transform
       pos: -91.23403,-12.5
@@ -31411,7 +31418,7 @@ entities:
       locked: False
 - proto: LockerHeadOfSecurityFilledHardsuit
   entities:
-  - uid: 5333
+  - uid: 5635
     components:
     - type: Transform
       pos: -97.265526,-1.5
@@ -31420,7 +31427,7 @@ entities:
       locked: False
 - proto: LockerParamedicFilledHardsuit
   entities:
-  - uid: 5334
+  - uid: 5636
     components:
     - type: Transform
       pos: -84.28266,6.5
@@ -31429,7 +31436,7 @@ entities:
       locked: False
 - proto: LockerQuarterMasterFilled
   entities:
-  - uid: 5335
+  - uid: 5637
     components:
     - type: Transform
       pos: -75.26872,-1.5
@@ -31438,7 +31445,7 @@ entities:
       locked: False
 - proto: LockerResearchDirectorFilledHardsuit
   entities:
-  - uid: 5336
+  - uid: 5638
     components:
     - type: Transform
       pos: -96.73568,0.5
@@ -31447,21 +31454,21 @@ entities:
       locked: False
 - proto: LockerSalvageSpecialistFilledHardsuit
   entities:
-  - uid: 5337
+  - uid: 5639
     components:
     - type: Transform
       pos: -75.26749,-4.5
       parent: 2
     - type: Lock
       locked: False
-  - uid: 5338
+  - uid: 5640
     components:
     - type: Transform
       pos: -75.76749,-1.5
       parent: 2
     - type: Lock
       locked: False
-  - uid: 5339
+  - uid: 5641
     components:
     - type: Transform
       pos: -75.76749,-4.5
@@ -31470,7 +31477,7 @@ entities:
       locked: False
 - proto: LockerScienceFilled
   entities:
-  - uid: 5340
+  - uid: 5642
     components:
     - type: Transform
       pos: -96.26693,0.5
@@ -31479,28 +31486,28 @@ entities:
       locked: False
 - proto: LockerSteel
   entities:
-  - uid: 5341
+  - uid: 5643
     components:
     - type: Transform
       pos: -30.263252,-47.5
       parent: 2
     - type: Lock
       locked: False
-  - uid: 5342
+  - uid: 5644
     components:
     - type: Transform
       pos: -31.225754,-36.5
       parent: 2
     - type: Lock
       locked: False
-  - uid: 5343
+  - uid: 5645
     components:
     - type: Transform
       pos: -44.22718,-36.5
       parent: 2
     - type: Lock
       locked: False
-  - uid: 5344
+  - uid: 5646
     components:
     - type: Transform
       pos: -47.696083,-47.5
@@ -31509,7 +31516,7 @@ entities:
       locked: False
 - proto: LockerWardenFilledHardsuit
   entities:
-  - uid: 5345
+  - uid: 5647
     components:
     - type: Transform
       pos: -97.765526,-1.5
@@ -31518,53 +31525,53 @@ entities:
       locked: False
 - proto: LogisticsTechFab
   entities:
-  - uid: 5346
+  - uid: 5648
     components:
     - type: Transform
       pos: -79.5,-1.5
       parent: 2
 - proto: LuxuryPen
   entities:
-  - uid: 5347
+  - uid: 5649
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: -42.552063,-50.504593
       parent: 2
-  - uid: 5348
+  - uid: 5650
     components:
     - type: Transform
       pos: -35.427063,-50.520218
       parent: 2
-  - uid: 5349
+  - uid: 5651
     components:
     - type: Transform
       pos: -30.981781,-45.4805
       parent: 2
-  - uid: 5350
+  - uid: 5652
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: -47.001472,-45.464874
       parent: 2
-  - uid: 5351
+  - uid: 5653
     components:
     - type: Transform
       pos: -33.02285,-36.418743
       parent: 2
-  - uid: 5352
+  - uid: 5654
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: -46.069725,-36.418743
       parent: 2
-  - uid: 5353
+  - uid: 5655
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: -96.4338,3.4934177
       parent: 2
-  - uid: 5354
+  - uid: 5656
     components:
     - type: Transform
       rot: 3.141592653589793 rad
@@ -31572,64 +31579,64 @@ entities:
       parent: 2
 - proto: MachineArtifactAnalyzer
   entities:
-  - uid: 5355
+  - uid: 5657
     components:
     - type: Transform
       pos: -96.5,6.5
       parent: 2
 - proto: MachineMaterialSilo
   entities:
-  - uid: 5356
+  - uid: 5658
     components:
     - type: Transform
       pos: -79.5,-4.5
       parent: 2
 - proto: MedicalBed
   entities:
-  - uid: 5357
+  - uid: 5659
     components:
     - type: Transform
       pos: -80.5,0.5
       parent: 2
-  - uid: 5358
+  - uid: 5660
     components:
     - type: Transform
       pos: -80.5,2.5
       parent: 2
-  - uid: 5359
+  - uid: 5661
     components:
     - type: Transform
       pos: -85.5,2.5
       parent: 2
 - proto: MedicalTechFab
   entities:
-  - uid: 5360
+  - uid: 5662
     components:
     - type: Transform
       pos: -85.5,6.5
       parent: 2
 - proto: MedkitAdvancedFilled
   entities:
-  - uid: 5361
+  - uid: 5663
     components:
     - type: Transform
       pos: -85.59921,1.7002239
       parent: 2
-  - uid: 5362
+  - uid: 5664
     components:
     - type: Transform
       pos: -85.40951,1.5410461
       parent: 2
 - proto: Mirror
   entities:
-  - uid: 5363
+  - uid: 5665
     components:
     - type: Transform
       pos: -27.5,-39.5
       parent: 2
     - type: Fixtures
       fixtures: {}
-  - uid: 5364
+  - uid: 5666
     components:
     - type: Transform
       pos: -50.5,-39.5
@@ -31638,867 +31645,867 @@ entities:
       fixtures: {}
 - proto: MountainRock
   entities:
-  - uid: 2468
+  - uid: 5667
     components:
     - type: Transform
       pos: 18.5,-3.5
       parent: 2
-  - uid: 2511
+  - uid: 5668
     components:
     - type: Transform
       pos: -46.5,-20.5
       parent: 2
-  - uid: 2526
+  - uid: 5669
     components:
     - type: Transform
       pos: 1.5,2.5
       parent: 2
-  - uid: 2528
+  - uid: 5670
     components:
     - type: Transform
       pos: -52.5,-21.5
       parent: 2
-  - uid: 2535
+  - uid: 5671
     components:
     - type: Transform
       pos: -53.5,-20.5
       parent: 2
-  - uid: 2537
+  - uid: 5672
     components:
     - type: Transform
       pos: -29.5,26.5
       parent: 2
-  - uid: 2548
+  - uid: 5673
     components:
     - type: Transform
       pos: -48.5,-20.5
       parent: 2
-  - uid: 2554
+  - uid: 5674
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: -48.5,-14.5
       parent: 2
-  - uid: 2557
+  - uid: 5675
     components:
     - type: Transform
       pos: -47.5,10.5
       parent: 2
-  - uid: 2585
+  - uid: 5676
     components:
     - type: Transform
       pos: 3.5,52.5
       parent: 2
-  - uid: 2590
+  - uid: 5677
     components:
     - type: Transform
       pos: -18.5,29.5
       parent: 2
-  - uid: 2596
+  - uid: 5678
     components:
     - type: Transform
       pos: -2.5,9.5
       parent: 2
-  - uid: 2624
+  - uid: 5679
     components:
     - type: Transform
       pos: -52.5,37.5
       parent: 2
-  - uid: 2640
+  - uid: 5680
     components:
     - type: Transform
       pos: -63.5,-22.5
       parent: 2
-  - uid: 2676
+  - uid: 5681
     components:
     - type: Transform
       pos: -55.5,-7.5
       parent: 2
-  - uid: 2687
+  - uid: 5682
     components:
     - type: Transform
       pos: -62.5,-24.5
       parent: 2
-  - uid: 2699
+  - uid: 5683
     components:
     - type: Transform
       pos: -50.5,11.5
       parent: 2
-  - uid: 2702
+  - uid: 5684
     components:
     - type: Transform
       pos: -55.5,-27.5
       parent: 2
-  - uid: 2707
+  - uid: 5685
     components:
     - type: Transform
       pos: -2.5,-14.5
       parent: 2
-  - uid: 2711
+  - uid: 5686
     components:
     - type: Transform
       pos: -42.5,47.5
       parent: 2
-  - uid: 2716
+  - uid: 5687
     components:
     - type: Transform
       pos: -55.5,-5.5
       parent: 2
-  - uid: 2742
+  - uid: 5688
     components:
     - type: Transform
       pos: -36.5,0.5
       parent: 2
-  - uid: 2778
+  - uid: 5689
     components:
     - type: Transform
       pos: -55.5,8.5
       parent: 2
-  - uid: 2820
+  - uid: 5690
     components:
     - type: Transform
       pos: 4.5,11.5
       parent: 2
-  - uid: 2828
+  - uid: 5691
     components:
     - type: Transform
       pos: -53.5,-25.5
       parent: 2
-  - uid: 2898
+  - uid: 5692
     components:
     - type: Transform
       pos: -2.5,-17.5
       parent: 2
-  - uid: 2918
+  - uid: 5693
     components:
     - type: Transform
       pos: -48.5,-15.5
       parent: 2
-  - uid: 2936
+  - uid: 5694
     components:
     - type: Transform
       pos: -12.5,3.5
       parent: 2
-  - uid: 2939
+  - uid: 5695
     components:
     - type: Transform
       pos: 17.5,-2.5
       parent: 2
-  - uid: 2942
+  - uid: 5696
     components:
     - type: Transform
       pos: -54.5,-5.5
       parent: 2
-  - uid: 2961
+  - uid: 5697
     components:
     - type: Transform
       pos: -3.5,-15.5
       parent: 2
-  - uid: 2972
+  - uid: 5698
     components:
     - type: Transform
       pos: -47.5,-15.5
       parent: 2
-  - uid: 2974
+  - uid: 5699
     components:
     - type: Transform
       pos: -52.5,11.5
       parent: 2
-  - uid: 2991
+  - uid: 5700
     components:
     - type: Transform
       pos: -51.5,-27.5
       parent: 2
-  - uid: 3026
+  - uid: 5701
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: -47.5,-14.5
       parent: 2
-  - uid: 3051
+  - uid: 5702
     components:
     - type: Transform
       pos: -47.5,9.5
       parent: 2
-  - uid: 3072
+  - uid: 5703
     components:
     - type: Transform
       pos: -64.5,-23.5
       parent: 2
-  - uid: 3079
+  - uid: 5704
     components:
     - type: Transform
       pos: -44.5,45.5
       parent: 2
-  - uid: 3081
+  - uid: 5705
     components:
     - type: Transform
       pos: -35.5,2.5
       parent: 2
-  - uid: 3094
+  - uid: 5706
     components:
     - type: Transform
       pos: -46.5,-22.5
       parent: 2
-  - uid: 5368
+  - uid: 5707
     components:
     - type: Transform
       pos: -47.5,11.5
       parent: 2
-  - uid: 5370
+  - uid: 5708
     components:
     - type: Transform
       pos: -1.5,-14.5
       parent: 2
-  - uid: 5372
+  - uid: 5709
     components:
     - type: Transform
       pos: 2.5,51.5
       parent: 2
-  - uid: 5374
+  - uid: 5710
     components:
     - type: Transform
       pos: -46.5,-23.5
       parent: 2
-  - uid: 5389
+  - uid: 5711
     components:
     - type: Transform
       pos: -43.5,46.5
       parent: 2
-  - uid: 5400
+  - uid: 5712
     components:
     - type: Transform
       pos: -52.5,-26.5
       parent: 2
-  - uid: 5402
+  - uid: 5713
     components:
     - type: Transform
       pos: 3.5,12.5
       parent: 2
-  - uid: 5403
+  - uid: 5714
     components:
     - type: Transform
       pos: -14.5,1.5
       parent: 2
-  - uid: 5406
+  - uid: 5715
     components:
     - type: Transform
       pos: 1.5,50.5
       parent: 2
-  - uid: 5418
+  - uid: 5716
     components:
     - type: Transform
       pos: -14.5,2.5
       parent: 2
-  - uid: 5430
+  - uid: 5717
     components:
     - type: Transform
       pos: -30.5,44.5
       parent: 2
-  - uid: 5445
+  - uid: 5718
     components:
     - type: Transform
       pos: 4.5,13.5
       parent: 2
-  - uid: 5446
+  - uid: 5719
     components:
     - type: Transform
       pos: -50.5,12.5
       parent: 2
-  - uid: 5450
+  - uid: 5720
     components:
     - type: Transform
       pos: -4.5,13.5
       parent: 2
-  - uid: 5458
+  - uid: 5721
     components:
     - type: Transform
       pos: -55.5,-26.5
       parent: 2
-  - uid: 5459
+  - uid: 5722
     components:
     - type: Transform
       pos: -33.5,30.5
       parent: 2
-  - uid: 5467
+  - uid: 5723
     components:
     - type: Transform
       pos: -29.5,25.5
       parent: 2
-  - uid: 5468
+  - uid: 5724
     components:
     - type: Transform
       pos: -23.5,42.5
       parent: 2
-  - uid: 5469
+  - uid: 5725
     components:
     - type: Transform
       pos: -34.5,0.5
       parent: 2
-  - uid: 5472
+  - uid: 5726
     components:
     - type: Transform
       pos: -34.5,30.5
       parent: 2
-  - uid: 5476
+  - uid: 5727
     components:
     - type: Transform
       pos: -31.5,42.5
       parent: 2
-  - uid: 5477
+  - uid: 5728
     components:
     - type: Transform
       pos: -3.5,13.5
       parent: 2
-  - uid: 5478
+  - uid: 5729
     components:
     - type: Transform
       pos: -44.5,1.5
       parent: 2
-  - uid: 5486
+  - uid: 5730
     components:
     - type: Transform
       pos: -3.5,10.5
       parent: 2
-  - uid: 5491
+  - uid: 5731
     components:
     - type: Transform
       pos: 19.5,-0.5
       parent: 2
-  - uid: 5504
+  - uid: 5732
     components:
     - type: Transform
       pos: -20.5,30.5
       parent: 2
-  - uid: 5513
+  - uid: 5733
     components:
     - type: Transform
       pos: 1.5,11.5
       parent: 2
-  - uid: 5514
+  - uid: 5734
     components:
     - type: Transform
       pos: -37.5,1.5
       parent: 2
-  - uid: 5515
+  - uid: 5735
     components:
     - type: Transform
       pos: -51.5,12.5
       parent: 2
-  - uid: 5516
+  - uid: 5736
     components:
     - type: Transform
       pos: -49.5,11.5
       parent: 2
-  - uid: 5529
+  - uid: 5737
     components:
     - type: Transform
       pos: -47.5,-16.5
       parent: 2
-  - uid: 5532
+  - uid: 5738
     components:
     - type: Transform
       pos: -46.5,-18.5
       parent: 2
-  - uid: 5534
+  - uid: 5739
     components:
     - type: Transform
       pos: -2.5,-13.5
       parent: 2
-  - uid: 5538
+  - uid: 5740
     components:
     - type: Transform
       pos: -61.5,-25.5
       parent: 2
-  - uid: 5540
+  - uid: 5741
     components:
     - type: Transform
       pos: -33.5,44.5
       parent: 2
-  - uid: 5543
+  - uid: 5742
     components:
     - type: Transform
       pos: -32.5,29.5
       parent: 2
-  - uid: 5546
+  - uid: 5743
     components:
     - type: Transform
       pos: -50.5,37.5
       parent: 2
-  - uid: 5551
+  - uid: 5744
     components:
     - type: Transform
       pos: 2.5,13.5
       parent: 2
-  - uid: 5570
+  - uid: 5745
     components:
     - type: Transform
       pos: 1.5,0.5
       parent: 2
-  - uid: 5571
+  - uid: 5746
     components:
     - type: Transform
       pos: -51.5,36.5
       parent: 2
-  - uid: 6220
+  - uid: 5747
     components:
     - type: Transform
       pos: -33.5,-18.5
       parent: 2
-  - uid: 6223
+  - uid: 5748
     components:
     - type: Transform
       pos: -34.5,-17.5
       parent: 2
-  - uid: 6244
+  - uid: 5749
     components:
     - type: Transform
       pos: 1.5,12.5
       parent: 2
-  - uid: 6250
+  - uid: 5750
     components:
     - type: Transform
       pos: -3.5,-14.5
       parent: 2
-  - uid: 6251
+  - uid: 5751
     components:
     - type: Transform
       pos: -32.5,44.5
       parent: 2
-  - uid: 6259
+  - uid: 5752
     components:
     - type: Transform
       pos: -48.5,10.5
       parent: 2
-  - uid: 6260
+  - uid: 5753
     components:
     - type: Transform
       pos: -34.5,42.5
       parent: 2
-  - uid: 6261
+  - uid: 5754
     components:
     - type: Transform
       pos: -54.5,-6.5
       parent: 2
-  - uid: 6262
+  - uid: 5755
     components:
     - type: Transform
       pos: -2.5,12.5
       parent: 2
-  - uid: 6264
+  - uid: 5756
     components:
     - type: Transform
       pos: 2.5,50.5
       parent: 2
-  - uid: 6267
+  - uid: 5757
     components:
     - type: Transform
       pos: 1.5,53.5
       parent: 2
-  - uid: 6275
+  - uid: 5758
     components:
     - type: Transform
       pos: -48.5,9.5
       parent: 2
-  - uid: 6276
+  - uid: 5759
     components:
     - type: Transform
       pos: -33.5,42.5
       parent: 2
-  - uid: 6281
+  - uid: 5760
     components:
     - type: Transform
       pos: -48.5,11.5
       parent: 2
-  - uid: 6283
+  - uid: 5761
     components:
     - type: Transform
       pos: -51.5,11.5
       parent: 2
-  - uid: 6284
+  - uid: 5762
     components:
     - type: Transform
       pos: -30.5,27.5
       parent: 2
-  - uid: 6285
+  - uid: 5763
     components:
     - type: Transform
       pos: -29.5,44.5
       parent: 2
-  - uid: 6286
+  - uid: 5764
     components:
     - type: Transform
       pos: -47.5,8.5
       parent: 2
-  - uid: 6287
+  - uid: 5765
     components:
     - type: Transform
       pos: -34.5,31.5
       parent: 2
-  - uid: 6289
+  - uid: 5766
     components:
     - type: Transform
       pos: -36.5,1.5
       parent: 2
-  - uid: 6291
+  - uid: 5767
     components:
     - type: Transform
       pos: 0.5,0.5
       parent: 2
-  - uid: 6294
+  - uid: 5768
     components:
     - type: Transform
       pos: 2.5,53.5
       parent: 2
-  - uid: 6295
+  - uid: 5769
     components:
     - type: Transform
       pos: -52.5,-20.5
       parent: 2
-  - uid: 6296
+  - uid: 5770
     components:
     - type: Transform
       pos: -3.5,14.5
       parent: 2
-  - uid: 6298
+  - uid: 5771
     components:
     - type: Transform
       pos: -50.5,38.5
       parent: 2
-  - uid: 6300
+  - uid: 5772
     components:
     - type: Transform
       pos: -14.5,3.5
       parent: 2
-  - uid: 6303
+  - uid: 5773
     components:
     - type: Transform
       pos: 2.5,11.5
       parent: 2
-  - uid: 6312
+  - uid: 5774
     components:
     - type: Transform
       pos: -3.5,12.5
       parent: 2
-  - uid: 6313
+  - uid: 5775
     components:
     - type: Transform
       pos: -2.5,13.5
       parent: 2
-  - uid: 6315
+  - uid: 5776
     components:
     - type: Transform
       pos: -51.5,39.5
       parent: 2
-  - uid: 6318
+  - uid: 5777
     components:
     - type: Transform
       pos: -61.5,-23.5
       parent: 2
-  - uid: 6319
+  - uid: 5778
     components:
     - type: Transform
       pos: -2.5,10.5
       parent: 2
-  - uid: 6320
+  - uid: 5779
     components:
     - type: Transform
       pos: -12.5,-1.5
       parent: 2
-  - uid: 6322
+  - uid: 5780
     components:
     - type: Transform
       pos: -51.5,38.5
       parent: 2
-  - uid: 6323
+  - uid: 5781
     components:
     - type: Transform
       pos: -13.5,2.5
       parent: 2
-  - uid: 6329
+  - uid: 5782
     components:
     - type: Transform
       pos: -11.5,-1.5
       parent: 2
-  - uid: 6331
+  - uid: 5783
     components:
     - type: Transform
       pos: -45.5,2.5
       parent: 2
-  - uid: 6333
+  - uid: 5784
     components:
     - type: Transform
       pos: -19.5,30.5
       parent: 2
-  - uid: 6337
+  - uid: 5785
     components:
     - type: Transform
       pos: 1.5,52.5
       parent: 2
-  - uid: 6343
+  - uid: 5786
     components:
     - type: Transform
       pos: -33.5,-0.5
       parent: 2
-  - uid: 6344
+  - uid: 5787
     components:
     - type: Transform
       pos: -35.5,-1.5
       parent: 2
-  - uid: 6345
+  - uid: 5788
     components:
     - type: Transform
       pos: -26.5,42.5
       parent: 2
-  - uid: 6353
+  - uid: 5789
     components:
     - type: Transform
       pos: -55.5,7.5
       parent: 2
-  - uid: 6355
+  - uid: 5790
     components:
     - type: Transform
       pos: -2.5,-16.5
       parent: 2
-  - uid: 6356
+  - uid: 5791
     components:
     - type: Transform
       pos: -4.5,-15.5
       parent: 2
-  - uid: 6357
+  - uid: 5792
     components:
     - type: Transform
       pos: -25.5,43.5
       parent: 2
-  - uid: 6360
+  - uid: 5793
     components:
     - type: Transform
       pos: -56.5,-8.5
       parent: 2
-  - uid: 6362
+  - uid: 5794
     components:
     - type: Transform
       pos: -44.5,46.5
       parent: 2
-  - uid: 6367
+  - uid: 5795
     components:
     - type: Transform
       pos: 18.5,-0.5
       parent: 2
-  - uid: 6370
+  - uid: 5796
     components:
     - type: Transform
       pos: -51.5,37.5
       parent: 2
-  - uid: 6371
+  - uid: 5797
     components:
     - type: Transform
       pos: -62.5,-21.5
       parent: 2
-  - uid: 6377
+  - uid: 5798
     components:
     - type: Transform
       pos: -33.5,0.5
       parent: 2
-  - uid: 6378
+  - uid: 5799
     components:
     - type: Transform
       pos: -55.5,9.5
       parent: 2
-  - uid: 6382
+  - uid: 5800
     components:
     - type: Transform
       pos: -45.5,-22.5
       parent: 2
-  - uid: 6386
+  - uid: 5801
     components:
     - type: Transform
       pos: -47.5,-19.5
       parent: 2
-  - uid: 6390
+  - uid: 5802
     components:
     - type: Transform
       pos: -0.5,-14.5
       parent: 2
-  - uid: 6397
+  - uid: 5803
     components:
     - type: Transform
       pos: -31.5,27.5
       parent: 2
-  - uid: 6401
+  - uid: 5804
     components:
     - type: Transform
       pos: -47.5,-20.5
       parent: 2
-  - uid: 6402
+  - uid: 5805
     components:
     - type: Transform
       pos: -54.5,-26.5
       parent: 2
-  - uid: 6410
+  - uid: 5806
     components:
     - type: Transform
       pos: -46.5,-21.5
       parent: 2
-  - uid: 6412
+  - uid: 5807
     components:
     - type: Transform
       pos: -34.5,-19.5
       parent: 2
-  - uid: 6413
+  - uid: 5808
     components:
     - type: Transform
       pos: -34.5,-0.5
       parent: 2
-  - uid: 6414
+  - uid: 5809
     components:
     - type: Transform
       pos: -36.5,2.5
       parent: 2
-  - uid: 6416
+  - uid: 5810
     components:
     - type: Transform
       pos: -48.5,-21.5
       parent: 2
-  - uid: 6417
+  - uid: 5811
     components:
     - type: Transform
       pos: -30.5,43.5
       parent: 2
-  - uid: 6418
+  - uid: 5812
     components:
     - type: Transform
       pos: -35.5,0.5
       parent: 2
-  - uid: 6420
+  - uid: 5813
     components:
     - type: Transform
       pos: -32.5,43.5
       parent: 2
-  - uid: 6421
+  - uid: 5814
     components:
     - type: Transform
       pos: -4.5,12.5
       parent: 2
-  - uid: 6424
+  - uid: 5815
     components:
     - type: Transform
       pos: -48.5,-18.5
       parent: 2
-  - uid: 6432
+  - uid: 5816
     components:
     - type: Transform
       pos: 18.5,-1.5
       parent: 2
-  - uid: 6433
+  - uid: 5817
     components:
     - type: Transform
       pos: -50.5,10.5
       parent: 2
-  - uid: 6436
+  - uid: 5818
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: -49.5,-14.5
       parent: 2
-  - uid: 6438
+  - uid: 5819
     components:
     - type: Transform
       pos: -32.5,30.5
       parent: 2
-  - uid: 6439
+  - uid: 5820
     components:
     - type: Transform
       pos: 1.5,1.5
       parent: 2
-  - uid: 6441
+  - uid: 5821
     components:
     - type: Transform
       pos: -51.5,35.5
       parent: 2
-  - uid: 6447
+  - uid: 5822
     components:
     - type: Transform
       pos: -48.5,8.5
       parent: 2
 - proto: N14RugMat
   entities:
-  - uid: 5574
+  - uid: 5823
     components:
     - type: Transform
       pos: -49.5,-41.5
       parent: 2
-  - uid: 5575
+  - uid: 5824
     components:
     - type: Transform
       pos: -28.5,-41.5
       parent: 2
 - proto: N14TableCounterMetal
   entities:
-  - uid: 5576
+  - uid: 5825
     components:
     - type: Transform
       pos: -96.5,-9.5
       parent: 2
-  - uid: 5577
+  - uid: 5826
     components:
     - type: Transform
       pos: -94.5,-9.5
       parent: 2
-  - uid: 5578
+  - uid: 5827
     components:
     - type: Transform
       pos: -95.5,-9.5
       parent: 2
 - proto: N14TableDeskWood2
   entities:
-  - uid: 5579
+  - uid: 5828
     components:
     - type: Transform
       pos: -33.5,-36.5
       parent: 2
-  - uid: 5580
+  - uid: 5829
     components:
     - type: Transform
       pos: -31.5,-45.5
       parent: 2
-  - uid: 5581
+  - uid: 5830
     components:
     - type: Transform
       pos: -47.5,-45.5
       parent: 2
-  - uid: 5582
+  - uid: 5831
     components:
     - type: Transform
       pos: -46.5,-36.5
       parent: 2
 - proto: N14TableWoodLow
   entities:
-  - uid: 5583
+  - uid: 5832
     components:
     - type: Transform
       pos: -42.5,-50.5
       parent: 2
-  - uid: 5584
+  - uid: 5833
     components:
     - type: Transform
       pos: -35.5,-50.5
       parent: 2
 - proto: N14TableWoodRound
   entities:
-  - uid: 5585
+  - uid: 5834
     components:
     - type: Transform
       pos: -43.5,-38.5
       parent: 2
-  - uid: 5586
+  - uid: 5835
     components:
     - type: Transform
       pos: -30.5,-38.5
       parent: 2
 - proto: OreBox
   entities:
-  - uid: 5587
+  - uid: 5836
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
@@ -32506,91 +32513,91 @@ entities:
       parent: 2
 - proto: OreProcessor
   entities:
-  - uid: 5588
+  - uid: 5837
     components:
     - type: Transform
       pos: -78.5,-4.5
       parent: 2
 - proto: PaperBin20
   entities:
-  - uid: 5589
+  - uid: 5838
     components:
     - type: Transform
       pos: -102.5,-4.5
       parent: 2
 - proto: PaperOffice
   entities:
-  - uid: 5590
+  - uid: 5839
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: -42.598938,-50.442093
       parent: 2
-  - uid: 5591
+  - uid: 5840
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: -42.552063,-50.488968
       parent: 2
-  - uid: 5592
+  - uid: 5841
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: -35.380188,-50.488968
       parent: 2
-  - uid: 5593
+  - uid: 5842
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: -35.458313,-50.426468
       parent: 2
-  - uid: 5594
+  - uid: 5843
     components:
     - type: Transform
       pos: -47.112984,-45.32425
       parent: 2
-  - uid: 5595
+  - uid: 5844
     components:
     - type: Transform
       pos: -47.06611,-45.38675
       parent: 2
-  - uid: 5596
+  - uid: 5845
     components:
     - type: Transform
       pos: -30.919281,-45.339874
       parent: 2
-  - uid: 5597
+  - uid: 5846
     components:
     - type: Transform
       pos: -30.981781,-45.402374
       parent: 2
-  - uid: 5598
+  - uid: 5847
     components:
     - type: Transform
       pos: -33.100975,-36.324993
       parent: 2
-  - uid: 5599
+  - uid: 5848
     components:
     - type: Transform
       pos: -32.975975,-36.37187
       parent: 2
-  - uid: 5600
+  - uid: 5849
     components:
     - type: Transform
       pos: -45.9291,-36.324993
       parent: 2
-  - uid: 5601
+  - uid: 5850
     components:
     - type: Transform
       pos: -46.038475,-36.37187
       parent: 2
-  - uid: 5602
+  - uid: 5851
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: -91.53681,1.9565601
       parent: 2
-  - uid: 5603
+  - uid: 5852
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
@@ -32598,334 +32605,334 @@ entities:
       parent: 2
 - proto: PlasmaChemistryVial
   entities:
-  - uid: 5604
+  - uid: 5853
     components:
     - type: Transform
       pos: -82.04829,6.665659
       parent: 2
 - proto: PlayerStationAi
   entities:
-  - uid: 5605
+  - uid: 5854
     components:
     - type: Transform
       pos: -80.5,-8.5
       parent: 2
 - proto: PlushieMothRandom
   entities:
-  - uid: 5606
+  - uid: 5855
     components:
     - type: Transform
       pos: -91.477554,-6.4235115
       parent: 2
 - proto: PottedPlantRandom
   entities:
-  - uid: 5607
+  - uid: 5856
     components:
     - type: Transform
       pos: -92.5,-1.5
       parent: 2
-  - uid: 5608
+  - uid: 5857
     components:
     - type: Transform
       pos: -92.5,-4.5
       parent: 2
-  - uid: 5609
+  - uid: 5858
     components:
     - type: Transform
       pos: -36.5,-39.5
       parent: 2
-  - uid: 5610
+  - uid: 5859
     components:
     - type: Transform
       pos: -30.5,-40.5
       parent: 2
-  - uid: 5611
+  - uid: 5860
     components:
     - type: Transform
       pos: -34.5,-43.5
       parent: 2
-  - uid: 5612
+  - uid: 5861
     components:
     - type: Transform
       pos: -43.5,-43.5
       parent: 2
-  - uid: 5613
+  - uid: 5862
     components:
     - type: Transform
       pos: -47.5,-40.5
       parent: 2
-  - uid: 5614
+  - uid: 5863
     components:
     - type: Transform
       pos: -37.5,-46.5
       parent: 2
-  - uid: 5615
+  - uid: 5864
     components:
     - type: Transform
       pos: -40.5,-50.5
       parent: 2
-  - uid: 5616
+  - uid: 5865
     components:
     - type: Transform
       pos: -84.5,-4.5
       parent: 2
-  - uid: 5617
+  - uid: 5866
     components:
     - type: Transform
       pos: -84.5,-1.5
       parent: 2
 - proto: PowerCellRecharger
   entities:
-  - uid: 5618
+  - uid: 5867
     components:
     - type: Transform
       pos: -80.5,1.5
       parent: 2
 - proto: Poweredlight
   entities:
-  - uid: 5619
+  - uid: 5868
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: -79.5,-4.5
       parent: 2
-  - uid: 5620
+  - uid: 5869
     components:
     - type: Transform
       pos: -75.5,-1.5
       parent: 2
-  - uid: 5621
+  - uid: 5870
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: -0.5,12.5
       parent: 2
-  - uid: 5622
+  - uid: 5871
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: -60.5,-36.5
       parent: 2
-  - uid: 5623
+  - uid: 5872
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: -38.5,-29.5
       parent: 2
-  - uid: 5624
+  - uid: 5873
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: -38.5,21.5
       parent: 2
-  - uid: 5625
+  - uid: 5874
     components:
     - type: Transform
       pos: -41.5,-2.5
       parent: 2
-  - uid: 5626
+  - uid: 5875
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: -59.5,-20.5
       parent: 2
-  - uid: 5627
+  - uid: 5876
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: -38.5,-19.5
       parent: 2
-  - uid: 5628
+  - uid: 5877
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: -38.5,31.5
       parent: 2
-  - uid: 5629
+  - uid: 5878
     components:
     - type: Transform
       pos: -61.5,-2.5
       parent: 2
-  - uid: 5630
+  - uid: 5879
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: -0.5,2.5
       parent: 2
-  - uid: 5631
+  - uid: 5880
     components:
     - type: Transform
       pos: -8.5,41.5
       parent: 2
-  - uid: 5632
+  - uid: 5881
     components:
     - type: Transform
       pos: -15.5,-2.5
       parent: 2
-  - uid: 5633
+  - uid: 5882
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: -38.5,4.5
       parent: 2
-  - uid: 5634
+  - uid: 5883
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: -0.5,39.5
       parent: 2
-  - uid: 5635
+  - uid: 5884
     components:
     - type: Transform
       pos: -5.5,-2.5
       parent: 2
-  - uid: 5636
+  - uid: 5885
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: -59.5,-10.5
       parent: 2
-  - uid: 5637
+  - uid: 5886
     components:
     - type: Transform
       pos: -27.5,41.5
       parent: 2
-  - uid: 5638
+  - uid: 5887
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: -38.5,-9.5
       parent: 2
-  - uid: 5639
+  - uid: 5888
     components:
     - type: Transform
       pos: -51.5,-2.5
       parent: 2
-  - uid: 5640
+  - uid: 5889
     components:
     - type: Transform
       pos: -31.5,-2.5
       parent: 2
-  - uid: 5641
+  - uid: 5890
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: -60.5,-40.5
       parent: 2
-  - uid: 5642
+  - uid: 5891
     components:
     - type: Transform
       pos: -37.5,41.5
       parent: 2
-  - uid: 5643
+  - uid: 5892
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: -98.5,-0.5
       parent: 2
-  - uid: 5644
+  - uid: 5893
     components:
     - type: Transform
       pos: -92.5,-1.5
       parent: 2
-  - uid: 5645
+  - uid: 5894
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: -92.5,-4.5
       parent: 2
-  - uid: 5646
+  - uid: 5895
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: -84.5,-4.5
       parent: 2
-  - uid: 5647
+  - uid: 5896
     components:
     - type: Transform
       pos: -84.5,-1.5
       parent: 2
-  - uid: 5648
+  - uid: 5897
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: -91.5,6.5
       parent: 2
-  - uid: 5649
+  - uid: 5898
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: -81.5,0.5
       parent: 2
-  - uid: 5650
+  - uid: 5899
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: -80.5,6.5
       parent: 2
-  - uid: 5651
+  - uid: 5900
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: -93.5,-12.5
       parent: 2
-  - uid: 5652
+  - uid: 5901
     components:
     - type: Transform
       pos: -80.5,-6.5
       parent: 2
-  - uid: 5653
+  - uid: 5902
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: -84.5,0.5
       parent: 2
-  - uid: 5654
+  - uid: 5903
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: -95.5,0.5
       parent: 2
-  - uid: 5655
+  - uid: 5904
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: -36.5,-40.5
       parent: 2
-  - uid: 5656
+  - uid: 5905
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: -41.5,-43.5
       parent: 2
-  - uid: 5657
+  - uid: 5906
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: -33.5,-43.5
       parent: 2
-  - uid: 5658
+  - uid: 5907
     components:
     - type: Transform
       pos: -31.5,-40.5
       parent: 2
-  - uid: 5659
+  - uid: 5908
     components:
     - type: Transform
       pos: -46.5,-40.5
       parent: 2
-  - uid: 5660
+  - uid: 5909
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: -44.5,-43.5
       parent: 2
-  - uid: 5661
+  - uid: 5910
     components:
     - type: Transform
       pos: -40.5,-46.5
       parent: 2
-  - uid: 5662
+  - uid: 5911
     components:
     - type: Transform
       rot: 3.141592653589793 rad
@@ -32933,54 +32940,54 @@ entities:
       parent: 2
 - proto: PoweredLightColoredFrostyBlue
   entities:
-  - uid: 5663
+  - uid: 5912
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: -102.5,-4.5
       parent: 2
-  - uid: 5664
+  - uid: 5913
     components:
     - type: Transform
       pos: -94.5,3.5
       parent: 2
-  - uid: 5665
+  - uid: 5914
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: -85.5,6.5
       parent: 2
-  - uid: 5666
+  - uid: 5915
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: -42.5,-50.5
       parent: 2
-  - uid: 5667
+  - uid: 5916
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: -45.5,-47.5
       parent: 2
-  - uid: 5668
+  - uid: 5917
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: -43.5,-38.5
       parent: 2
-  - uid: 5669
+  - uid: 5918
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: -30.5,-38.5
       parent: 2
-  - uid: 5670
+  - uid: 5919
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: -32.5,-47.5
       parent: 2
-  - uid: 5671
+  - uid: 5920
     components:
     - type: Transform
       rot: 3.141592653589793 rad
@@ -32988,13 +32995,13 @@ entities:
       parent: 2
 - proto: PoweredLightPostSmall
   entities:
-  - uid: 5672
+  - uid: 5921
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: -64.5,-49.5
       parent: 2
-  - uid: 5673
+  - uid: 5922
     components:
     - type: Transform
       rot: 3.141592653589793 rad
@@ -33002,47 +33009,47 @@ entities:
       parent: 2
 - proto: PoweredlightSodium
   entities:
-  - uid: 5674
+  - uid: 5923
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: -92.5,-8.5
       parent: 2
-  - uid: 5675
+  - uid: 5924
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: -85.5,-9.5
       parent: 2
-  - uid: 5676
+  - uid: 5925
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: -46.5,-38.5
       parent: 2
-  - uid: 5677
+  - uid: 5926
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: -45.5,-45.5
       parent: 2
-  - uid: 5678
+  - uid: 5927
     components:
     - type: Transform
       pos: -42.5,-49.5
       parent: 2
-  - uid: 5679
+  - uid: 5928
     components:
     - type: Transform
       pos: -35.5,-49.5
       parent: 2
-  - uid: 5680
+  - uid: 5929
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: -32.5,-45.5
       parent: 2
-  - uid: 5681
+  - uid: 5930
     components:
     - type: Transform
       rot: 3.141592653589793 rad
@@ -33050,48 +33057,48 @@ entities:
       parent: 2
 - proto: PoweredSmallLight
   entities:
-  - uid: 5682
+  - uid: 5931
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: -95.5,6.5
       parent: 2
-  - uid: 5683
+  - uid: 5932
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: -91.5,-10.5
       parent: 2
-  - uid: 5684
+  - uid: 5933
     components:
     - type: Transform
       pos: -72.5,-2.5
       parent: 2
-  - uid: 5685
+  - uid: 5934
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: -38.5,-37.5
       parent: 2
-  - uid: 5686
+  - uid: 5935
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: -50.5,-40.5
       parent: 2
-  - uid: 5687
+  - uid: 5936
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: -27.5,-40.5
       parent: 2
-  - uid: 5688
+  - uid: 5937
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: -42.5,-47.5
       parent: 2
-  - uid: 5689
+  - uid: 5938
     components:
     - type: Transform
       rot: 3.141592653589793 rad
@@ -33099,13 +33106,13 @@ entities:
       parent: 2
 - proto: PoweredWarmSmallLight
   entities:
-  - uid: 5690
+  - uid: 5939
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: -81.5,-15.5
       parent: 2
-  - uid: 5691
+  - uid: 5940
     components:
     - type: Transform
       rot: 3.141592653589793 rad
@@ -33113,25 +33120,25 @@ entities:
       parent: 2
 - proto: RailingCornerDeltaVGrey
   entities:
-  - uid: 5692
+  - uid: 5941
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: -56.5,-36.5
       parent: 2
-  - uid: 5693
+  - uid: 5942
     components:
     - type: Transform
       pos: -56.5,-40.5
       parent: 2
 - proto: RailingCornerSmallDeltaVGrey
   entities:
-  - uid: 5694
+  - uid: 5943
     components:
     - type: Transform
       pos: -60.5,-36.5
       parent: 2
-  - uid: 5695
+  - uid: 5944
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
@@ -33139,535 +33146,535 @@ entities:
       parent: 2
 - proto: RailingDeltaVGrey
   entities:
-  - uid: 5696
+  - uid: 5945
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: -13.5,41.5
       parent: 2
-  - uid: 5697
+  - uid: 5946
     components:
     - type: Transform
       pos: -57.5,-40.5
       parent: 2
-  - uid: 5698
+  - uid: 5947
     components:
     - type: Transform
       pos: -16.5,-3.5
       parent: 2
-  - uid: 5699
+  - uid: 5948
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: -60.5,-30.5
       parent: 2
-  - uid: 5700
+  - uid: 5949
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: -12.5,41.5
       parent: 2
-  - uid: 5701
+  - uid: 5950
     components:
     - type: Transform
       pos: -22.5,-3.5
       parent: 2
-  - uid: 5702
+  - uid: 5951
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: -14.5,41.5
       parent: 2
-  - uid: 5703
+  - uid: 5952
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: -59.5,-33.5
       parent: 2
-  - uid: 5704
+  - uid: 5953
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: -0.5,25.5
       parent: 2
-  - uid: 5705
+  - uid: 5954
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: -16.5,-2.5
       parent: 2
-  - uid: 5706
+  - uid: 5955
     components:
     - type: Transform
       pos: -19.5,-3.5
       parent: 2
-  - uid: 5707
+  - uid: 5956
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: -59.5,-31.5
       parent: 2
-  - uid: 5708
+  - uid: 5957
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: -17.5,-2.5
       parent: 2
-  - uid: 5709
+  - uid: 5958
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: -9.5,41.5
       parent: 2
-  - uid: 5710
+  - uid: 5959
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: -1.5,34.5
       parent: 2
-  - uid: 5711
+  - uid: 5960
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: -0.5,28.5
       parent: 2
-  - uid: 5712
+  - uid: 5961
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: -60.5,-29.5
       parent: 2
-  - uid: 5713
+  - uid: 5962
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: -1.5,25.5
       parent: 2
-  - uid: 5714
+  - uid: 5963
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: -60.5,-33.5
       parent: 2
-  - uid: 5715
+  - uid: 5964
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: -60.5,-34.5
       parent: 2
-  - uid: 5716
+  - uid: 5965
     components:
     - type: Transform
       pos: -19.5,40.5
       parent: 2
-  - uid: 5717
+  - uid: 5966
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: -60.5,-35.5
       parent: 2
-  - uid: 5718
+  - uid: 5967
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: -1.5,28.5
       parent: 2
-  - uid: 5719
+  - uid: 5968
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: -23.5,-2.5
       parent: 2
-  - uid: 5720
+  - uid: 5969
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: -18.5,41.5
       parent: 2
-  - uid: 5721
+  - uid: 5970
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: -16.5,41.5
       parent: 2
-  - uid: 5722
+  - uid: 5971
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: -0.5,24.5
       parent: 2
-  - uid: 5723
+  - uid: 5972
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: -24.5,-2.5
       parent: 2
-  - uid: 5724
+  - uid: 5973
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: -11.5,41.5
       parent: 2
-  - uid: 5725
+  - uid: 5974
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: -25.5,-2.5
       parent: 2
-  - uid: 5726
+  - uid: 5975
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: -1.5,30.5
       parent: 2
-  - uid: 5727
+  - uid: 5976
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: -1.5,26.5
       parent: 2
-  - uid: 5728
+  - uid: 5977
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: -18.5,-2.5
       parent: 2
-  - uid: 5729
+  - uid: 5978
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: -59.5,-34.5
       parent: 2
-  - uid: 5730
+  - uid: 5979
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: -20.5,-2.5
       parent: 2
-  - uid: 5731
+  - uid: 5980
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: -19.5,-2.5
       parent: 2
-  - uid: 5732
+  - uid: 5981
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: -1.5,29.5
       parent: 2
-  - uid: 5733
+  - uid: 5982
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: -1.5,33.5
       parent: 2
-  - uid: 5734
+  - uid: 5983
     components:
     - type: Transform
       pos: -17.5,40.5
       parent: 2
-  - uid: 5735
+  - uid: 5984
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: -22.5,-2.5
       parent: 2
-  - uid: 5736
+  - uid: 5985
     components:
     - type: Transform
       pos: -25.5,-3.5
       parent: 2
-  - uid: 5737
+  - uid: 5986
     components:
     - type: Transform
       pos: -12.5,40.5
       parent: 2
-  - uid: 5738
+  - uid: 5987
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: -60.5,-31.5
       parent: 2
-  - uid: 5739
+  - uid: 5988
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: -59.5,-32.5
       parent: 2
-  - uid: 5740
+  - uid: 5989
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: -60.5,-32.5
       parent: 2
-  - uid: 5741
+  - uid: 5990
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: -0.5,32.5
       parent: 2
-  - uid: 5742
+  - uid: 5991
     components:
     - type: Transform
       pos: -20.5,-3.5
       parent: 2
-  - uid: 5743
+  - uid: 5992
     components:
     - type: Transform
       pos: -11.5,40.5
       parent: 2
-  - uid: 5744
+  - uid: 5993
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: -57.5,-36.5
       parent: 2
-  - uid: 5745
+  - uid: 5994
     components:
     - type: Transform
       pos: -20.5,40.5
       parent: 2
-  - uid: 5746
+  - uid: 5995
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: -0.5,33.5
       parent: 2
-  - uid: 5747
+  - uid: 5996
     components:
     - type: Transform
       pos: -17.5,-3.5
       parent: 2
-  - uid: 5748
+  - uid: 5997
     components:
     - type: Transform
       pos: -9.5,40.5
       parent: 2
-  - uid: 5749
+  - uid: 5998
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: -59.5,-29.5
       parent: 2
-  - uid: 5750
+  - uid: 5999
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: -0.5,29.5
       parent: 2
-  - uid: 5751
+  - uid: 6000
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: -1.5,31.5
       parent: 2
-  - uid: 5752
+  - uid: 6001
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: -58.5,-36.5
       parent: 2
-  - uid: 5753
+  - uid: 6002
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: -21.5,-2.5
       parent: 2
-  - uid: 5754
+  - uid: 6003
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: -10.5,41.5
       parent: 2
-  - uid: 5755
+  - uid: 6004
     components:
     - type: Transform
       pos: -21.5,-3.5
       parent: 2
-  - uid: 5756
+  - uid: 6005
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: -0.5,26.5
       parent: 2
-  - uid: 5757
+  - uid: 6006
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: -0.5,34.5
       parent: 2
-  - uid: 5758
+  - uid: 6007
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: -0.5,27.5
       parent: 2
-  - uid: 5759
+  - uid: 6008
     components:
     - type: Transform
       pos: -15.5,40.5
       parent: 2
-  - uid: 5760
+  - uid: 6009
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: -56.5,-39.5
       parent: 2
-  - uid: 5761
+  - uid: 6010
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: -1.5,24.5
       parent: 2
-  - uid: 5762
+  - uid: 6011
     components:
     - type: Transform
       pos: -10.5,40.5
       parent: 2
-  - uid: 5763
+  - uid: 6012
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: -1.5,21.5
       parent: 2
-  - uid: 5764
+  - uid: 6013
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: -0.5,30.5
       parent: 2
-  - uid: 5765
+  - uid: 6014
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: -20.5,41.5
       parent: 2
-  - uid: 5766
+  - uid: 6015
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: -1.5,32.5
       parent: 2
-  - uid: 5767
+  - uid: 6016
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: -15.5,41.5
       parent: 2
-  - uid: 5768
+  - uid: 6017
     components:
     - type: Transform
       pos: -16.5,40.5
       parent: 2
-  - uid: 5769
+  - uid: 6018
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: -0.5,31.5
       parent: 2
-  - uid: 5770
+  - uid: 6019
     components:
     - type: Transform
       pos: -13.5,40.5
       parent: 2
-  - uid: 5771
+  - uid: 6020
     components:
     - type: Transform
       pos: -18.5,-3.5
       parent: 2
-  - uid: 5772
+  - uid: 6021
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: -56.5,-38.5
       parent: 2
-  - uid: 5773
+  - uid: 6022
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: -0.5,21.5
       parent: 2
-  - uid: 5774
+  - uid: 6023
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: -0.5,22.5
       parent: 2
-  - uid: 5775
+  - uid: 6024
     components:
     - type: Transform
       pos: -14.5,40.5
       parent: 2
-  - uid: 5776
+  - uid: 6025
     components:
     - type: Transform
       pos: -18.5,40.5
       parent: 2
-  - uid: 5777
+  - uid: 6026
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: -1.5,22.5
       parent: 2
-  - uid: 5778
+  - uid: 6027
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: -59.5,-30.5
       parent: 2
-  - uid: 5779
+  - uid: 6028
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: -1.5,27.5
       parent: 2
-  - uid: 5780
+  - uid: 6029
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: -56.5,-37.5
       parent: 2
-  - uid: 5781
+  - uid: 6030
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: -0.5,23.5
       parent: 2
-  - uid: 5782
+  - uid: 6031
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: -19.5,41.5
       parent: 2
-  - uid: 5783
+  - uid: 6032
     components:
     - type: Transform
       pos: -58.5,-40.5
       parent: 2
-  - uid: 5784
+  - uid: 6033
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: -59.5,-35.5
       parent: 2
-  - uid: 5785
+  - uid: 6034
     components:
     - type: Transform
       pos: -23.5,-3.5
       parent: 2
-  - uid: 5786
+  - uid: 6035
     components:
     - type: Transform
       pos: -24.5,-3.5
       parent: 2
-  - uid: 5787
+  - uid: 6036
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: -17.5,41.5
       parent: 2
-  - uid: 5788
+  - uid: 6037
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
@@ -33675,205 +33682,205 @@ entities:
       parent: 2
 - proto: RandomVending
   entities:
-  - uid: 5789
+  - uid: 6038
     components:
     - type: Transform
       pos: -81.5,-4.5
       parent: 2
-  - uid: 5790
+  - uid: 6039
     components:
     - type: Transform
       pos: -81.5,-1.5
       parent: 2
-  - uid: 5791
+  - uid: 6040
     components:
     - type: Transform
       pos: -95.5,-1.5
       parent: 2
-  - uid: 5792
+  - uid: 6041
     components:
     - type: Transform
       pos: -95.5,-4.5
       parent: 2
 - proto: RandomVendingClothing
   entities:
-  - uid: 5793
+  - uid: 6042
     components:
     - type: Transform
       pos: -34.5,-40.5
       parent: 2
-  - uid: 5794
+  - uid: 6043
     components:
     - type: Transform
       pos: -43.5,-40.5
       parent: 2
-  - uid: 5795
+  - uid: 6044
     components:
     - type: Transform
       pos: -40.5,-48.5
       parent: 2
 - proto: RandomVendingDrinks
   entities:
-  - uid: 5796
+  - uid: 6045
     components:
     - type: Transform
       pos: -40.5,-39.5
       parent: 2
 - proto: RandomVendingSnacks
   entities:
-  - uid: 5797
+  - uid: 6046
     components:
     - type: Transform
       pos: -37.5,-44.5
       parent: 2
 - proto: Recycler
   entities:
-  - uid: 5798
+  - uid: 6047
     components:
     - type: Transform
       pos: -78.5,-1.5
       parent: 2
 - proto: ReinforcedGirder
   entities:
-  - uid: 5799
+  - uid: 6048
     components:
     - type: Transform
       pos: -61.5,-1.5
       parent: 2
-  - uid: 5800
+  - uid: 6049
     components:
     - type: Transform
       pos: -51.5,-1.5
       parent: 2
-  - uid: 5801
+  - uid: 6050
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: -15.5,-1.5
       parent: 2
-  - uid: 5802
+  - uid: 6051
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: -37.5,4.5
       parent: 2
-  - uid: 5803
+  - uid: 6052
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: -61.5,-38.5
       parent: 2
-  - uid: 5804
+  - uid: 6053
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: -31.5,-1.5
       parent: 2
-  - uid: 5805
+  - uid: 6054
     components:
     - type: Transform
       pos: -37.5,-9.5
       parent: 2
-  - uid: 5806
+  - uid: 6055
     components:
     - type: Transform
       pos: -37.5,-29.5
       parent: 2
-  - uid: 5807
+  - uid: 6056
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: -37.5,21.5
       parent: 2
-  - uid: 5808
+  - uid: 6057
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: 0.5,39.5
       parent: 2
-  - uid: 5809
+  - uid: 6058
     components:
     - type: Transform
       pos: -58.5,-10.5
       parent: 2
-  - uid: 5810
+  - uid: 6059
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: -37.5,31.5
       parent: 2
-  - uid: 5811
+  - uid: 6060
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: -5.5,-1.5
       parent: 2
-  - uid: 5812
+  - uid: 6061
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: 0.5,2.5
       parent: 2
-  - uid: 5813
+  - uid: 6062
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: -27.5,42.5
       parent: 2
-  - uid: 5814
+  - uid: 6063
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: -8.5,42.5
       parent: 2
-  - uid: 5815
+  - uid: 6064
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: -37.5,42.5
       parent: 2
-  - uid: 5816
+  - uid: 6065
     components:
     - type: Transform
       pos: -37.5,-19.5
       parent: 2
-  - uid: 5817
+  - uid: 6066
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: 0.5,12.5
       parent: 2
-  - uid: 5818
+  - uid: 6067
     components:
     - type: Transform
       pos: -41.5,-1.5
       parent: 2
-  - uid: 5819
+  - uid: 6068
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: -61.5,-40.5
       parent: 2
-  - uid: 5820
+  - uid: 6069
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: -61.5,-36.5
       parent: 2
-  - uid: 5821
+  - uid: 6070
     components:
     - type: Transform
       pos: -58.5,-20.5
       parent: 2
 - proto: ReinforcedPlasmaWindow
   entities:
-  - uid: 5822
+  - uid: 6071
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: -84.5,-13.5
       parent: 2
-  - uid: 5823
+  - uid: 6072
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
@@ -33881,28 +33888,28 @@ entities:
       parent: 2
 - proto: ResearchAndDevelopmentServer
   entities:
-  - uid: 5824
+  - uid: 6073
     components:
     - type: Transform
       pos: -96.5,2.5
       parent: 2
 - proto: SalvageMagnet
   entities:
-  - uid: 5825
+  - uid: 6074
     components:
     - type: Transform
       pos: -59.5,-52.5
       parent: 2
 - proto: SecureCabinet
   entities:
-  - uid: 5826
+  - uid: 6075
     components:
     - type: Transform
       pos: -44.7416,-36.5
       parent: 2
     - type: Lock
       locked: False
-  - uid: 5827
+  - uid: 6076
     components:
     - type: Transform
       pos: -31.7416,-36.5
@@ -33911,7 +33918,7 @@ entities:
       locked: False
 - proto: SecureCabinetCaptain
   entities:
-  - uid: 5828
+  - uid: 6077
     components:
     - type: Transform
       pos: -101.5,-4.5
@@ -33920,21 +33927,21 @@ entities:
       locked: False
 - proto: SecurityTechFab
   entities:
-  - uid: 5829
+  - uid: 6078
     components:
     - type: Transform
       pos: -98.5,-0.5
       parent: 2
 - proto: ServiceTechFab
   entities:
-  - uid: 5830
+  - uid: 6079
     components:
     - type: Transform
       pos: -90.5,-4.5
       parent: 2
 - proto: Shower
   entities:
-  - uid: 5831
+  - uid: 6080
     components:
     - type: Transform
       rot: 3.141592653589793 rad
@@ -33942,7 +33949,7 @@ entities:
       parent: 2
     - type: Fixtures
       fixtures: {}
-  - uid: 5832
+  - uid: 6081
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
@@ -33952,7 +33959,7 @@ entities:
       fixtures: {}
 - proto: SignalSwitchDirectional
   entities:
-  - uid: 5833
+  - uid: 6082
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
@@ -33960,12 +33967,12 @@ entities:
       parent: 2
     - type: DeviceLinkSource
       linkedPorts:
-        3677:
+        3979:
         - - On
           - Open
         - - Off
           - Close
-        3676:
+        3978:
         - - On
           - Open
         - - Off
@@ -33977,7 +33984,7 @@ entities:
       fixtures: {}
 - proto: SignPlaque
   entities:
-  - uid: 5834
+  - uid: 6083
     components:
     - type: MetaData
       desc: As the twins bore together the chthonic as much as the ouranic, so too do these residents of Gemini live on the precipice between safety and the bright burn of Kronos.
@@ -33990,25 +33997,25 @@ entities:
       fixtures: {}
 - proto: Sink
   entities:
-  - uid: 5835
+  - uid: 6084
     components:
     - type: Transform
       pos: -50.5,-40.5
       parent: 2
-  - uid: 5836
+  - uid: 6085
     components:
     - type: Transform
       pos: -27.5,-40.5
       parent: 2
 - proto: SinkWide
   entities:
-  - uid: 5837
+  - uid: 6086
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: -93.5,-10.5
       parent: 2
-  - uid: 5838
+  - uid: 6087
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
@@ -34016,14 +34023,14 @@ entities:
       parent: 2
 - proto: SmartFridgeFood
   entities:
-  - uid: 5839
+  - uid: 6088
     components:
     - type: Transform
       pos: -93.5,-9.5
       parent: 2
 - proto: SmartFridgeMedical
   entities:
-  - uid: 5840
+  - uid: 6089
     components:
     - type: Transform
       pos: -81.5,4.5
@@ -34032,7 +34039,7 @@ entities:
     - DatasetVocalizer
 - proto: SpareIdCabinetFilled
   entities:
-  - uid: 5841
+  - uid: 6090
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
@@ -34044,518 +34051,512 @@ entities:
       fixtures: {}
 - proto: SpawnPointAdminAssistant
   entities:
-  - uid: 5842
+  - uid: 6091
     components:
     - type: Transform
       pos: -97.5,-3.5
       parent: 2
 - proto: SpawnPointAtmos
   entities:
-  - uid: 5843
+  - uid: 6092
     components:
     - type: Transform
       pos: -38.5,-50.5
       parent: 2
 - proto: SpawnPointBartender
   entities:
-  - uid: 5844
+  - uid: 6093
     components:
     - type: Transform
       pos: -38.5,-50.5
       parent: 2
 - proto: SpawnPointBorg
   entities:
-  - uid: 5845
+  - uid: 6094
     components:
     - type: Transform
       pos: -38.5,-50.5
       parent: 2
 - proto: SpawnPointBotanist
   entities:
-  - uid: 5846
+  - uid: 6095
     components:
     - type: Transform
       pos: -38.5,-50.5
       parent: 2
 - proto: SpawnPointBoxer
   entities:
-  - uid: 5847
+  - uid: 6096
     components:
     - type: Transform
       pos: -38.5,-50.5
       parent: 2
 - proto: SpawnPointBrigmedic
   entities:
-  - uid: 5848
+  - uid: 6097
     components:
     - type: Transform
       pos: -38.5,-50.5
       parent: 2
 - proto: SpawnPointCaptain
   entities:
-  - uid: 5849
+  - uid: 6098
     components:
     - type: Transform
       pos: -98.5,-4.5
       parent: 2
 - proto: SpawnPointCargoAssistant
   entities:
-  - uid: 5850
+  - uid: 6099
     components:
     - type: Transform
       pos: -38.5,-50.5
       parent: 2
 - proto: SpawnPointCargoTechnician
   entities:
-  - uid: 5851
+  - uid: 6100
     components:
     - type: Transform
       pos: -38.5,-50.5
       parent: 2
 - proto: SpawnPointChaplain
   entities:
-  - uid: 5852
+  - uid: 6101
     components:
     - type: Transform
       pos: -38.5,-50.5
       parent: 2
 - proto: SpawnPointChef
   entities:
-  - uid: 5853
+  - uid: 6102
     components:
     - type: Transform
       pos: -38.5,-50.5
       parent: 2
 - proto: SpawnPointChemist
   entities:
-  - uid: 5854
+  - uid: 6103
     components:
     - type: Transform
       pos: -38.5,-50.5
       parent: 2
 - proto: SpawnPointChiefEngineer
   entities:
-  - uid: 5855
+  - uid: 6104
     components:
     - type: Transform
       pos: -80.5,-7.5
       parent: 2
 - proto: SpawnPointChiefJustice
   entities:
-  - uid: 5856
+  - uid: 6105
     components:
     - type: Transform
       pos: -38.5,-50.5
       parent: 2
 - proto: SpawnPointChiefMedicalOfficer
   entities:
-  - uid: 5857
+  - uid: 6106
     components:
     - type: Transform
       pos: -85.5,5.5
       parent: 2
 - proto: SpawnPointClerk
   entities:
-  - uid: 5858
+  - uid: 6107
     components:
     - type: Transform
       pos: -38.5,-50.5
       parent: 2
 - proto: SpawnPointClown
   entities:
-  - uid: 5859
+  - uid: 6108
     components:
     - type: Transform
       pos: -38.5,-50.5
       parent: 2
 - proto: SpawnPointCourier
   entities:
-  - uid: 5860
+  - uid: 6109
     components:
     - type: Transform
       pos: -38.5,-50.5
       parent: 2
 - proto: SpawnPointDetective
   entities:
-  - uid: 5861
+  - uid: 6110
     components:
     - type: Transform
       pos: -38.5,-50.5
       parent: 2
 - proto: SpawnPointForensicMantis
   entities:
-  - uid: 5862
+  - uid: 6111
     components:
     - type: Transform
       pos: -38.5,-50.5
       parent: 2
 - proto: SpawnPointHeadOfPersonnel
   entities:
-  - uid: 5863
+  - uid: 6112
     components:
     - type: Transform
       pos: -91.5,-11.5
       parent: 2
 - proto: SpawnPointHeadOfSecurity
   entities:
-  - uid: 5864
+  - uid: 6113
     components:
     - type: Transform
       pos: -98.5,-1.5
       parent: 2
 - proto: SpawnPointJanitor
   entities:
-  - uid: 5865
+  - uid: 6114
     components:
     - type: Transform
       pos: -38.5,-50.5
       parent: 2
 - proto: SpawnPointLatejoin
   entities:
-  - uid: 5866
+  - uid: 6115
     components:
     - type: Transform
       pos: -88.5,-3.5
       parent: 2
 - proto: SpawnPointLawyer
   entities:
-  - uid: 5867
+  - uid: 6116
     components:
     - type: Transform
       pos: -38.5,-50.5
       parent: 2
 - proto: SpawnPointLibrarian
   entities:
-  - uid: 5868
+  - uid: 6117
     components:
     - type: Transform
       pos: -38.5,-50.5
       parent: 2
 - proto: SpawnPointMedicalBorg
   entities:
-  - uid: 5869
+  - uid: 6118
     components:
     - type: Transform
       pos: -38.5,-50.5
       parent: 2
 - proto: SpawnPointMedicalDoctor
   entities:
-  - uid: 5870
+  - uid: 6119
     components:
     - type: Transform
       pos: -38.5,-50.5
       parent: 2
 - proto: SpawnPointMedicalIntern
   entities:
-  - uid: 5871
+  - uid: 6120
     components:
     - type: Transform
       pos: -38.5,-50.5
       parent: 2
 - proto: SpawnPointMime
   entities:
-  - uid: 5872
+  - uid: 6121
     components:
     - type: Transform
       pos: -38.5,-50.5
       parent: 2
 - proto: SpawnPointMusician
   entities:
-  - uid: 5873
+  - uid: 6122
     components:
     - type: Transform
       pos: -38.5,-50.5
       parent: 2
 - proto: SpawnPointParamedic
   entities:
-  - uid: 5874
+  - uid: 6123
     components:
     - type: Transform
       pos: -84.5,5.5
       parent: 2
 - proto: SpawnPointPassenger
   entities:
-  - uid: 5875
+  - uid: 6124
     components:
     - type: Transform
       pos: -38.5,-50.5
       parent: 2
 - proto: SpawnPointPrincipalArchitect
   entities:
-  - uid: 5876
+  - uid: 6125
     components:
     - type: Transform
       pos: -100.5,-3.5
       parent: 2
 - proto: SpawnPointProsecutor
   entities:
-  - uid: 5877
+  - uid: 6126
     components:
     - type: Transform
       pos: -38.5,-50.5
       parent: 2
 - proto: SpawnPointPsychologist
   entities:
-  - uid: 5878
+  - uid: 6127
     components:
     - type: Transform
       pos: -38.5,-50.5
       parent: 2
 - proto: SpawnPointQuartermaster
   entities:
-  - uid: 5879
+  - uid: 6128
     components:
     - type: Transform
       pos: -75.5,-2.5
       parent: 2
 - proto: SpawnPointReporter
   entities:
-  - uid: 5880
+  - uid: 6129
     components:
     - type: Transform
       pos: -38.5,-50.5
       parent: 2
 - proto: SpawnPointResearchAssistant
   entities:
-  - uid: 5881
+  - uid: 6130
     components:
     - type: Transform
       pos: -38.5,-50.5
       parent: 2
 - proto: SpawnPointResearchDirector
   entities:
-  - uid: 5882
+  - uid: 6131
     components:
     - type: Transform
       pos: -96.5,1.5
       parent: 2
 - proto: SpawnPointRoboticist
   entities:
-  - uid: 5883
+  - uid: 6132
     components:
     - type: Transform
       pos: -38.5,-50.5
       parent: 2
 - proto: SpawnPointSalvageSpecialist
   entities:
-  - uid: 5884
+  - uid: 6133
     components:
     - type: Transform
       pos: -76.5,-2.5
       parent: 2
-  - uid: 5885
+  - uid: 6134
     components:
     - type: Transform
       pos: -75.5,-3.5
       parent: 2
-  - uid: 5886
+  - uid: 6135
     components:
     - type: Transform
       pos: -76.5,-3.5
       parent: 2
 - proto: SpawnPointScientist
   entities:
-  - uid: 5887
+  - uid: 6136
     components:
     - type: Transform
       pos: -95.5,1.5
       parent: 2
 - proto: SpawnPointSecurityCadet
   entities:
-  - uid: 5888
+  - uid: 6137
     components:
     - type: Transform
       pos: -38.5,-50.5
       parent: 2
 - proto: SpawnPointSecurityOfficer
   entities:
-  - uid: 5889
+  - uid: 6138
     components:
     - type: Transform
       pos: -38.5,-50.5
       parent: 2
 - proto: SpawnPointServiceWorker
   entities:
-  - uid: 5890
+  - uid: 6139
     components:
     - type: Transform
       pos: -92.5,-8.5
       parent: 2
 - proto: SpawnPointStationEngineer
   entities:
-  - uid: 5891
+  - uid: 6140
     components:
     - type: Transform
       pos: -81.5,-7.5
       parent: 2
 - proto: SpawnPointSurgeon
   entities:
-  - uid: 5892
+  - uid: 6141
     components:
     - type: Transform
       pos: -38.5,-50.5
       parent: 2
 - proto: SpawnPointTechnicalAssistant
   entities:
-  - uid: 5893
+  - uid: 6142
     components:
     - type: Transform
       pos: -38.5,-50.5
       parent: 2
 - proto: SpawnPointWarden
   entities:
-  - uid: 5894
+  - uid: 6143
     components:
     - type: Transform
       pos: -97.5,-2.5
       parent: 2
 - proto: StasisBed
   entities:
-  - uid: 5895
+  - uid: 6144
     components:
     - type: Transform
       pos: -85.5,0.5
       parent: 2
 - proto: StaticField
   entities:
-  - uid: 5896
+  - uid: 6145
     components:
     - type: Transform
       pos: -38.5,-35.5
       parent: 2
-    - type: ApcPowerReceiver
-      powerDisabled: True
     - type: DeviceLinkSink
       invokeCounter: 1
-  - uid: 5897
+  - uid: 6146
     components:
     - type: Transform
       pos: -71.5,-3.5
       parent: 2
-    - type: ApcPowerReceiver
-      powerDisabled: True
     - type: DeviceLinkSink
       invokeCounter: 1
-  - uid: 5898
+  - uid: 6147
     components:
     - type: Transform
       pos: -39.5,-35.5
       parent: 2
-    - type: ApcPowerReceiver
-      powerDisabled: True
     - type: DeviceLinkSink
       invokeCounter: 1
-  - uid: 5899
+  - uid: 6148
     components:
     - type: Transform
       pos: -71.5,-2.5
       parent: 2
-    - type: ApcPowerReceiver
-      powerDisabled: True
     - type: DeviceLinkSink
       invokeCounter: 1
 - proto: StoolBar
   entities:
-  - uid: 5900
+  - uid: 6149
     components:
     - type: Transform
       pos: -96.5,-8.5
       parent: 2
-  - uid: 5901
+  - uid: 6150
     components:
     - type: Transform
       pos: -94.5,-8.5
       parent: 2
-  - uid: 5902
+  - uid: 6151
     components:
     - type: Transform
       pos: -95.5,-8.5
       parent: 2
 - proto: StorageCanister
   entities:
-  - uid: 5903
+  - uid: 6152
     components:
     - type: Transform
       pos: -91.5,5.5
       parent: 2
 - proto: SubstationBasic
   entities:
-  - uid: 5904
+  - uid: 6153
     components:
     - type: Transform
       pos: -82.5,-12.5
       parent: 2
+    - type: PowerNetworkBattery
+      supplyRampPosition: 150000
 - proto: TableReinforced
   entities:
-  - uid: 5905
+  - uid: 6154
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: -102.5,-4.5
       parent: 2
-  - uid: 5906
+  - uid: 6155
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: -91.5,2.5
       parent: 2
-  - uid: 5907
+  - uid: 6156
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: -95.5,-12.5
       parent: 2
-  - uid: 5908
+  - uid: 6157
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: -81.5,6.5
       parent: 2
-  - uid: 5909
+  - uid: 6158
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: -82.5,6.5
       parent: 2
-  - uid: 5910
+  - uid: 6159
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: -85.5,1.5
       parent: 2
-  - uid: 5911
+  - uid: 6160
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: -80.5,1.5
       parent: 2
-  - uid: 5912
+  - uid: 6161
     components:
     - type: Transform
       pos: -96.5,3.5
       parent: 2
-  - uid: 5913
+  - uid: 6162
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: -91.5,1.5
       parent: 2
-  - uid: 5914
+  - uid: 6163
     components:
     - type: Transform
       pos: -93.5,-12.5
       parent: 2
-  - uid: 5915
+  - uid: 6164
     components:
     - type: Transform
       pos: -94.5,-12.5
       parent: 2
-  - uid: 5916
+  - uid: 6165
     components:
     - type: Transform
       pos: -96.5,-12.5
       parent: 2
-  - uid: 5917
+  - uid: 6166
     components:
     - type: Transform
       rot: 3.141592653589793 rad
@@ -34563,23 +34564,23 @@ entities:
       parent: 2
 - proto: TableWood
   entities:
-  - uid: 5918
+  - uid: 6167
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: -31.5,-42.5
       parent: 2
-  - uid: 5919
+  - uid: 6168
     components:
     - type: Transform
       pos: -46.5,-42.5
       parent: 2
-  - uid: 5920
+  - uid: 6169
     components:
     - type: Transform
       pos: -95.5,-7.5
       parent: 2
-  - uid: 5921
+  - uid: 6170
     components:
     - type: Transform
       rot: 3.141592653589793 rad
@@ -34587,112 +34588,112 @@ entities:
       parent: 2
 - proto: TelecomServerFilled
   entities:
-  - uid: 5922
+  - uid: 6171
     components:
     - type: Transform
       pos: -80.5,-12.5
       parent: 2
 - proto: ToiletEmpty
   entities:
-  - uid: 5923
+  - uid: 6172
     components:
     - type: Transform
       pos: -28.5,-40.5
       parent: 2
-  - uid: 5924
+  - uid: 6173
     components:
     - type: Transform
       pos: -49.5,-40.5
       parent: 2
 - proto: TowelColorBlack
   entities:
-  - uid: 3687
+  - uid: 3989
     components:
     - type: Transform
-      parent: 3685
+      parent: 3987
     - type: Physics
       canCollide: False
     - type: InsideEntityStorage
 - proto: TowelColorBlue
   entities:
-  - uid: 3688
+  - uid: 3990
     components:
     - type: Transform
-      parent: 3685
+      parent: 3987
     - type: Physics
       canCollide: False
     - type: InsideEntityStorage
 - proto: TowelColorGold
   entities:
-  - uid: 3689
+  - uid: 3991
     components:
     - type: Transform
-      parent: 3685
+      parent: 3987
     - type: Physics
       canCollide: False
     - type: InsideEntityStorage
 - proto: TowelColorMaroon
   entities:
-  - uid: 3690
+  - uid: 3992
     components:
     - type: Transform
-      parent: 3685
+      parent: 3987
     - type: Physics
       canCollide: False
     - type: InsideEntityStorage
 - proto: TowelColorPink
   entities:
-  - uid: 3693
+  - uid: 3995
     components:
     - type: Transform
-      parent: 3691
+      parent: 3993
     - type: Physics
       canCollide: False
     - type: InsideEntityStorage
 - proto: TowelColorPurple
   entities:
-  - uid: 3694
+  - uid: 3996
     components:
     - type: Transform
-      parent: 3691
+      parent: 3993
     - type: Physics
       canCollide: False
     - type: InsideEntityStorage
 - proto: TowelColorSilver
   entities:
-  - uid: 3695
+  - uid: 3997
     components:
     - type: Transform
-      parent: 3691
+      parent: 3993
     - type: Physics
       canCollide: False
     - type: InsideEntityStorage
 - proto: TowelColorTeal
   entities:
-  - uid: 3696
+  - uid: 3998
     components:
     - type: Transform
-      parent: 3691
+      parent: 3993
     - type: Physics
       canCollide: False
     - type: InsideEntityStorage
 - proto: ToyRubberDuck
   entities:
-  - uid: 5925
+  - uid: 6174
     components:
     - type: Transform
       pos: -28.011639,-42.64564
       parent: 2
 - proto: TwoWayLever
   entities:
-  - uid: 5926
+  - uid: 6175
     components:
     - type: Transform
       pos: -77.5,-1.5
       parent: 2
     - type: DeviceLinkSource
       linkedPorts:
-        5798:
+        6047:
         - - Left
           - Reverse
         - - Right
@@ -34701,7 +34702,7 @@ entities:
           - Off
 - proto: VendingMachineChefvend
   entities:
-  - uid: 5927
+  - uid: 6176
     components:
     - type: Transform
       pos: -96.5,-10.5
@@ -34710,14 +34711,14 @@ entities:
     - DatasetVocalizer
 - proto: VendingMachineChemicals
   entities:
-  - uid: 5928
+  - uid: 6177
     components:
     - type: Transform
       pos: -83.5,6.5
       parent: 2
 - proto: VendingMachineDinnerware
   entities:
-  - uid: 5929
+  - uid: 6178
     components:
     - type: Transform
       pos: -96.5,-11.5
@@ -34726,7 +34727,7 @@ entities:
     - DatasetVocalizer
 - proto: VendingMachineMedical
   entities:
-  - uid: 5930
+  - uid: 6179
     components:
     - type: Transform
       pos: -80.5,4.5
@@ -34735,1158 +34736,1158 @@ entities:
     - DatasetVocalizer
 - proto: VendingMachineSalvage
   entities:
-  - uid: 5931
+  - uid: 6180
     components:
     - type: Transform
       pos: -58.5,-49.5
       parent: 2
 - proto: WallNecropolis
   entities:
-  - uid: 5932
+  - uid: 6181
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: -94.5,6.5
       parent: 2
-  - uid: 5933
+  - uid: 6182
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: -92.5,-10.5
       parent: 2
-  - uid: 5934
+  - uid: 6183
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: -92.5,-13.5
       parent: 2
-  - uid: 5935
+  - uid: 6184
     components:
     - type: Transform
       pos: -94.5,7.5
       parent: 2
-  - uid: 5936
+  - uid: 6185
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: -94.5,4.5
       parent: 2
-  - uid: 5937
+  - uid: 6186
     components:
     - type: Transform
       pos: -97.5,-10.5
       parent: 2
-  - uid: 5938
+  - uid: 6187
     components:
     - type: Transform
       pos: -97.5,-11.5
       parent: 2
-  - uid: 5939
+  - uid: 6188
     components:
     - type: Transform
       pos: -97.5,-12.5
       parent: 2
-  - uid: 5940
+  - uid: 6189
     components:
     - type: Transform
       pos: -97.5,5.5
       parent: 2
-  - uid: 5941
+  - uid: 6190
     components:
     - type: Transform
       pos: -97.5,4.5
       parent: 2
-  - uid: 5942
+  - uid: 6191
     components:
     - type: Transform
       pos: -93.5,-13.5
       parent: 2
-  - uid: 5943
+  - uid: 6192
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: -92.5,-9.5
       parent: 2
-  - uid: 5944
+  - uid: 6193
     components:
     - type: Transform
       pos: -43.5,-44.5
       parent: 2
-  - uid: 5945
+  - uid: 6194
     components:
     - type: Transform
       pos: -35.5,-35.5
       parent: 2
-  - uid: 5946
+  - uid: 6195
     components:
     - type: Transform
       pos: -90.5,0.5
       parent: 2
-  - uid: 5947
+  - uid: 6196
     components:
     - type: Transform
       pos: -74.5,-5.5
       parent: 2
-  - uid: 5948
+  - uid: 6197
     components:
     - type: Transform
       pos: -32.5,-50.5
       parent: 2
-  - uid: 5949
+  - uid: 6198
     components:
     - type: Transform
       pos: -97.5,-5.5
       parent: 2
-  - uid: 5950
+  - uid: 6199
     components:
     - type: Transform
       pos: -90.5,-0.5
       parent: 2
-  - uid: 5951
+  - uid: 6200
     components:
     - type: Transform
       pos: -97.5,-13.5
       parent: 2
-  - uid: 5952
+  - uid: 6201
     components:
     - type: Transform
       pos: -28.5,-43.5
       parent: 2
-  - uid: 5953
+  - uid: 6202
     components:
     - type: Transform
       pos: -97.5,-0.5
       parent: 2
-  - uid: 5954
+  - uid: 6203
     components:
     - type: Transform
       pos: -96.5,-1.5
       parent: 2
-  - uid: 5955
+  - uid: 6204
     components:
     - type: Transform
       pos: -33.5,-39.5
       parent: 2
-  - uid: 5956
+  - uid: 6205
     components:
     - type: Transform
       pos: -90.5,7.5
       parent: 2
-  - uid: 5957
+  - uid: 6206
     components:
     - type: Transform
       pos: -29.5,-42.5
       parent: 2
-  - uid: 5958
+  - uid: 6207
     components:
     - type: Transform
       pos: -29.5,-43.5
       parent: 2
-  - uid: 5959
+  - uid: 6208
     components:
     - type: Transform
       pos: -35.5,-44.5
       parent: 2
-  - uid: 5960
+  - uid: 6209
     components:
     - type: Transform
       pos: -97.5,0.5
       parent: 2
-  - uid: 5961
+  - uid: 6210
     components:
     - type: Transform
       pos: -42.5,-36.5
       parent: 2
-  - uid: 5962
+  - uid: 6211
     components:
     - type: Transform
       pos: -42.5,-38.5
       parent: 2
-  - uid: 5963
+  - uid: 6212
     components:
     - type: Transform
       pos: -46.5,-44.5
       parent: 2
-  - uid: 5964
+  - uid: 6213
     components:
     - type: Transform
       pos: -40.5,-38.5
       parent: 2
-  - uid: 5965
+  - uid: 6214
     components:
     - type: Transform
       pos: -30.5,-48.5
       parent: 2
-  - uid: 5966
+  - uid: 6215
     components:
     - type: Transform
       pos: -48.5,-35.5
       parent: 2
-  - uid: 5967
+  - uid: 6216
     components:
     - type: Transform
       pos: -79.5,-12.5
       parent: 2
-  - uid: 5968
+  - uid: 6217
     components:
     - type: Transform
       pos: -45.5,-48.5
       parent: 2
-  - uid: 5969
+  - uid: 6218
     components:
     - type: Transform
       pos: -42.5,-45.5
       parent: 2
-  - uid: 5970
+  - uid: 6219
     components:
     - type: Transform
       pos: -31.5,-39.5
       parent: 2
-  - uid: 5971
+  - uid: 6220
     components:
     - type: Transform
       pos: -34.5,-35.5
       parent: 2
-  - uid: 5972
+  - uid: 6221
     components:
     - type: Transform
       pos: -92.5,-12.5
       parent: 2
-  - uid: 5973
+  - uid: 6222
     components:
     - type: Transform
       pos: -80.5,-0.5
       parent: 2
-  - uid: 5974
+  - uid: 6223
     components:
     - type: Transform
       pos: -43.5,-48.5
       parent: 2
-  - uid: 5975
+  - uid: 6224
     components:
     - type: Transform
       pos: -96.5,-5.5
       parent: 2
-  - uid: 5976
+  - uid: 6225
     components:
     - type: Transform
       pos: -96.5,-0.5
       parent: 2
-  - uid: 5977
+  - uid: 6226
     components:
     - type: Transform
       pos: -31.5,-48.5
       parent: 2
-  - uid: 5978
+  - uid: 6227
     components:
     - type: Transform
       pos: -51.5,-43.5
       parent: 2
-  - uid: 5979
+  - uid: 6228
     components:
     - type: Transform
       pos: -91.5,-13.5
       parent: 2
-  - uid: 5980
+  - uid: 6229
     components:
     - type: Transform
       pos: -97.5,3.5
       parent: 2
-  - uid: 5981
+  - uid: 6230
     components:
     - type: Transform
       pos: -34.5,-39.5
       parent: 2
-  - uid: 5982
+  - uid: 6231
     components:
     - type: Transform
       pos: -47.5,-35.5
       parent: 2
-  - uid: 5983
+  - uid: 6232
     components:
     - type: Transform
       pos: -86.5,0.5
       parent: 2
-  - uid: 5984
+  - uid: 6233
     components:
     - type: Transform
       pos: -86.5,-6.5
       parent: 2
-  - uid: 5985
+  - uid: 6234
     components:
     - type: Transform
       pos: -32.5,-51.5
       parent: 2
-  - uid: 5986
+  - uid: 6235
     components:
     - type: Transform
       pos: -48.5,-40.5
       parent: 2
-  - uid: 5987
+  - uid: 6236
     components:
     - type: Transform
       pos: -35.5,-38.5
       parent: 2
-  - uid: 5988
+  - uid: 6237
     components:
     - type: Transform
       pos: -32.5,-49.5
       parent: 2
-  - uid: 5989
+  - uid: 6238
     components:
     - type: Transform
       pos: -90.5,-13.5
       parent: 2
-  - uid: 5990
+  - uid: 6239
     components:
     - type: Transform
       pos: -79.5,-9.5
       parent: 2
-  - uid: 5991
+  - uid: 6240
     components:
     - type: Transform
       pos: -41.5,-50.5
       parent: 2
-  - uid: 5992
+  - uid: 6241
     components:
     - type: Transform
       pos: -44.5,-39.5
       parent: 2
-  - uid: 5993
+  - uid: 6242
     components:
     - type: Transform
       pos: -46.5,-39.5
       parent: 2
-  - uid: 5994
+  - uid: 6243
     components:
     - type: Transform
       pos: -75.5,-0.5
       parent: 2
-  - uid: 5995
+  - uid: 6244
     components:
     - type: Transform
       pos: -33.5,-46.5
       parent: 2
-  - uid: 5996
+  - uid: 6245
     components:
     - type: Transform
       pos: -96.5,-4.5
       parent: 2
-  - uid: 5997
+  - uid: 6246
     components:
     - type: Transform
       pos: -36.5,-46.5
       parent: 2
-  - uid: 5998
+  - uid: 6247
     components:
     - type: Transform
       pos: -79.5,-5.5
       parent: 2
-  - uid: 5999
+  - uid: 6248
     components:
     - type: Transform
       pos: -79.5,3.5
       parent: 2
-  - uid: 6000
+  - uid: 6249
     components:
     - type: Transform
       pos: -41.5,-38.5
       parent: 2
-  - uid: 6001
+  - uid: 6250
     components:
     - type: Transform
       pos: -90.5,-9.5
       parent: 2
-  - uid: 6002
+  - uid: 6251
     components:
     - type: Transform
       pos: -80.5,-4.5
       parent: 2
-  - uid: 6003
+  - uid: 6252
     components:
     - type: Transform
       pos: -85.5,7.5
       parent: 2
-  - uid: 6004
+  - uid: 6253
     components:
     - type: Transform
       pos: -32.5,-48.5
       parent: 2
-  - uid: 6005
+  - uid: 6254
     components:
     - type: Transform
       pos: -102.5,0.5
       parent: 2
-  - uid: 6006
+  - uid: 6255
     components:
     - type: Transform
       pos: -79.5,6.5
       parent: 2
-  - uid: 6007
+  - uid: 6256
     components:
     - type: Transform
       pos: -92.5,-5.5
       parent: 2
-  - uid: 6008
+  - uid: 6257
     components:
     - type: Transform
       pos: -29.5,-39.5
       parent: 2
-  - uid: 6009
+  - uid: 6258
     components:
     - type: Transform
       pos: -102.5,-5.5
       parent: 2
-  - uid: 6010
+  - uid: 6259
     components:
     - type: Transform
       pos: -42.5,-48.5
       parent: 2
-  - uid: 6011
+  - uid: 6260
     components:
     - type: Transform
       pos: -35.5,-40.5
       parent: 2
-  - uid: 6012
+  - uid: 6261
     components:
     - type: Transform
       pos: -29.5,-48.5
       parent: 2
-  - uid: 6013
+  - uid: 6262
     components:
     - type: Transform
       pos: -79.5,0.5
       parent: 2
-  - uid: 6014
+  - uid: 6263
     components:
     - type: Transform
       pos: -30.5,-44.5
       parent: 2
-  - uid: 6015
+  - uid: 6264
     components:
     - type: Transform
       pos: -41.5,-48.5
       parent: 2
-  - uid: 6016
+  - uid: 6265
     components:
     - type: Transform
       pos: -33.5,-48.5
       parent: 2
-  - uid: 6017
+  - uid: 6266
     components:
     - type: Transform
       pos: -47.5,-39.5
       parent: 2
-  - uid: 6018
+  - uid: 6267
     components:
     - type: Transform
       pos: -96.5,-13.5
       parent: 2
-  - uid: 6019
+  - uid: 6268
     components:
     - type: Transform
       pos: -26.5,-39.5
       parent: 2
-  - uid: 6020
+  - uid: 6269
     components:
     - type: Transform
       pos: -36.5,-38.5
       parent: 2
-  - uid: 6021
+  - uid: 6270
     components:
     - type: Transform
       pos: -85.5,-0.5
       parent: 2
-  - uid: 6022
+  - uid: 6271
     components:
     - type: Transform
       pos: -26.5,-42.5
       parent: 2
-  - uid: 6023
+  - uid: 6272
     components:
     - type: Transform
       pos: -81.5,-5.5
       parent: 2
-  - uid: 6024
+  - uid: 6273
     components:
     - type: Transform
       pos: -45.5,-50.5
       parent: 2
-  - uid: 6025
+  - uid: 6274
     components:
     - type: Transform
       pos: -29.5,-44.5
       parent: 2
-  - uid: 6026
+  - uid: 6275
     components:
     - type: Transform
       pos: -44.5,-48.5
       parent: 2
-  - uid: 6027
+  - uid: 6276
     components:
     - type: Transform
       pos: -103.5,-0.5
       parent: 2
-  - uid: 6028
+  - uid: 6277
     components:
     - type: Transform
       pos: -51.5,-42.5
       parent: 2
-  - uid: 6029
+  - uid: 6278
     components:
     - type: Transform
       pos: -30.5,-39.5
       parent: 2
-  - uid: 6030
+  - uid: 6279
     components:
     - type: Transform
       pos: -35.5,-39.5
       parent: 2
-  - uid: 6031
+  - uid: 6280
     components:
     - type: Transform
       pos: -41.5,-51.5
       parent: 2
-  - uid: 6032
+  - uid: 6281
     components:
     - type: Transform
       pos: -51.5,-40.5
       parent: 2
-  - uid: 6033
+  - uid: 6282
     components:
     - type: Transform
       pos: -79.5,-0.5
       parent: 2
-  - uid: 6034
+  - uid: 6283
     components:
     - type: Transform
       pos: -37.5,-35.5
       parent: 2
-  - uid: 6035
+  - uid: 6284
     components:
     - type: Transform
       pos: -37.5,-38.5
       parent: 2
-  - uid: 6036
+  - uid: 6285
     components:
     - type: Transform
       pos: -46.5,-48.5
       parent: 2
-  - uid: 6037
+  - uid: 6286
     components:
     - type: Transform
       pos: -80.5,-1.5
       parent: 2
-  - uid: 6038
+  - uid: 6287
     components:
     - type: Transform
       pos: -37.5,-45.5
       parent: 2
-  - uid: 6039
+  - uid: 6288
     components:
     - type: Transform
       pos: -28.5,-39.5
       parent: 2
-  - uid: 6040
+  - uid: 6289
     components:
     - type: Transform
       pos: -33.5,-47.5
       parent: 2
-  - uid: 6041
+  - uid: 6290
     components:
     - type: Transform
       pos: -71.5,-4.5
       parent: 2
-  - uid: 6042
+  - uid: 6291
     components:
     - type: Transform
       pos: -36.5,-51.5
       parent: 2
-  - uid: 6043
+  - uid: 6292
     components:
     - type: Transform
       pos: -86.5,-5.5
       parent: 2
-  - uid: 6044
+  - uid: 6293
     components:
     - type: Transform
       pos: -44.5,-45.5
       parent: 2
-  - uid: 6045
+  - uid: 6294
     components:
     - type: Transform
       pos: -51.5,-39.5
       parent: 2
-  - uid: 6046
+  - uid: 6295
     components:
     - type: Transform
       pos: -85.5,-5.5
       parent: 2
-  - uid: 6047
+  - uid: 6296
     components:
     - type: Transform
       pos: -44.5,-44.5
       parent: 2
-  - uid: 6048
+  - uid: 6297
     components:
     - type: Transform
       pos: -47.5,-48.5
       parent: 2
-  - uid: 6049
+  - uid: 6298
     components:
     - type: Transform
       pos: -41.5,-45.5
       parent: 2
-  - uid: 6050
+  - uid: 6299
     components:
     - type: Transform
       pos: -42.5,-40.5
       parent: 2
-  - uid: 6051
+  - uid: 6300
     components:
     - type: Transform
       pos: -43.5,-45.5
       parent: 2
-  - uid: 6052
+  - uid: 6301
     components:
     - type: Transform
       pos: -49.5,-39.5
       parent: 2
-  - uid: 6053
+  - uid: 6302
     components:
     - type: Transform
       pos: -42.5,-43.5
       parent: 2
-  - uid: 6054
+  - uid: 6303
     components:
     - type: Transform
       pos: -44.5,-47.5
       parent: 2
-  - uid: 6055
+  - uid: 6304
     components:
     - type: Transform
       pos: -90.5,3.5
       parent: 2
-  - uid: 6056
+  - uid: 6305
     components:
     - type: Transform
       pos: -97.5,6.5
       parent: 2
-  - uid: 6057
+  - uid: 6306
     components:
     - type: Transform
       pos: -81.5,-0.5
       parent: 2
-  - uid: 6058
+  - uid: 6307
     components:
     - type: Transform
       pos: -86.5,-13.5
       parent: 2
-  - uid: 6059
+  - uid: 6308
     components:
     - type: Transform
       pos: -35.5,-45.5
       parent: 2
-  - uid: 6060
+  - uid: 6309
     components:
     - type: Transform
       pos: -36.5,-48.5
       parent: 2
-  - uid: 6061
+  - uid: 6310
     components:
     - type: Transform
       pos: -26.5,-43.5
       parent: 2
-  - uid: 6062
+  - uid: 6311
     components:
     - type: Transform
       pos: -43.5,-35.5
       parent: 2
-  - uid: 6063
+  - uid: 6312
     components:
     - type: Transform
       pos: -42.5,-37.5
       parent: 2
-  - uid: 6064
+  - uid: 6313
     components:
     - type: Transform
       pos: -26.5,-41.5
       parent: 2
-  - uid: 6065
+  - uid: 6314
     components:
     - type: Transform
       pos: -30.5,-35.5
       parent: 2
-  - uid: 6066
+  - uid: 6315
     components:
     - type: Transform
       pos: -34.5,-48.5
       parent: 2
-  - uid: 6067
+  - uid: 6316
     components:
     - type: Transform
       pos: -48.5,-42.5
       parent: 2
-  - uid: 6068
+  - uid: 6317
     components:
     - type: Transform
       pos: -86.5,7.5
       parent: 2
-  - uid: 6069
+  - uid: 6318
     components:
     - type: Transform
       pos: -74.5,-4.5
       parent: 2
-  - uid: 6070
+  - uid: 6319
     components:
     - type: Transform
       pos: -35.5,-48.5
       parent: 2
-  - uid: 6071
+  - uid: 6320
     components:
     - type: Transform
       pos: -95.5,-5.5
       parent: 2
-  - uid: 6072
+  - uid: 6321
     components:
     - type: Transform
       pos: -79.5,-13.5
       parent: 2
-  - uid: 6073
+  - uid: 6322
     components:
     - type: Transform
       pos: -97.5,7.5
       parent: 2
-  - uid: 6074
+  - uid: 6323
     components:
     - type: Transform
       pos: -103.5,-5.5
       parent: 2
-  - uid: 6075
+  - uid: 6324
     components:
     - type: Transform
       pos: -51.5,-41.5
       parent: 2
-  - uid: 6076
+  - uid: 6325
     components:
     - type: Transform
       pos: -40.5,-45.5
       parent: 2
-  - uid: 6077
+  - uid: 6326
     components:
     - type: Transform
       pos: -74.5,-1.5
       parent: 2
-  - uid: 6078
+  - uid: 6327
     components:
     - type: Transform
       pos: -90.5,6.5
       parent: 2
-  - uid: 6079
+  - uid: 6328
     components:
     - type: Transform
       pos: -48.5,-39.5
       parent: 2
-  - uid: 6080
+  - uid: 6329
     components:
     - type: Transform
       pos: -75.5,-5.5
       parent: 2
-  - uid: 6081
+  - uid: 6330
     components:
     - type: Transform
       pos: -90.5,-12.5
       parent: 2
-  - uid: 6082
+  - uid: 6331
     components:
     - type: Transform
       pos: -43.5,-39.5
       parent: 2
-  - uid: 6083
+  - uid: 6332
     components:
     - type: Transform
       pos: -29.5,-40.5
       parent: 2
-  - uid: 6084
+  - uid: 6333
     components:
     - type: Transform
       pos: -35.5,-36.5
       parent: 2
-  - uid: 6085
+  - uid: 6334
     components:
     - type: Transform
       pos: -26.5,-40.5
       parent: 2
-  - uid: 6086
+  - uid: 6335
     components:
     - type: Transform
       pos: -45.5,-51.5
       parent: 2
-  - uid: 6087
+  - uid: 6336
     components:
     - type: Transform
       pos: -36.5,-50.5
       parent: 2
-  - uid: 6088
+  - uid: 6337
     components:
     - type: Transform
       pos: -92.5,-0.5
       parent: 2
-  - uid: 6089
+  - uid: 6338
     components:
     - type: Transform
       pos: -49.5,-43.5
       parent: 2
-  - uid: 6090
+  - uid: 6339
     components:
     - type: Transform
       pos: -84.5,-0.5
       parent: 2
-  - uid: 6091
+  - uid: 6340
     components:
     - type: Transform
       pos: -50.5,-43.5
       parent: 2
-  - uid: 6092
+  - uid: 6341
     components:
     - type: Transform
       pos: -102.5,-0.5
       parent: 2
-  - uid: 6093
+  - uid: 6342
     components:
     - type: Transform
       pos: -48.5,-48.5
       parent: 2
-  - uid: 6094
+  - uid: 6343
     components:
     - type: Transform
       pos: -29.5,-35.5
       parent: 2
-  - uid: 6095
+  - uid: 6344
     components:
     - type: Transform
       pos: -80.5,-5.5
       parent: 2
-  - uid: 6096
+  - uid: 6345
     components:
     - type: Transform
       pos: -40.5,-35.5
       parent: 2
-  - uid: 6097
+  - uid: 6346
     components:
     - type: Transform
       pos: -35.5,-43.5
       parent: 2
-  - uid: 6098
+  - uid: 6347
     components:
     - type: Transform
       pos: -42.5,-44.5
       parent: 2
-  - uid: 6099
+  - uid: 6348
     components:
     - type: Transform
       pos: -86.5,3.5
       parent: 2
-  - uid: 6100
+  - uid: 6349
     components:
     - type: Transform
       pos: -91.5,-5.5
       parent: 2
-  - uid: 6101
+  - uid: 6350
     components:
     - type: Transform
       pos: -31.5,-44.5
       parent: 2
-  - uid: 6102
+  - uid: 6351
     components:
     - type: Transform
       pos: -50.5,-39.5
       parent: 2
-  - uid: 6103
+  - uid: 6352
     components:
     - type: Transform
       pos: -40.5,-51.5
       parent: 2
-  - uid: 6104
+  - uid: 6353
     components:
     - type: Transform
       pos: -86.5,-9.5
       parent: 2
-  - uid: 6105
+  - uid: 6354
     components:
     - type: Transform
       pos: -41.5,-46.5
       parent: 2
-  - uid: 6106
+  - uid: 6355
     components:
     - type: Transform
       pos: -47.5,-44.5
       parent: 2
-  - uid: 6107
+  - uid: 6356
     components:
     - type: Transform
       pos: -86.5,-12.5
       parent: 2
-  - uid: 6108
+  - uid: 6357
     components:
     - type: Transform
       pos: -91.5,-0.5
       parent: 2
-  - uid: 6109
+  - uid: 6358
     components:
     - type: Transform
       pos: -34.5,-44.5
       parent: 2
-  - uid: 6110
+  - uid: 6359
     components:
     - type: Transform
       pos: -71.5,-1.5
       parent: 2
-  - uid: 6111
+  - uid: 6360
     components:
     - type: Transform
       pos: -91.5,7.5
       parent: 2
-  - uid: 6112
+  - uid: 6361
     components:
     - type: Transform
       pos: -35.5,-37.5
       parent: 2
-  - uid: 6113
+  - uid: 6362
     components:
     - type: Transform
       pos: -44.5,-46.5
       parent: 2
-  - uid: 6114
+  - uid: 6363
     components:
     - type: Transform
       pos: -45.5,-49.5
       parent: 2
-  - uid: 6115
+  - uid: 6364
     components:
     - type: Transform
       pos: -79.5,7.5
       parent: 2
-  - uid: 6116
+  - uid: 6365
     components:
     - type: Transform
       pos: -74.5,-0.5
       parent: 2
-  - uid: 6117
+  - uid: 6366
     components:
     - type: Transform
       pos: -95.5,-0.5
       parent: 2
-  - uid: 6118
+  - uid: 6367
     components:
     - type: Transform
       pos: -97.5,-6.5
       parent: 2
-  - uid: 6119
+  - uid: 6368
     components:
     - type: Transform
       pos: -84.5,-5.5
       parent: 2
-  - uid: 6120
+  - uid: 6369
     components:
     - type: Transform
       pos: -97.5,-9.5
       parent: 2
-  - uid: 6121
+  - uid: 6370
     components:
     - type: Transform
       pos: -86.5,-0.5
       parent: 2
-  - uid: 6122
+  - uid: 6371
     components:
     - type: Transform
       pos: -48.5,-44.5
       parent: 2
-  - uid: 6123
+  - uid: 6372
     components:
     - type: Transform
       pos: -27.5,-43.5
       parent: 2
-  - uid: 6124
+  - uid: 6373
     components:
     - type: Transform
       pos: -90.5,-6.5
       parent: 2
-  - uid: 6125
+  - uid: 6374
     components:
     - type: Transform
       pos: -102.5,-6.5
       parent: 2
-  - uid: 6126
+  - uid: 6375
     components:
     - type: Transform
       pos: -37.5,-51.5
       parent: 2
-  - uid: 6127
+  - uid: 6376
     components:
     - type: Transform
       pos: -42.5,-35.5
       parent: 2
-  - uid: 6128
+  - uid: 6377
     components:
     - type: Transform
       pos: -90.5,-5.5
       parent: 2
-  - uid: 6129
+  - uid: 6378
     components:
     - type: Transform
       pos: -79.5,-6.5
       parent: 2
-  - uid: 6130
+  - uid: 6379
     components:
     - type: Transform
       pos: -80.5,7.5
       parent: 2
-  - uid: 6131
+  - uid: 6380
     components:
     - type: Transform
       pos: -33.5,-45.5
       parent: 2
-  - uid: 6132
+  - uid: 6381
     components:
     - type: Transform
       pos: -34.5,-45.5
       parent: 2
-  - uid: 6133
+  - uid: 6382
     components:
     - type: Transform
       pos: -86.5,6.5
       parent: 2
-  - uid: 6134
+  - uid: 6383
     components:
     - type: Transform
       pos: -33.5,-44.5
       parent: 2
-  - uid: 6135
+  - uid: 6384
     components:
     - type: Transform
       pos: -27.5,-39.5
       parent: 2
-  - uid: 6136
+  - uid: 6385
     components:
     - type: Transform
       pos: -42.5,-39.5
       parent: 2
-  - uid: 6137
+  - uid: 6386
     components:
     - type: Transform
       pos: -48.5,-43.5
       parent: 2
-  - uid: 6138
+  - uid: 6387
     components:
     - type: Transform
       pos: -36.5,-45.5
       parent: 2
 - proto: WallReinforced
   entities:
-  - uid: 6139
+  - uid: 6388
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: -85.5,-15.5
       parent: 2
-  - uid: 6140
+  - uid: 6389
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: -82.5,-15.5
       parent: 2
-  - uid: 6141
+  - uid: 6390
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: -83.5,-13.5
       parent: 2
-  - uid: 6142
+  - uid: 6391
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: -85.5,-14.5
       parent: 2
-  - uid: 6143
+  - uid: 6392
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: -82.5,-14.5
       parent: 2
-  - uid: 6144
+  - uid: 6393
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: -82.5,-13.5
       parent: 2
-  - uid: 6145
+  - uid: 6394
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: -83.5,-15.5
       parent: 2
-  - uid: 6146
+  - uid: 6395
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: -80.5,-13.5
       parent: 2
-  - uid: 6147
+  - uid: 6396
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: -83.5,-14.5
       parent: 2
-  - uid: 6148
+  - uid: 6397
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: -85.5,-13.5
       parent: 2
-  - uid: 6149
+  - uid: 6398
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: -83.5,-16.5
       parent: 2
-  - uid: 6150
+  - uid: 6399
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: -85.5,-16.5
       parent: 2
-  - uid: 6151
+  - uid: 6400
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: -80.5,-15.5
       parent: 2
-  - uid: 6152
+  - uid: 6401
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: -80.5,-14.5
       parent: 2
-  - uid: 6153
+  - uid: 6402
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: -82.5,-16.5
       parent: 2
-  - uid: 6154
+  - uid: 6403
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: -80.5,-16.5
       parent: 2
-  - uid: 6155
+  - uid: 6404
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: -81.5,-16.5
       parent: 2
-  - uid: 6156
+  - uid: 6405
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
@@ -35894,14 +35895,14 @@ entities:
       parent: 2
 - proto: WallWeaponCapacitorRecharger
   entities:
-  - uid: 5556
+  - uid: 6406
     components:
     - type: Transform
       pos: -97.5,-0.5
       parent: 2
 - proto: WarningN2
   entities:
-  - uid: 6157
+  - uid: 6407
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
@@ -35911,7 +35912,7 @@ entities:
       fixtures: {}
 - proto: WarningO2
   entities:
-  - uid: 6158
+  - uid: 6408
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
@@ -35921,7 +35922,7 @@ entities:
       fixtures: {}
 - proto: WarpPoint
   entities:
-  - uid: 6159
+  - uid: 6409
     components:
     - type: MetaData
       name: SCS Gemini
@@ -35932,14 +35933,14 @@ entities:
       location: SCS Gemini
 - proto: WaterCooler
   entities:
-  - uid: 6160
+  - uid: 6410
     components:
     - type: Transform
       pos: -37.5,-48.5
       parent: 2
 - proto: WeaponWaterPistol
   entities:
-  - uid: 6161
+  - uid: 6411
     components:
     - type: Transform
       rot: -0.8901179185171081 rad
@@ -35947,182 +35948,182 @@ entities:
       parent: 2
 - proto: WoodenSupportBeam
   entities:
-  - uid: 6162
+  - uid: 6412
     components:
     - type: Transform
       pos: -56.5,-3.5
       parent: 2
-  - uid: 6163
+  - uid: 6413
     components:
     - type: Transform
       pos: 0.5,-3.5
       parent: 2
-  - uid: 6164
+  - uid: 6414
     components:
     - type: Transform
       pos: 0.5,-2.5
       parent: 2
-  - uid: 6165
+  - uid: 6415
     components:
     - type: Transform
       pos: -39.5,-24.5
       parent: 2
-  - uid: 6166
+  - uid: 6416
     components:
     - type: Transform
       pos: -10.5,-2.5
       parent: 2
-  - uid: 6167
+  - uid: 6417
     components:
     - type: Transform
       pos: -32.5,41.5
       parent: 2
-  - uid: 6168
+  - uid: 6418
     components:
     - type: Transform
       pos: -38.5,26.5
       parent: 2
-  - uid: 6169
+  - uid: 6419
     components:
     - type: Transform
       pos: -1.5,16.5
       parent: 2
-  - uid: 6170
+  - uid: 6420
     components:
     - type: Transform
       pos: -1.5,8.5
       parent: 2
-  - uid: 6171
+  - uid: 6421
     components:
     - type: Transform
       pos: -32.5,40.5
       parent: 2
-  - uid: 6172
+  - uid: 6422
     components:
     - type: Transform
       pos: -66.5,-3.5
       parent: 2
-  - uid: 6173
+  - uid: 6423
     components:
     - type: Transform
       pos: 7.5,-2.5
       parent: 2
-  - uid: 6174
+  - uid: 6424
     components:
     - type: Transform
       pos: -39.5,26.5
       parent: 2
-  - uid: 6175
+  - uid: 6425
     components:
     - type: Transform
       pos: -46.5,-3.5
       parent: 2
-  - uid: 6176
+  - uid: 6426
     components:
     - type: Transform
       pos: -10.5,-3.5
       parent: 2
-  - uid: 6177
+  - uid: 6427
     components:
     - type: Transform
       pos: -32.5,34.5
       parent: 2
-  - uid: 6178
+  - uid: 6428
     components:
     - type: Transform
       pos: -1.5,43.5
       parent: 2
-  - uid: 6179
+  - uid: 6429
     components:
     - type: Transform
       pos: -32.5,-2.5
       parent: 2
-  - uid: 6180
+  - uid: 6430
     components:
     - type: Transform
       pos: -59.5,-25.5
       parent: 2
-  - uid: 6181
+  - uid: 6431
     components:
     - type: Transform
       pos: -56.5,-2.5
       parent: 2
-  - uid: 6182
+  - uid: 6432
     components:
     - type: Transform
       pos: -60.5,-15.5
       parent: 2
-  - uid: 6183
+  - uid: 6433
     components:
     - type: Transform
       pos: -66.5,-2.5
       parent: 2
-  - uid: 6184
+  - uid: 6434
     components:
     - type: Transform
       pos: -38.5,-14.5
       parent: 2
-  - uid: 6185
+  - uid: 6435
     components:
     - type: Transform
       pos: -46.5,-2.5
       parent: 2
-  - uid: 6186
+  - uid: 6436
     components:
     - type: Transform
       pos: 5.5,10.5
       parent: 2
-  - uid: 6187
+  - uid: 6437
     components:
     - type: Transform
       pos: -0.5,8.5
       parent: 2
-  - uid: 6188
+  - uid: 6438
     components:
     - type: Transform
       pos: -0.5,43.5
       parent: 2
-  - uid: 6189
+  - uid: 6439
     components:
     - type: Transform
       pos: -32.5,-3.5
       parent: 2
-  - uid: 6190
+  - uid: 6440
     components:
     - type: Transform
       pos: -60.5,-25.5
       parent: 2
-  - uid: 6191
+  - uid: 6441
     components:
     - type: Transform
       pos: 7.5,-3.5
       parent: 2
-  - uid: 6192
+  - uid: 6442
     components:
     - type: Transform
       pos: 5.5,9.5
       parent: 2
-  - uid: 6193
+  - uid: 6443
     components:
     - type: Transform
       pos: -39.5,-14.5
       parent: 2
-  - uid: 6194
+  - uid: 6444
     components:
     - type: Transform
       pos: -32.5,33.5
       parent: 2
-  - uid: 6195
+  - uid: 6445
     components:
     - type: Transform
       pos: -38.5,-24.5
       parent: 2
-  - uid: 6196
+  - uid: 6446
     components:
     - type: Transform
       pos: -59.5,-15.5
       parent: 2
-  - uid: 6197
+  - uid: 6447
     components:
     - type: Transform
       pos: -0.5,16.5


### PR DESCRIPTION
Fix thirty seconds of power outage at round start.

## About the PR
The power suppliers have a ramping delay that was too long.

## Why / Balance
No gravity for 30 seconds sucks.

## Technical details
The ramping mechanic is usually not a huge deal, but in marginal power situations like on Gemini, we need every Watt as soon as possible.

## Requirements
<!-- Confirm the following by placing an X in the brackets [X]: -->
- [X] I have tested all added content and changes.
- [X] I have added media to this PR or it does not require an ingame showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->

**Changelog**
<!-- Add a Changelog entry to make players aware of new features or changes that could affect gameplay.
Make sure to read the guidelines and take this Changelog template out of the comment block in order for it to show up.
Changelogs must have a :cl: symbol, so the bot recognizes the changes and adds them to the game's changelog. -->
:cl: Yule&
- fix: Gemini is no longer blacked out at round start.
